### PR TITLE
fixed NCR base access hotfix

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -40245,7 +40245,7 @@
 /area/f13/wasteland/quarry)
 "kZu" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
-	req_access_txt = "132"
+	req_one_access_txt = "121"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -50579,7 +50579,7 @@
 /area/f13/wasteland/east)
 "rVW" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
-	req_access_txt = "132"
+	req_one_access_txt = "121"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -112212,7 +112212,7 @@ bdg
 qjV
 cvh
 ecp
-ecp
+qlQ
 aua
 ecp
 hJW


### PR DESCRIPTION
Front gates were tied to NCR Leadership access instead of regular, now corrected.