### PR TITLE
Fixes a sprite issue with improvised ammo bags

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -93,7 +93,7 @@
 		if(give_round(AC, replace_spent))
 			user.transferItemToLoc(AC, src, TRUE)
 			num_loaded++
-	
+
 	if(num_loaded)
 		if(!silent)
 			to_chat(user, "<span class='notice'>You load [num_loaded] shell\s into \the [src]!</span>")
@@ -132,6 +132,11 @@
 			icon_state = "[initial(icon_state)]-[stored_ammo.len]"
 		if(2)
 			icon_state = "[initial(icon_state)]-[stored_ammo.len ? "[max_ammo]" : "0"]"
+		if(3)
+			if(stored_ammo.len >= 8)
+				icon_state = "[initial(icon_state)]-8"
+			else
+				icon_state = "[initial(icon_state)]-[stored_ammo.len]"
 
 //Behavior for magazines
 /obj/item/ammo_box/magazine/proc/ammo_count()

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -115,7 +115,7 @@
 	name = "bag with reloaded 9mm bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/blackpowder = 1000)
 	ammo_type = /obj/item/ammo_casing/c9mm/improv
 
@@ -145,7 +145,7 @@
 	name = "bag with reloaded .38 bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 	ammo_type = /obj/item/ammo_casing/c38/improv
 
 
@@ -175,7 +175,7 @@
 	name = "bag with reloaded 10mm bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 
 //.357 Magnum
 /obj/item/ammo_box/a357box
@@ -205,7 +205,7 @@
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	ammo_type = /obj/item/ammo_casing/a357/improv
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 
 //.44 Magnum
 /obj/item/ammo_box/m44box
@@ -363,7 +363,7 @@
 /obj/item/ammo_box/a556/sport/improvised
 	name = "bag with reloaded .223 bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
-	multiple_sprites = 1
+	multiple_sprites = 3
 	custom_materials = list(/datum/material/iron = 2000, /datum/material/blackpowder = 500)
 	icon_state = "improvshotbag"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Most improvised ammo bags had significantly more ammo than the sprite they share had icon states to support it. I refactored the code to account for this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
refactor: A variable that determines how the ammo items update their sprites has had a new option added, which the improvised ammo bag will now use to show the most full icon state it has until the stored ammo inside falls below a threshold of 8. This is done to account for ammo bags having a higher ammo count than their current sprite code and icon states support, which in turn caused the bags to be invisible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
