### PR TITLE
Clothing that don't have digi-adapted sprites should now snap digi-legs to plantigrade when worn

### DIFF
--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -5,6 +5,7 @@
 */
 /obj/item/clothing/shoes/f13
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
+	mutantrace_variation = NONE // Temporal fix until digitigrade-adapted sprites are done
 
 /obj/item/clothing/shoes/f13/enclave/serviceboots
 	name = "enclave service boots"

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -17,6 +17,11 @@
 	if(!allowed)
 		allowed = GLOB.security_vest_allowed
 */
+
+// Temporal fix until digitigrade-adapted sprites are done
+/obj/item/clothing/suit/armor/f13
+	mutantrace_variation = NONE
+
 //Leather and metal
 /obj/item/clothing/suit/armor/f13/leather_jacket
 	name = "leather jacket"

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -4,6 +4,7 @@
 	fitted = FEMALE_UNIFORM_FULL
 	can_adjust = FALSE
 	resistance_flags = NONE
+	mutantrace_variation = NONE // Temporal fix until digitigrade-adapted sprites are done
 	has_sensor = NO_SENSORS //kek
 
 /obj/item/clothing/under/f13/female


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
**Please note, that I wasn't able to test the code on _current codebase_ because I cannot localhost it for some reasons.**
It was tested on other similar codebase, however, and code works so far.
<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
This "fixes" digitigrade legs for most (if not all, let me or devs know if I missed some stuff) FO13 clothing making them snap into plantigrade sprites temporally when worn. If clothing don't cover legs and/or feet, it probably allows digitigrade to be seen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make it less frustrating to constantly see "SUIT" error icons if you character is digitigrade.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
fix: Fixes "SUIT" error for digitigrades by temporally snapping their legs to plantigrade when related clothing is worn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
