### PR TITLE
Fixes some issues with ECR and GST surgeries

### DIFF
--- a/code/modules/surgery/emergency_cardioversion_recovery.dm
+++ b/code/modules/surgery/emergency_cardioversion_recovery.dm
@@ -5,7 +5,7 @@
 	possible_locs = list(BODY_ZONE_CHEST)
 	requires_bodypart_type = BODYPART_ORGANIC
 	requires_trait = 2
-	requires_trait = "MEDICALGRADUATE"
+	requires_trait = TRAIT_SURGERY_MID
 
 /datum/surgery_step/ventricular_electrotherapy
 	name = "ventricular electrotherapy"
@@ -89,8 +89,6 @@
 		failed = "<span class='warning'>The heart is zapped by the [tool], but nothing happens. You feel like the spark of life has fully left [H].</span>"
 	else if (H.hellbound)
 		failed = "<span class='warning'>The heart is zapped by the [tool], but nothing happens. You notice a small tatoo with the words \"Property of Satan\" branded just above the right ventricle.</span>"
-	else if(tdelta > (DEFIB_TIME_LIMIT * 10))
-		failed = "<span class='warning'>The heart is zapped by the [tool], but nothing happens. It appears their body decomposed beyond repair.</span>"
 	else if(total_burn >= 180 || total_brute >= 180)
 		failed = "<span class='warning'>The [tool] zaps the heart, inducing a sudden contraction, but it appears [H]'s body is too damaged to revive presently.</span>"
 	else if(H.get_ghost())

--- a/code/modules/surgery/graft_synthtissue.dm
+++ b/code/modules/surgery/graft_synthtissue.dm
@@ -16,7 +16,7 @@
 	/datum/surgery_step/close
 	)
 	requires_trait = 2
-	requires_trait = "MEDICALGRADUATE"
+	requires_trait = TRAIT_SURGERY_MID
 
 //repair organs
 /datum/surgery_step/graft_synthtissue
@@ -51,7 +51,7 @@
 				to_chat(user, "<span class='notice'>There's not enough synthtissue to perform the operation! There needs to be at least 10u.</span>")
 				return -1
 
-			if((chosen_organ.organ_flags & ORGAN_FAILING) && !(Sf.data["grown_volume"] >= 80))
+			if((chosen_organ.organ_flags & ORGAN_FAILING) && !(Sf.volume>= 80))
 				to_chat(user, "<span class='notice'>[chosen_organ] is too damaged to graft onto!</span>")
 				return -1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Makes it possible to perform Emergency Cardiovascular Recovery and Graft Synthtissue with Medium Surgery. Fixes a bug with GST resulting from fermichem's removal. Removes the time of death check from ECR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Synthtissue grafting now works properly with the fermichem removal. Reviving an organ with chronic failure requires >80u of synthtissue in the patient's bloodstream, instead of the now-defunct grown volume.

Cardioversion recovery no longer checks for time of death, making it a true replacement for the defunct Cerebral Revival surgery and eliminating the necessity for players to call the "I'M DED PLS RESTART" vote if they die during low-pop.

Both surgeries now require mid-level surgery instead of the medical graduate trait, meaning that roles with access to the DC Journal of Internal Medicine can revive you, assuming they can obtain the defib and chems to do so. This will increase the odds of a role being present that can revive the long-dead.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
fix: Synthtissue volume check in surgery now checks for reagent volume instead of grown volume.
balance: Removes the time of death check from cardiovascular recovery, due to revival surgery being non-functional
balance: lowers trait requirement of both surgeries to Intermediate Surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
