### PR TITLE
Removes crafting restrictions on spear quivers, fixes an oversight

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -362,12 +362,11 @@
 
 /datum/crafting_recipe/tribalwar/spearquiver
 	name = "Spear Quiver"
-	result = /obj/item/storage/backpack/spearquiver
+	result = /obj/item/storage/backpack/spearquiver/empty
 	time = 60
 	reqs = list(/obj/item/stack/sheet/leather = 3,
 				/obj/item/stack/sheet/metal = 1)
 	category = CAT_TRIBAL
-	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/lighttribe
 	name = "Light Tribal Plates"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -66,6 +66,8 @@
 	item_state = "spearquiver"
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 
+/obj/item/storage/backpack/spearquiver/empty
+
 /obj/item/storage/backpack/spearquiver/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
@@ -78,6 +80,9 @@
 	new /obj/item/throwing_star/spear(src)
 	new /obj/item/throwing_star/spear(src)
 	new /obj/item/throwing_star/spear(src)
+
+/obj/item/storage/backpack/spearquiver/empty/PopulateContents()
+	return
 
 /obj/item/storage/backpack/spearquiver/AltClick(mob/living/carbon/user)
 	. = ..()

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1134,8 +1134,7 @@ datum/job/wasteland/f13dendoctor
 		/datum/crafting_recipe/tribalwar/bonecodpiece,
 		/datum/crafting_recipe/tribalwar/bracers,
 		/datum/crafting_recipe/tribal/bonetalisman,
-		/datum/crafting_recipe/tribal/bonebag,
-		/datum/crafting_recipe/tribalwar/spearquiver
+		/datum/crafting_recipe/tribal/bonebag
 	)
 	for(var/datum/crafting_recipe/recipe as() in recipes)
 		H.mind.teach_crafting_recipe(recipe)


### PR DESCRIPTION
## About The Pull Request

Spear quivers are no longer only craftable by tribals. Anyone with the materials can craft them. I've also fixed an oversight which caused crafted quivers to spawn with spears already in them, circumventing the need for a workshop to make them. Any spear quiver that spawns on the map or in loadouts is unaffected; the recipe creates a new, empty subtype.

## Why It's Good For The Game

Spear quivers and throwing spears are really simple weapons that should be attainable by pretty much anyone. Random wastelanders and legionnaires alike can find use for these weapons, and having something to hold them in that isn't a backpack is super handy.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
tweak: Spear quivers can now be crafted by anyone.
fix: Crafted spear quivers no longer spawn with spears already in them. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
