### PR TITLE
Fixes custom patch icons

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -1,7 +1,7 @@
 /obj/item/reagent_containers/pill/patch
 	name = "chemical patch"
 	desc = "A chemical patch for touch based applications."
-	icon = 'icons/fallout/objects/medicine/drugs.dmi'
+	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bandaid"
 	item_state = "bandaid"
 	possible_transfer_amounts = list()
@@ -54,6 +54,7 @@
 	name = "Jet"
 	desc = "A highly addictive meta-amphetamine that produces a fast-acting, intense euphoric high on the user."
 	list_reagents = list(/datum/reagent/drug/jet = 10)
+	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_jet"
 
 
@@ -98,6 +99,7 @@
 	name = "Homebrew powder"
 	desc = "A mysterious mix of powders."
 	list_reagents = null
+	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_healingpowder"
 	self_delay = 0
 	color = COLOR_PALE_GREEN_GRAY
@@ -108,6 +110,7 @@
 /obj/item/reagent_containers/pill/patch/bitterdrink
 	name = "Bitter drink"
 	desc = "A strong herbal healing concoction which enables wounded soldiers and travelers to tend to their wounds without stopping during journeys."
+	icon = 'icons/fallout/objects/medicine/drugs.dmi'
 	icon_state = "patch_bitterdrink"
 	list_reagents = list(/datum/reagent/medicine/bitter_drink = 15) 
 	self_delay = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Closes #70 

The default patch icon file was set to a fallout-specific one, which had no icon state for normal custom patches. I've updated the default icon file to the SS13 default and set the items that use the fallout-specific icons to use that file instead. I believe this is the cleaner implementation, but this could also be accomplished by manually adding the bandaid icon state to the fallout icon file. 

## Why It's Good For The Game

Less error sprites.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

Not necessary.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
