### PR TITLE
Mass Fusion Glowup

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -634,6 +634,14 @@
 /mob/living/simple_animal/hostile/alien,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"akE" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "akK" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -1174,6 +1182,15 @@
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"aOq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/radiation)
 "aPj" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/darkred/side{
@@ -1197,6 +1214,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
+"aQR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "aRI" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -1309,7 +1334,12 @@
 /area/f13/building)
 "biU" = (
 /mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "bjZ" = (
 /obj/effect/spawner/lootdrop/f13/medical/random_fev,
@@ -1394,7 +1424,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bqY" = (
 /obj/machinery/computer/terminal{
@@ -1502,7 +1534,9 @@
 "bxg" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bxk" = (
 /obj/structure/flora/wasteplant/wild_fungus,
@@ -1557,6 +1591,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bzq" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "bzs" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -3327,7 +3367,10 @@
 /area/f13/tunnel)
 "bMw" = (
 /obj/structure/reagent_dispensers/barrel/two,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bMx" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -4538,7 +4581,12 @@
 /area/f13/sewer)
 "bQD" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bQE" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -4566,7 +4614,12 @@
 "bQI" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/wreck/trash/one_barrel,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bQJ" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -4600,7 +4653,10 @@
 /area/f13/tunnel)
 "bQS" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bQT" = (
 /obj/structure/sink{
@@ -4634,12 +4690,18 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bRc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/good,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bRd" = (
 /obj/structure/table/wood/settler,
@@ -4682,7 +4744,9 @@
 "bRs" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "bRt" = (
 /obj/structure/closet/cabinet,
@@ -4700,14 +4764,29 @@
 "bRC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "factorybasement";
+	name = "shutters button";
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bRD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bRE" = (
 /obj/structure/nest/ghoul,
@@ -4772,7 +4851,12 @@
 /area/f13/sewer)
 "bSo" = (
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bSp" = (
 /obj/machinery/workbench,
@@ -4889,7 +4973,9 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bUM" = (
 /obj/effect/decal/remains{
@@ -4912,7 +4998,9 @@
 "bVb" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "bVc" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -4939,7 +5027,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bVK" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -4957,7 +5047,12 @@
 	},
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "bWf" = (
 /obj/structure/simple_door/wood,
@@ -5296,6 +5391,18 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"chw" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "chJ" = (
 /turf/closed/wall/r_wall,
 /area/f13/tcoms)
@@ -5751,7 +5858,9 @@
 "cmy" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "cne" = (
 /mob/living/simple_animal/hostile/deathclaw,
@@ -5825,6 +5934,15 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"coP" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "coY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -5918,6 +6036,14 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/building/museum)
+"cto" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "ctH" = (
 /obj/machinery/light{
 	dir = 1
@@ -5946,7 +6072,9 @@
 /area/f13/caves)
 "cuK" = (
 /obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "cvv" = (
 /turf/closed/wall,
@@ -6146,6 +6274,13 @@
 	icon_state = "grass2"
 	},
 /area/f13/brotherhood)
+"cGt" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "cGQ" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/random,
@@ -6365,7 +6500,9 @@
 "dfI" = (
 /obj/structure/nest/ghoul,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "dgB" = (
 /obj/structure/chair/stool/retro/tan,
@@ -6474,7 +6611,12 @@
 /area/f13/tunnel)
 "dpc" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "dpy" = (
 /obj/item/storage/trash_stack,
@@ -6626,6 +6768,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"dAK" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "dBy" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -6659,7 +6806,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/human/limb,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "dEl" = (
 /obj/machinery/shower{
@@ -6798,12 +6947,14 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "dOG" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/old{
-	id = null;
+	id = "factorybasement";
 	name = "shutters"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "dQF" = (
 /obj/machinery/light,
@@ -6812,6 +6963,13 @@
 	dir = 1
 	},
 /area/f13/brotherhood)
+"dRc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "dSb" = (
 /obj/item/clothing/under/f13/roving,
 /obj/item/clothing/under/f13/roving,
@@ -6910,6 +7068,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "dYy" = (
@@ -6917,7 +7078,9 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "dYA" = (
 /obj/structure/flora/grass/wasteland{
@@ -6930,7 +7093,12 @@
 /area/f13/brotherhood)
 "dYU" = (
 /obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "dZI" = (
 /obj/structure/rack,
@@ -7011,7 +7179,10 @@
 /area/f13/followers)
 "eht" = (
 /obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "ehZ" = (
 /obj/structure/closet/crate/large{
@@ -7125,14 +7296,21 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "erg" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "erk" = (
 /turf/open/floor/plasteel/darkblue/side{
@@ -7155,7 +7333,12 @@
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "euN" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -7194,7 +7377,9 @@
 	pixel_y = -7
 	},
 /mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "exv" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7232,6 +7417,15 @@
 	dir = 4
 	},
 /area/f13/brotherhood)
+"eBP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "eCg" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorrusty"
@@ -7249,6 +7443,9 @@
 /obj/effect/decal/waste{
 	icon_state = "goo12";
 	tag = "icon-goo12"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
@@ -7297,6 +7494,9 @@
 /obj/effect/decal/waste{
 	icon_state = "goo10"
 	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "eHS" = (
@@ -7332,10 +7532,12 @@
 /area/f13/building/museum)
 "eJI" = (
 /obj/machinery/door/poddoor/shutters/old{
-	id = null;
+	id = "factorybasement";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "eKa" = (
 /obj/machinery/door/airlock/hatch{
@@ -7388,7 +7590,9 @@
 "eOg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "eOt" = (
 /obj/machinery/processor,
@@ -7404,6 +7608,16 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ePY" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "eRH" = (
 /obj/machinery/workbench,
 /obj/structure/railing/wood{
@@ -7453,7 +7667,12 @@
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "eWp" = (
 /obj/structure/junk/arcade,
@@ -7532,6 +7751,19 @@
 	dir = 1
 	},
 /area/f13/brotherhood)
+"fhs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "fht" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -7681,6 +7913,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"fAs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "fAE" = (
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
@@ -7764,7 +8006,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "fKd" = (
 /obj/machinery/firealarm{
@@ -7778,7 +8022,9 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "fLu" = (
 /obj/machinery/door/airlock/hatch{
@@ -7824,7 +8070,22 @@
 	icon_state = "gib3-old";
 	pixel_x = 20
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
+"fOE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "fOG" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -7882,7 +8143,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "fTM" = (
 /obj/structure/noticeboard{
@@ -8039,7 +8303,12 @@
 "ghO" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/salvage/low,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "giB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8203,13 +8472,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "gEp" = (
 /obj/item/storage/trash_stack{
 	layer = 2
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "gEA" = (
 /obj/effect/turf_decal/delivery,
@@ -8740,7 +9016,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "hxV" = (
 /obj/machinery/light/small{
@@ -8861,6 +9140,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"hGh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "hGr" = (
 /obj/item/storage/trash_stack,
 /obj/structure/handrail/g_central{
@@ -8875,7 +9164,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "hHU" = (
 /obj/structure/door_assembly,
@@ -8909,7 +9203,12 @@
 "hKR" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "hLj" = (
 /obj/machinery/button/crematorium,
@@ -8963,7 +9262,9 @@
 "hNr" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "hOV" = (
 /obj/machinery/door/airlock/hatch{
@@ -8980,6 +9281,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"hPF" = (
+/obj/item/storage/trash_stack{
+	layer = 2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "hQf" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
@@ -9653,6 +9965,15 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
+"jgS" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "jgU" = (
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/rust,
@@ -9683,7 +10004,9 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jnv" = (
 /turf/open/floor/plasteel/darkblue/side{
@@ -9722,7 +10045,12 @@
 /area/f13/tunnel)
 "jri" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jrj" = (
 /obj/structure/closet/cabinet,
@@ -9746,7 +10074,10 @@
 "jrX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/human/core,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "jsj" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -9826,6 +10157,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jzM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "jAs" = (
 /obj/structure/railing/wood{
 	layer = 0;
@@ -9847,7 +10186,12 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibtorso"
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jBB" = (
 /obj/structure/table,
@@ -10128,7 +10472,12 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "kkR" = (
 /obj/structure/rack,
@@ -10153,7 +10502,12 @@
 /obj/machinery/light/broken{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "kov" = (
 /obj/item/storage/trash_stack,
@@ -10188,7 +10542,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "ktR" = (
 /obj/structure/table/glass,
@@ -10250,6 +10606,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"kyt" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "kzp" = (
 /obj/item/stack/ore/gold,
 /obj/item/stack/ore/gold,
@@ -10317,7 +10682,9 @@
 /area/f13/tunnel)
 "kGg" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "kHa" = (
 /obj/machinery/autolathe/constructionlathe,
@@ -10503,7 +10870,10 @@
 "kVx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "kVU" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -10511,7 +10881,12 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "kWr" = (
 /obj/structure/chair/comfy/brown,
@@ -10571,14 +10946,23 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "lcF" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
 /obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "lcO" = (
 /obj/structure/table/booth,
@@ -10826,7 +11210,15 @@
 /area/f13/brotherhood)
 "ltl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "ltr" = (
 /obj/structure/table/wood/poker,
@@ -10869,6 +11261,15 @@
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"lwz" = (
+/obj/effect/decal/cleanable/chem_pile,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "lwL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -11056,7 +11457,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "lKx" = (
 /obj/machinery/light{
@@ -11065,12 +11471,26 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"lLr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "lLM" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
 	},
 /obj/effect/decal/cleanable/blood/gibs/human/body,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "lLV" = (
 /obj/structure/closet/cabinet,
@@ -11238,7 +11658,9 @@
 /area/f13/building/museum)
 "lUi" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "lUs" = (
 /obj/item/seeds/cannabis,
@@ -11289,6 +11711,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"lWq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "lWu" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -11403,7 +11833,15 @@
 /area/f13/brotherhood)
 "mix" = (
 /obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "miK" = (
 /obj/structure/simple_door/metal/barred,
@@ -11465,6 +11903,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/tunnel)
+"mnH" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "moJ" = (
 /obj/item/trash/f13/tin{
 	dir = 4;
@@ -11513,7 +11963,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /obj/item/salvage/tool,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "msW" = (
 /obj/structure/bed,
@@ -11648,6 +12103,15 @@
 /obj/item/reagent_containers/food/drinks/mug/coco,
 /turf/open/floor/carpet,
 /area/f13/brotherhood)
+"mGd" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "mHa" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/prize/mauler,
@@ -11818,6 +12282,14 @@
 /obj/structure/chair/right,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
+"neo" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "nez" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/surgical{
@@ -11856,7 +12328,15 @@
 /area/f13/brotherhood)
 "niW" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "njj" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -11878,6 +12358,15 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nmb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "nmK" = (
 /obj/machinery/light/small,
 /turf/open/water,
@@ -12010,7 +12499,9 @@
 /area/f13/tunnel)
 "nDR" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "nEP" = (
 /obj/machinery/hydroponics/constructable,
@@ -12062,6 +12553,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"nJg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "nJL" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -12125,7 +12625,9 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "nPk" = (
 /obj/machinery/light{
@@ -12180,6 +12682,19 @@
 	dir = 8
 	},
 /area/f13/brotherhood)
+"nXY" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/chem_pile,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "nYS" = (
 /mob/living/simple_animal/hostile/raider/thief{
 	name = "Junker Deserter"
@@ -12208,7 +12723,9 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "obc" = (
 /obj/machinery/computer/rdconsole/core/bos{
@@ -12384,6 +12901,17 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"opq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "oqB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -12408,7 +12936,15 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "orG" = (
 /obj/structure/simple_door/metal/barred,
@@ -12637,6 +13173,14 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/brotherhood)
+"oQX" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "oRj" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -12699,7 +13243,12 @@
 "oVu" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "oWD" = (
 /turf/open/floor/plasteel/darkred/side{
@@ -12730,18 +13279,34 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"paE" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "paF" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12";
 	tag = "icon-goo12"
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "paX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "pbB" = (
 /obj/machinery/computer/card/bos{
@@ -12808,7 +13373,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "pkF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13042,13 +13609,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "pCD" = (
-/turf/closed/wall/f13/store,
+/obj/structure/decoration/rads,
+/turf/closed/wall/f13/tunnel,
 /area/f13/radiation)
 "pCM" = (
 /turf/open/floor/plasteel/darkblue/side,
 /area/f13/brotherhood)
 "pDI" = (
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "pGJ" = (
 /obj/structure/toilet{
@@ -13155,7 +13726,9 @@
 "pNc" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "pNE" = (
 /obj/structure/window/fulltile/ruins,
@@ -13337,7 +13910,12 @@
 /area/f13/tunnel)
 "qet" = (
 /obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "qew" = (
 /obj/structure/barricade/bars,
@@ -13466,7 +14044,10 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "qpd" = (
 /obj/structure/table,
@@ -13495,7 +14076,9 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "qqi" = (
 /obj/machinery/vending/cigarette,
@@ -13567,7 +14150,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "qus" = (
 /obj/structure/table/wood,
@@ -13661,6 +14246,17 @@
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"qDw" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "qDU" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -13703,7 +14299,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "qJm" = (
 /obj/structure/curtain,
@@ -13751,6 +14349,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
+"qLM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "qMh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -13952,6 +14558,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"riA" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "riD" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -14089,7 +14704,12 @@
 "rwL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "rxf" = (
 /obj/structure/rack/shelf_metal,
@@ -14140,14 +14760,30 @@
 "rCg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
+"rEO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "rEX" = (
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "rFi" = (
 /obj/machinery/light/fo13colored/Aqua{
@@ -14197,7 +14833,9 @@
 /area/f13/tunnel)
 "rIZ" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "rJm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14232,7 +14870,12 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib2-old"
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "rNn" = (
 /obj/structure/rack/shelf_metal,
@@ -14595,7 +15238,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "svy" = (
 /obj/effect/decal/cleanable/generic,
@@ -14625,7 +15270,12 @@
 /area/f13/tunnel)
 "sAs" = (
 /mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "sAM" = (
 /obj/machinery/light{
@@ -14660,6 +15310,14 @@
 	},
 /turf/open/floor/plasteel/vault/side,
 /area/f13/brotherhood)
+"sGe" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "sGj" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -15093,7 +15751,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "toa" = (
 /obj/machinery/light{
@@ -15200,6 +15863,17 @@
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"twa" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "twk" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -15329,7 +16003,9 @@
 /obj/effect/decal/waste{
 	icon_state = "goo5"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "tKL" = (
 /obj/structure/ore_box,
@@ -15442,6 +16118,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"tXe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "tXs" = (
 /obj/structure/table/wood,
 /obj/item/restraints/legcuffs/bola,
@@ -15484,6 +16168,13 @@
 "ubM" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/tunnel)
+"udi" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "udp" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/bubbleplush{
@@ -15494,7 +16185,9 @@
 "ueb" = (
 /obj/machinery/light/small/broken,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "ufI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15524,7 +16217,12 @@
 /area/f13/tunnel)
 "ugV" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "ugW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15605,7 +16303,9 @@
 /area/f13/brotherhood)
 "unL" = (
 /obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "unO" = (
 /turf/open/floor/plasteel/darkred/side{
@@ -15654,7 +16354,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "uxf" = (
 /obj/effect/decal/fakelattice{
@@ -15727,6 +16429,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"uzy" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "uzY" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/machinery/light/small{
@@ -15734,6 +16443,15 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"uAq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "uBh" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -15853,7 +16571,9 @@
 "uLz" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "uML" = (
 /obj/machinery/icecream_vat,
@@ -15899,8 +16619,16 @@
 /area/f13/brotherhood)
 "uOV" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
+"uPc" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "uPv" = (
 /turf/closed/wall/r_wall,
 /area/f13/tunnel)
@@ -15988,7 +16716,10 @@
 /area/f13/ncr)
 "uYT" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "uZs" = (
 /obj/structure/table/abductor{
@@ -16083,7 +16814,12 @@
 /area/f13/brotherhood)
 "vgh" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "vgq" = (
 /obj/structure/rack/shelf_metal,
@@ -16130,7 +16866,18 @@
 /area/f13/brotherhood)
 "vii" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
+"vik" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "viE" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -16140,7 +16887,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "viF" = (
 /obj/structure/barricade/bars,
@@ -16209,7 +16958,12 @@
 /area/f13/building/massfusion)
 "vmW" = (
 /obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "vnC" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -16390,7 +17144,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "vJN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16469,7 +17225,12 @@
 /obj/machinery/light/broken{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "vOc" = (
 /obj/machinery/autolathe,
@@ -16579,6 +17340,11 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"waM" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "waO" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss{
 	name = "Tunnel Torturers Boss"
@@ -16594,6 +17360,12 @@
 /obj/item/surgicaldrill,
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
+"wbw" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "wbM" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16694,7 +17466,12 @@
 	pixel_x = -10;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "wiW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16771,7 +17548,12 @@
 /area/f13/tunnel)
 "wqv" = (
 /obj/item/salvage/crafting,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "wrE" = (
 /obj/structure/bed/pod,
@@ -16784,7 +17566,9 @@
 "wsL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "wtq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16960,12 +17744,28 @@
 /obj/machinery/computer/shuttle/bos,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
+"wHX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "wIn" = (
 /obj/machinery/light/broken{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "wIv" = (
 /obj/structure/barricade/bars,
@@ -17222,7 +18022,9 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "xmT" = (
 /obj/structure/barricade/bars,
@@ -17431,7 +18233,12 @@
 "xHi" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "xHj" = (
 /turf/open/floor/f13{
@@ -17455,7 +18262,12 @@
 /area/f13/tunnel)
 "xIP" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "xKw" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -17480,7 +18292,12 @@
 "xNR" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "xOk" = (
 /obj/structure/table/snooker{
@@ -17503,10 +18320,10 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "xQO" = (
-/obj/machinery/light/small/broken{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/floor/plasteel/f13,
 /area/f13/building/massfusion)
 "xRp" = (
 /obj/structure/table/reinforced,
@@ -17548,8 +18365,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"xUc" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "xUW" = (
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "xVA" = (
 /obj/machinery/light{
@@ -17560,7 +18388,10 @@
 "xVN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "xWb" = (
 /obj/structure/handrail/g_central{
@@ -17610,10 +18441,12 @@
 /area/f13/tunnel)
 "xZu" = (
 /obj/machinery/door/poddoor/shutters/old{
-	id = null;
+	id = "factorybasement";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "yaj" = (
 /obj/machinery/light{
@@ -17665,7 +18498,12 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "ydM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17721,7 +18559,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "ygU" = (
 /obj/structure/table/glass,
@@ -65126,7 +65966,7 @@ aak
 aae
 aae
 nws
-dpc
+nXY
 ory
 mix
 nws
@@ -65637,15 +66477,15 @@ aae
 nws
 rwL
 vNL
-pDI
-pDI
+uwX
+jzM
 nws
-pDI
-pDI
+paX
+uPc
 bQS
 nws
-pDI
-pDI
+cto
+uwX
 wIn
 wqv
 nws
@@ -65893,17 +66733,17 @@ aak
 aak
 nws
 oVu
-pDI
+dAK
 qIb
-dpc
+oQX
 xZu
 niW
-pDI
-pDI
+dAK
+uzy
 xZu
-wsL
+fhs
 pjG
-pDI
+dAK
 bQZ
 nws
 aak
@@ -66150,17 +66990,17 @@ aae
 aak
 nws
 ugV
-xIP
+xQO
 eOg
-pDI
+uzy
 xZu
-xIP
-pDI
-pDI
+fOE
+dAK
+uzy
 xZu
-pDI
+qDw
 eOg
-pDI
+dAK
 bRc
 nws
 aae
@@ -66409,13 +67249,13 @@ nws
 ghO
 rEX
 xIP
-xIP
+nmb
 nws
-bQS
+paE
 nDR
-niW
+udi
 nws
-pDI
+akE
 xIP
 rEX
 eti
@@ -66669,8 +67509,8 @@ nws
 nws
 nws
 lbA
-pDI
-xIP
+xUc
+dRc
 vcq
 nws
 nws
@@ -66921,16 +67761,16 @@ aae
 aak
 nws
 gEp
-bQS
-xIP
-pDI
-xIP
+riA
+nJg
+uwX
+nJg
 oaF
 lUi
-dpc
-pDI
-sAs
-pDI
+wbw
+uwX
+jgS
+uwX
 bSo
 bQI
 nws
@@ -67177,8 +68017,8 @@ aae
 aae
 aak
 nws
-bQS
-pDI
+paE
+dAK
 bRD
 viE
 qub
@@ -67434,16 +68274,16 @@ aae
 aae
 aae
 nws
-rCg
+fAs
 uYT
 pCD
-pCD
-pCD
-pCD
+pua
+pua
+pua
 kGg
-pCD
-pCD
-pCD
+pua
+pua
+pua
 pCD
 qom
 kVx
@@ -67693,17 +68533,17 @@ aae
 nws
 dpc
 ueb
-pCD
+pua
 jBs
-xUW
-xUW
-jri
-xUW
-xUW
-rIZ
-pCD
+tXe
+tXe
+chw
+rEO
+tXe
+kyt
+pua
 vJq
-xIP
+qLM
 nws
 aae
 aae
@@ -67949,18 +68789,18 @@ aae
 aae
 nws
 xHi
-uYT
-pCD
+pDI
+pua
 kkd
 exe
 uOV
-xUW
+waM
 vii
 tKG
 eht
-pCD
+pua
 paX
-xIP
+dRc
 nws
 aak
 aae
@@ -68207,16 +69047,16 @@ aae
 nws
 sAs
 cmy
-pCD
-jri
+pua
+vik
 bVb
 fKL
 erg
-xUW
+waM
 qpK
-xUW
-pCD
-qom
+bzq
+pua
+eBP
 fSI
 nws
 aae
@@ -68465,15 +69305,15 @@ nws
 rLW
 xVN
 kGg
-xUW
+twa
 uOV
-xUW
+waM
 cuK
 bRs
-xUW
-jri
+waM
+sGe
 kGg
-paX
+qDw
 hxQ
 nws
 aae
@@ -68721,15 +69561,15 @@ aae
 nws
 wiw
 hNr
-pCD
+pua
 xUW
-xUW
-xUW
+waM
+waM
 uOV
-xUW
-xUW
-xUW
-pCD
+waM
+waM
+bzq
+pua
 dYy
 fNr
 nws
@@ -68976,17 +69816,17 @@ aak
 aae
 aae
 nws
-xIP
+eBP
 bxg
-pCD
+pua
 bWe
 jnp
-xUW
-xUW
-xUW
+waM
+waM
+waM
 rIZ
 lcF
-pCD
+pua
 paX
 jrX
 nws
@@ -69233,19 +70073,19 @@ aak
 aae
 aae
 nws
-pDI
+lwz
 ueb
-pCD
-xUW
+pua
+mGd
 paF
 vmW
-xUW
+opq
 jri
-xUW
+neo
 hKR
-pCD
+pua
 vJq
-xIP
+aQR
 nws
 aae
 aak
@@ -69490,16 +70330,16 @@ aae
 aae
 aae
 nws
+paX
 pDI
-uYT
 pCD
-pCD
-pCD
-pCD
+pua
+pua
+pua
 kGg
-pCD
-pCD
-pCD
+pua
+pua
+pua
 pCD
 xkB
 pDI
@@ -69747,7 +70587,7 @@ aae
 aae
 aae
 nws
-lJb
+lLr
 rCg
 uwX
 kth
@@ -70005,18 +70845,18 @@ aak
 aae
 nws
 bQD
-bQS
-pDI
-pDI
-pDI
+coP
+uAq
+qub
+qub
 rCg
-pDI
-xIP
-pNc
-pDI
-pDI
+dAK
+xQO
+ePY
+qub
+qub
 lJb
-gEp
+hPF
 nws
 aae
 aae
@@ -70266,9 +71106,9 @@ nws
 nws
 nws
 nws
+vJq
 xQO
-xIP
-pDI
+cGt
 pua
 pua
 pua
@@ -70520,8 +71360,8 @@ aae
 nws
 msT
 tnC
-pDI
-pDI
+uwX
+jzM
 nws
 dYU
 dDW
@@ -70776,13 +71616,13 @@ aae
 aae
 nws
 oVu
-pDI
+dAK
 gDx
-pDI
+uzy
 xZu
-dpc
+mnH
 nPj
-pDI
+uzy
 dOG
 ltl
 vdm
@@ -71033,15 +71873,15 @@ aae
 aae
 nws
 hHy
-pDI
+dAK
 bUs
-xIP
+xVN
 xZu
-pDI
-pDI
-pDI
+qDw
+dAK
+uzy
 eJI
-bKP
+aOq
 saE
 lfB
 gxz
@@ -71292,11 +72132,11 @@ nws
 eqq
 knm
 xIP
-pDI
+lWq
 nws
-bQS
+paE
 wsL
-xIP
+dRc
 pua
 biU
 eCq
@@ -71551,8 +72391,8 @@ nws
 nws
 nws
 nws
-xQO
-pDI
+vJq
+dAK
 pDI
 pua
 pua
@@ -72065,8 +72905,8 @@ aae
 aae
 aae
 nws
-xIP
-pDI
+hGh
+dAK
 pDI
 nws
 aae
@@ -72322,9 +73162,9 @@ aae
 aae
 aae
 nws
-hxQ
+wHX
 dfI
-sAs
+bxg
 nws
 aae
 aae

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1,16 +1,22 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aab" = (
 /obj/effect/overlay/junk/oldpipes,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aaZ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aba" = (
 /obj/structure/chair/wood/fancy{
@@ -70,12 +76,16 @@
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "abl" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "abm" = (
 /turf/closed/wall/mineral/concrete,
@@ -511,7 +521,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/junker/boss,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "acz" = (
 /obj/structure/ladder/unbreakable{
@@ -759,6 +771,12 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"aeq" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "ago" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -770,6 +788,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
+"atz" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "auN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/l_arm,
@@ -777,6 +803,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
+"avB" = (
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "avO" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -815,6 +847,12 @@
 "aKa" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"aKx" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "aNm" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -840,7 +878,9 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aWL" = (
 /obj/structure/railing{
@@ -853,7 +893,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aYm" = (
 /obj/structure/bed/old,
@@ -883,7 +925,9 @@
 "beC" = (
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bfJ" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -920,7 +964,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bsJ" = (
 /turf/open/floor/f13/wood,
@@ -951,7 +997,9 @@
 /obj/item/phone{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bDo" = (
 /obj/structure/chair/stool/retro/backed,
@@ -966,7 +1014,9 @@
 "bFw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bGT" = (
 /obj/structure/rack/shelf_metal,
@@ -984,6 +1034,12 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/city/bighorn)
+"bIn" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "bNC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -991,7 +1047,9 @@
 	pixel_y = 5;
 	termtag = "Business"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bOc" = (
 /obj/structure/sign/poster/prewar/poster70{
@@ -1012,7 +1070,7 @@
 	pixel_x = -14;
 	pixel_y = -9
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "bSA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1083,14 +1141,18 @@
 /obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "cmg" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cmx" = (
 /obj/structure/railing{
@@ -1145,7 +1207,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "cwL" = (
 /obj/structure/window/fulltile/house{
@@ -1167,7 +1231,9 @@
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cAO" = (
 /obj/structure/railing{
@@ -1180,13 +1246,17 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cJg" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cJr" = (
 /obj/structure/window/fulltile/store{
@@ -1201,7 +1271,9 @@
 /obj/item/clipboard{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cRx" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1220,6 +1292,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"cUD" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "cUT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
@@ -1232,7 +1310,7 @@
 /area/f13/building/khanfort)
 "dbF" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "dcP" = (
 /obj/structure/chair/wood{
@@ -1319,7 +1397,9 @@
 /area/f13/building/hospital)
 "dRi" = (
 /obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "dTc" = (
 /turf/closed/wall/r_wall,
@@ -1372,7 +1452,7 @@
 	pixel_x = 18;
 	pixel_y = 18
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "eoE" = (
 /obj/structure/flora/grass/wasteland{
@@ -1417,7 +1497,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/good,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "eCw" = (
 /obj/item/kirbyplants/random,
@@ -1430,7 +1512,9 @@
 "eNt" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/reagent_containers/glass/bucket/plastic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "eNW" = (
 /obj/machinery/light{
@@ -1457,7 +1541,9 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "eTN" = (
 /obj/structure/kitchenspike,
@@ -1476,7 +1562,9 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "fcZ" = (
 /obj/item/storage/belt/utility{
@@ -1489,7 +1577,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "fex" = (
 /obj/structure/table/optable,
@@ -1522,13 +1612,20 @@
 	pixel_x = -14;
 	pixel_y = -9
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "fym" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
+"fzW" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fDV" = (
 /obj/structure/railing{
 	dir = 8
@@ -1551,6 +1648,12 @@
 /obj/effect/landmark/start/f13/steward,
 /turf/open/floor/wood_worn,
 /area/f13/building/khanfort)
+"fHN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fKU" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khanfort)
@@ -1584,11 +1687,15 @@
 /area/f13/ncr)
 "fXj" = (
 /obj/structure/chair/office,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "fXx" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "fXR" = (
 /obj/structure/fluff/railing{
@@ -1638,7 +1745,9 @@
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "goM" = (
 /obj/structure/lattice/catwalk,
@@ -1647,7 +1756,7 @@
 	pixel_x = 14;
 	pixel_y = -9
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "grC" = (
 /obj/structure/sign/poster/prewar/poster60{
@@ -1663,6 +1772,17 @@
 	dir = 4
 	},
 /area/f13/building/hospital)
+"guq" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "gAD" = (
 /obj/structure/toilet{
 	dir = 4
@@ -1674,7 +1794,9 @@
 "gBp" = (
 /obj/structure/closet,
 /obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "gJu" = (
 /obj/structure/fluff/railing,
@@ -1725,7 +1847,9 @@
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "hcj" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1754,7 +1878,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "hih" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1775,7 +1901,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "hjx" = (
 /obj/structure/bed/roller,
@@ -1819,9 +1945,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"huF" = (
+/mob/living/simple_animal/hostile/raider/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"hwG" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "hAf" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "hBl" = (
 /obj/structure/decoration/rads,
@@ -1833,7 +1975,9 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "hDI" = (
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -1846,7 +1990,9 @@
 "hHz" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "hHO" = (
 /turf/open/indestructible/ground/outside/roof,
@@ -1912,7 +2058,7 @@
 /obj/structure/fence/handrail{
 	pixel_y = 18
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "ifa" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -1933,7 +2079,9 @@
 /obj/item/storage/pill_bottle/chem_tin/radx{
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "imL" = (
 /obj/structure/railing{
@@ -1968,7 +2116,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "iqu" = (
 /obj/structure/railing{
@@ -2006,7 +2156,9 @@
 /obj/item/clipboard{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "ixY" = (
 /turf/closed/wall/f13/store{
@@ -2090,7 +2242,9 @@
 /area/f13/building/khanfort)
 "iUG" = (
 /obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "iYg" = (
 /obj/structure/window/fulltile/wood,
@@ -2188,7 +2342,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "jCY" = (
 /obj/structure/table,
@@ -2220,7 +2376,9 @@
 "jNN" = (
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "jOE" = (
 /obj/structure/simple_door/house{
@@ -2251,7 +2409,7 @@
 	pixel_x = -18;
 	pixel_y = 18
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "jWA" = (
 /obj/structure/chair/stool{
@@ -2282,7 +2440,9 @@
 "kfx" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "khw" = (
 /obj/structure/lattice/catwalk,
@@ -2290,7 +2450,7 @@
 	height = 2;
 	id = "powerplantright"
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "khB" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -2308,7 +2468,9 @@
 /area/f13/wasteland/legion)
 "ksl" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "ktl" = (
 /obj/structure/rack/shelf_metal,
@@ -2336,7 +2498,9 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "kDw" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -2447,11 +2611,15 @@
 /area/f13/ncr)
 "ldu" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ldG" = (
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "lfq" = (
 /obj/machinery/light/small{
@@ -2467,7 +2635,9 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "lmm" = (
 /obj/structure/sign/poster/prewar/corporate_espionage{
@@ -2484,7 +2654,12 @@
 "lnz" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "loK" = (
 /obj/vehicle/ridden/wheelchair{
@@ -2615,7 +2790,9 @@
 	dir = 4
 	},
 /obj/item/soap,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mbu" = (
 /turf/closed/wall/f13/tentwall,
@@ -2654,7 +2831,9 @@
 /obj/structure/rack/shelf_metal{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mjv" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2666,7 +2845,9 @@
 /area/f13/building/hospital)
 "mke" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "moH" = (
 /obj/structure/lattice/catwalk,
@@ -2676,14 +2857,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "mrQ" = (
 /turf/open/transparent/openspace,
 /area/f13/legion)
 "mta" = (
 /obj/machinery/photocopier,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mvR" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -2706,7 +2889,16 @@
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
+"mAu" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mBg" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2735,7 +2927,7 @@
 	height = 2;
 	id = "powerplantleft"
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "mGL" = (
 /obj/structure/chair/stool/f13stool,
@@ -2754,7 +2946,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "mMd" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2807,7 +3001,9 @@
 /area/f13/wasteland)
 "mYA" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "mYP" = (
 /obj/structure/table/reinforced,
@@ -2816,7 +3012,9 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mZk" = (
 /obj/effect/overlay/junk/sink{
@@ -2853,7 +3051,9 @@
 /area/f13/building/hospital)
 "nfc" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "nnp" = (
 /obj/structure/bed/old,
@@ -2888,7 +3088,19 @@
 "nuj" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"nvf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 3;
+	termtag = "Security"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "nzf" = (
 /obj/item/bedsheet/random,
@@ -2896,6 +3108,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/f13/city/bighorn)
+"nBq" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "nGj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -2918,7 +3137,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "nLM" = (
 /obj/structure/simple_door/house{
@@ -2961,7 +3182,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "nVH" = (
 /obj/structure/lattice/catwalk,
@@ -2973,7 +3196,7 @@
 	pixel_x = 14;
 	pixel_y = -14
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "nWK" = (
 /obj/structure/railing{
@@ -3045,7 +3268,9 @@
 /area/f13/wasteland)
 "okr" = (
 /obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "olL" = (
 /turf/open/indestructible/ground/outside/wood{
@@ -3069,7 +3294,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "onq" = (
 /obj/machinery/door/unpowered/securedoor/khandoor,
@@ -3077,7 +3302,9 @@
 /area/f13/building/khanfort)
 "onr" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "ooN" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -3152,7 +3379,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/secway,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "oIu" = (
 /obj/structure/table/reinforced,
@@ -3160,7 +3389,9 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "oJO" = (
 /turf/open/floor/plasteel/f13,
@@ -3170,11 +3401,15 @@
 	name = "power unit"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "oNe" = (
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "oOa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3192,7 +3427,9 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "oVn" = (
 /turf/open/indestructible/ground/outside/roof,
@@ -3287,7 +3524,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "pGc" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
@@ -3308,7 +3545,9 @@
 /obj/machinery/teleport/station{
 	name = "power unit"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "pHv" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -3386,7 +3625,9 @@
 	pixel_y = 3;
 	termtag = "Security"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "qqp" = (
 /obj/structure/curtain{
@@ -3396,7 +3637,12 @@
 /area/f13/city/bighorn)
 "qqR" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "qtF" = (
 /obj/structure/railing{
@@ -3425,7 +3671,9 @@
 "qEi" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "qER" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3435,6 +3683,13 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/city/bighorn)
+"qFA" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "qHm" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
@@ -3454,13 +3709,17 @@
 	pixel_x = 5;
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "qKv" = (
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "qLy" = (
 /obj/structure/railing{
@@ -3493,6 +3752,11 @@
 	dir = 6
 	},
 /area/f13/building/hospital)
+"qPu" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "qQy" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
@@ -3547,7 +3811,7 @@
 	dir = 8;
 	pixel_x = 14
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "rlb" = (
 /obj/machinery/light/small{
@@ -3556,7 +3820,9 @@
 /obj/effect/overlay/junk/oldpipes,
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "roa" = (
 /obj/structure/simple_door/house,
@@ -3583,7 +3849,9 @@
 /area/f13/wasteland/ncr)
 "rsx" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "rvN" = (
 /obj/structure/table/wood,
@@ -3592,7 +3860,9 @@
 "rza" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rBR" = (
 /obj/structure/barricade/bars,
@@ -3613,7 +3883,9 @@
 /area/f13/building/hospital)
 "rDK" = (
 /mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rGU" = (
 /obj/structure/window/fulltile/house{
@@ -3624,7 +3896,16 @@
 "rHE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
+"rJd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "rJo" = (
 /obj/structure/table/reinforced,
@@ -3636,7 +3917,9 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rLB" = (
 /turf/open/transparent/openspace,
@@ -3662,6 +3945,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"rSv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
+"rVI" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "rZU" = (
 /obj/structure/sign/poster/prewar/poster60,
 /turf/closed/wall/f13/store{
@@ -3701,7 +4001,9 @@
 /area/f13/city/bighorn)
 "sjx" = (
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "sjy" = (
 /obj/structure/mopbucket,
@@ -3715,7 +4017,9 @@
 /obj/effect/overlay/junk/oldpipes,
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "smZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3743,7 +4047,9 @@
 	pixel_y = 10
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "sxs" = (
 /obj/structure/kitchenspike,
@@ -3793,7 +4099,9 @@
 	light_color = "#c1caff"
 	},
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "sPE" = (
 /turf/closed/indestructible/riveted,
@@ -3830,7 +4138,9 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "taC" = (
 /obj/structure/lattice/catwalk,
@@ -3838,7 +4148,7 @@
 	dir = 8;
 	pixel_x = -14
 	},
-/turf/open/space/basic,
+/turf/open/transparent/openspace,
 /area/f13/radiation)
 "tbU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -3967,7 +4277,9 @@
 /area/f13/wasteland)
 "tCQ" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "tGE" = (
 /turf/open/floor/wood_worn,
@@ -3998,7 +4310,9 @@
 "tWj" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "tWw" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4027,7 +4341,9 @@
 /area/f13/city/bighorn)
 "tXx" = (
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "tYl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -4075,11 +4391,15 @@
 /obj/item/crowbar{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "uiJ" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "ujK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4113,7 +4433,9 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "upn" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4156,6 +4478,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"uwZ" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "uxf" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -4218,7 +4546,9 @@
 "uPm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "uQU" = (
 /obj/structure/closet/cabinet,
@@ -4312,7 +4642,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "vDZ" = (
 /obj/machinery/light/small,
@@ -4351,7 +4683,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "vVM" = (
 /obj/structure/sign/poster/prewar/poster66{
@@ -4373,7 +4707,9 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "wbR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4384,6 +4720,12 @@
 	dir = 9
 	},
 /area/f13/building/hospital)
+"wjJ" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "wlR" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -4400,7 +4742,12 @@
 "wuZ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wxA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4462,10 +4809,14 @@
 /obj/item/storage/firstaid/toxin{
 	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wMt" = (
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wSn" = (
 /obj/structure/railing{
@@ -4529,7 +4880,18 @@
 	pixel_x = 10;
 	tag = "icon-sink (EAST)"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
+"xnw" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "xpn" = (
 /obj/structure/table,
@@ -4568,7 +4930,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "xAW" = (
 /obj/structure/chair/stool{
@@ -4609,7 +4973,9 @@
 "xMZ" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/mechanic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "xNc" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4625,7 +4991,9 @@
 "xQx" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "xQH" = (
 /obj/structure/chair/booth{
@@ -4677,12 +5045,16 @@
 /area/f13/city/bighorn)
 "ygG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "yic" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/mop,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ykM" = (
 /turf/closed/wall/f13/wood/house,
@@ -51246,7 +51618,7 @@ oVn
 oVn
 kfx
 rJo
-ygG
+fHN
 sjx
 oDo
 oVn
@@ -51763,15 +52135,15 @@ ikt
 wMt
 dRi
 oDo
-tXx
+xnw
 sXs
 wMt
 oDo
-oez
-oez
-oez
-oez
-oez
+lDT
+lDT
+lDT
+lDT
+lDT
 aKa
 hsd
 wqF
@@ -52022,7 +52394,7 @@ sjx
 oDo
 wuZ
 abl
-ygG
+fHN
 kfx
 oez
 oez
@@ -52258,20 +52630,20 @@ lDT
 oVn
 oVn
 oDo
-kfx
-kfx
-kfx
+qFA
+qFA
+qFA
 oDo
 oVn
 oVn
 oVn
 oVn
 oDo
-kfx
-kfx
+qFA
+qFA
 oDo
-kfx
-kfx
+qFA
+qFA
 oDo
 oDo
 uiJ
@@ -52515,9 +52887,9 @@ lDT
 oVn
 oVn
 oDo
-wMt
-wMt
-oNe
+qPu
+qPu
+huF
 oDo
 oDo
 oDo
@@ -52528,14 +52900,14 @@ nuj
 ygG
 aUS
 ygG
-wMt
+qPu
 oDo
 wMt
 wMt
 wMt
 wMt
-ygG
-ygG
+fHN
+fHN
 oDo
 oDo
 oez
@@ -52774,17 +53146,17 @@ oVn
 oDo
 xAT
 oLL
-wMt
+qPu
 ygG
 ygG
-rHE
-wuZ
+rJd
+nBq
 mYA
 oDo
 ygG
-oNe
-wMt
-wMt
+huF
+qPu
+qPu
 tXx
 oDo
 wMt
@@ -53030,20 +53402,20 @@ oVn
 oVn
 oDo
 tXx
-wMt
-wMt
-wMt
-wMt
-wMt
+qPu
+qPu
+qPu
+qPu
+qPu
 ygG
-wMt
-uiJ
+qPu
+aKx
 ygG
-wMt
+qPu
 pGF
-wMt
-wMt
-uiJ
+qPu
+qPu
+aKx
 wMt
 wMt
 qvL
@@ -53296,10 +53668,10 @@ aaa
 oDo
 oDo
 tXx
-wMt
+qPu
 ygG
 uPm
-wMt
+qPu
 oDo
 oTC
 wMt
@@ -53552,8 +53924,8 @@ aab
 aab
 kCU
 oDo
-wMt
-wMt
+qPu
+qPu
 ygG
 qEi
 ygG
@@ -54070,7 +54442,7 @@ dbF
 mGE
 xQx
 aaZ
-wMt
+qPu
 hAf
 wMt
 wMt
@@ -54328,7 +54700,7 @@ dbF
 xQx
 qoB
 cJg
-wMt
+qPu
 wMt
 wMt
 oDo
@@ -54587,7 +54959,7 @@ ixJ
 tXx
 hac
 wMt
-uPm
+rSv
 oDo
 oDo
 oDo
@@ -54826,8 +55198,8 @@ lDT
 lDT
 oDo
 pGF
-wMt
-wuZ
+qPu
+rVI
 onr
 xQx
 tik
@@ -54844,7 +55216,7 @@ oDo
 oDo
 oDo
 oTC
-ygG
+fHN
 wMt
 lnz
 jxL
@@ -55083,8 +55455,8 @@ lDT
 lDT
 oDo
 qKv
-wMt
-wMt
+qPu
+qPu
 bNC
 xQx
 tik
@@ -55101,7 +55473,7 @@ gos
 gBp
 oDo
 wMt
-tXx
+uwZ
 wMt
 wMt
 fcZ
@@ -55340,7 +55712,7 @@ lDT
 lDT
 oDo
 ipv
-wMt
+qPu
 fXj
 cKc
 xQx
@@ -55354,11 +55726,11 @@ tik
 iel
 dbF
 ksl
+hwG
+qPu
+aKx
 wMt
-wMt
-uiJ
-wMt
-ygG
+fHN
 wMt
 wMt
 hgr
@@ -55597,8 +55969,8 @@ lDT
 lDT
 oDo
 qKv
-wMt
-wMt
+qPu
+qPu
 bNC
 xQx
 tik
@@ -55614,8 +55986,8 @@ hBl
 vZT
 cDH
 oDo
-ygG
-ygG
+fHN
+fHN
 wMt
 ldu
 svH
@@ -55854,8 +56226,8 @@ lDT
 lDT
 oDo
 pGF
-ldu
-wMt
+cUD
+atz
 onr
 xQx
 tik
@@ -56126,7 +56498,7 @@ eiE
 dbF
 xQx
 tCQ
-ldu
+cUD
 cAl
 wMt
 wMt
@@ -56384,7 +56756,7 @@ dbF
 xQx
 qoB
 vAv
-wMt
+qPu
 wMt
 wMt
 oDo
@@ -56640,9 +57012,9 @@ dbF
 khw
 xQx
 lhP
-wMt
+qPu
 rsx
-rsx
+wjJ
 wMt
 oDo
 qqR
@@ -57150,9 +57522,9 @@ beC
 bFw
 smS
 oDo
-wMt
-mke
-wMt
+qPu
+aeq
+qPu
 ygG
 oGZ
 oDo
@@ -57409,8 +57781,8 @@ oDo
 oDo
 tXx
 ygG
-wMt
-wMt
+qPu
+qPu
 ygG
 oDo
 oTC
@@ -57655,22 +58027,22 @@ lDT
 oVn
 oVn
 oDo
-wMt
-wMt
-wMt
-nfc
+qPu
+qPu
+qPu
+avB
 ygG
 ygG
 ygG
-wMt
-uiJ
-wMt
-wMt
+qPu
+aKx
+qPu
+qPu
 pGF
 ygG
-wMt
-uiJ
-tXx
+qPu
+aKx
+uwZ
 ldu
 oDo
 okr
@@ -57914,7 +58286,7 @@ oVn
 oDo
 mLV
 pGF
-wMt
+qPu
 ygG
 ygG
 ygG
@@ -57922,10 +58294,10 @@ ygG
 tWj
 oDo
 ygG
-wMt
-wMt
+qPu
+qPu
 ygG
-wMt
+qPu
 oDo
 oDo
 uiJ
@@ -58185,11 +58557,11 @@ ygG
 tXx
 oDo
 chc
-ygG
-tXx
+fHN
+uwZ
 wMt
 cwk
-wuZ
+fzW
 oDo
 oDo
 oez
@@ -58426,27 +58798,27 @@ lDT
 oVn
 oVn
 oDo
-kfx
-kfx
-kfx
+qFA
+qFA
+qFA
 oDo
 oVn
 oVn
 oVn
 oVn
 oDo
-kfx
-kfx
+qFA
+qFA
 oDo
-kfx
-kfx
+qFA
+qFA
 oDo
 uhv
-ygG
-ygG
+fHN
+fHN
 oNe
-qoB
-ygG
+nvf
+fHN
 wMt
 kfx
 oez
@@ -58702,7 +59074,7 @@ oDo
 oTC
 wMt
 abk
-aaZ
+mAu
 acy
 wMt
 kfx
@@ -58959,9 +59331,9 @@ mta
 wMt
 wMt
 wMt
-lhP
+guq
 bBI
-onr
+bIn
 oDo
 lDT
 lDT
@@ -59214,7 +59586,7 @@ oVn
 kfx
 hHz
 rHE
-wuZ
+fzW
 oDo
 oDo
 oDo

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1413,9 +1413,8 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "aeP" = (
@@ -7594,7 +7593,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "awZ" = (
@@ -16521,7 +16520,7 @@
 "aXD" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "aXE" = (
@@ -16611,7 +16610,6 @@
 /area/f13/building/bighornbunker)
 "aXT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
@@ -19351,6 +19349,13 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/west)
+"bfQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "bfR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -24839,6 +24844,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
+"bEZ" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "bFz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25229,6 +25239,13 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland/massfusion)
+"bQR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "bQV" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -25500,12 +25517,6 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland/bighorn)
-"bUU" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "bUV" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25960,12 +25971,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
-"bZw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "bZL" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
@@ -26356,15 +26361,6 @@
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland/bighorn)
-"cdP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "cdQ" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
@@ -26718,6 +26714,12 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
+"cjM" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "cjX" = (
 /turf/open/floor/wood_common,
 /area/f13/village)
@@ -28535,12 +28537,6 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland/west)
-"cFE" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "cGc" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt{
@@ -29024,14 +29020,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/mall)
-"cXH" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "cYd" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29039,11 +29027,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
-"cYO" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
-	},
-/area/f13/building/massfusion)
 "cZg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -29246,11 +29229,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
-"dfL" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "dfM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -29778,12 +29756,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
-"dxr" = (
-/obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "dxs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -29843,6 +29815,11 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland/east)
+"dzC" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "dAy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/sosjerky/ration,
@@ -29874,14 +29851,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/quarry)
-"dBj" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "dBk" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
@@ -30115,6 +30084,15 @@
 /obj/item/melee/onehanded/slavewhip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"dIm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "dIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -30713,12 +30691,6 @@
 /obj/item/melee/onehanded/machete/training,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
-"ehb" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "ehL" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
@@ -30890,6 +30862,12 @@
 	icon_state = "hydrofloor"
 	},
 /area/f13/building)
+"enO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "enQ" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
@@ -31693,12 +31671,6 @@
 "eRk" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/west)
-"eRx" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "eRz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -32133,6 +32105,18 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland/followers)
+"ffM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"ffN" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "fgf" = (
 /obj/item/flag/khan,
 /obj/structure/reagent_dispensers/barrel/three,
@@ -32294,12 +32278,6 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland/massfusion)
-"fkR" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "fkV" = (
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32378,12 +32356,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
-"fog" = (
-/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "foi" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32437,12 +32409,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"fqA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "fqM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -32839,6 +32805,12 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/bighorn)
+"fBA" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "fCk" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
@@ -33149,13 +33121,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/ncr)
-"fLX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "fMc" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33255,6 +33220,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"fOC" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "fOH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33704,13 +33675,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/heaven)
-"gim" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "giX" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33764,12 +33728,6 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland/firestation)
-"gky" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "gkA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -34040,12 +33998,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"gtZ" = (
-/mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "guj" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34382,12 +34334,6 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
-"gGl" = (
-/obj/structure/closet,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "gGn" = (
@@ -34759,6 +34705,15 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/firestation)
+"gSN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "gTk" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -34939,12 +34894,6 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
 	icon_state = "innermaincornerinner"
-	},
-/area/f13/building/massfusion)
-"gZa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
 	},
 /area/f13/building/massfusion)
 "gZb" = (
@@ -35299,12 +35248,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"hnB" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "hnO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
@@ -35410,6 +35353,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/mall)
+"htq" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "htU" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -35519,12 +35468,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/heaven)
-"hyS" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "hyV" = (
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt{
@@ -36108,6 +36051,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
+"hTO" = (
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "hUc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -36313,19 +36265,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
 /area/f13/legion)
-"iaT" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
-"ibb" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "ibe" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/heaven)
@@ -36678,7 +36617,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "imr" = (
@@ -36726,14 +36665,6 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland/west)
-"ina" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "inx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowleft"
@@ -36870,12 +36801,6 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
-"ish" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "isj" = (
 /mob/living/simple_animal/hostile/raider/ranged{
 	name = "City Boys Raider"
@@ -37949,13 +37874,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
-"iXX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "iYc" = (
 /obj/structure/fence{
 	dir = 4
@@ -37995,12 +37913,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/f13/building)
-"iZc" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "iZd" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38220,12 +38132,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/ncr)
-"jgn" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "jgz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -38316,13 +38222,6 @@
 	icon_state = "horizontalbottomborderbottomleft"
 	},
 /area/f13/wasteland/east)
-"jjm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "jjp" = (
 /obj/structure/closet,
 /obj/item/geiger_counter,
@@ -38596,15 +38495,6 @@
 "jsB" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland/legion)
-"jsK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "jsX" = (
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
@@ -38768,6 +38658,14 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland/bighorn)
+"jAk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "jAn" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorywarehouse";
@@ -38863,6 +38761,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building/massfusion)
+"jCS" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "jCV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -38911,10 +38817,15 @@
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/mall)
+"jEf" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "jEC" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
 "jFG" = (
@@ -38991,6 +38902,14 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"jKB" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "jKE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/cone,
@@ -39165,7 +39084,7 @@
 "jPC" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "jPD" = (
@@ -39232,6 +39151,15 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/legion)
+"jRn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "jRM" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -39974,13 +39902,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"kuW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "kvl" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -40277,7 +40198,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
 "kFe" = (
@@ -40422,6 +40343,12 @@
 "kIS" = (
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
+"kJa" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "kJf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -40626,6 +40553,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/mall)
+"kQb" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "kRx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -40659,6 +40592,14 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/museum)
+"kSw" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "kSV" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -41257,12 +41198,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
-"lmX" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "lnc" = (
 /obj/effect/landmark/start/f13/vexillarius,
 /turf/open/floor/wood_mosaic,
@@ -41561,6 +41496,10 @@
 "lxJ" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate/radiation,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
@@ -42036,6 +41975,12 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lMB" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "lMY" = (
 /obj/machinery/smartfridge/bottlerack/alchemy_rack,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -42349,12 +42294,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
-"lUp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "lUy" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -42384,7 +42323,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "lVG" = (
@@ -42815,6 +42754,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building/firestation)
+"mkQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "mkY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42941,11 +42887,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
-"mos" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "mox" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt{
@@ -43267,6 +43208,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
+"mzI" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "mzO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -43302,12 +43252,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/wood_worn,
 /area/f13/building/khanfort)
-"mAx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "mAA" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -43450,7 +43394,7 @@
 /area/f13/building)
 "mFy" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "mFC" = (
@@ -43689,6 +43633,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
+"mOg" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "mOh" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie/black,
@@ -43781,6 +43731,15 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mRw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "mSa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44081,6 +44040,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"ncX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "ndc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44195,14 +44161,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/bighorn)
-"nhX" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/building/massfusion)
 "niB" = (
 /turf/closed/wall/f13/store,
 /area/f13/tunnel)
@@ -44891,6 +44849,12 @@
 "nCD" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland/khanfort)
+"nCK" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "nDc" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light/broken{
@@ -45066,6 +45030,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/quarry)
+"nJm" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "nJO" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -45721,6 +45691,13 @@
 "ofC" = (
 /turf/open/floor/wood_fancy,
 /area/f13/city/bighorn)
+"ofE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "ofG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -45864,6 +45841,13 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/city/bighorn)
+"okb" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "okd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -45878,6 +45862,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"oko" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "okD" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -46087,6 +46079,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"osj" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "osl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -46234,25 +46232,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/firestation)
-"oyc" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "oym" = (
 /obj/structure/rack,
 /obj/item/clothing/under/suit/charcoal,
 /obj/item/clothing/under/suit/navy,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"oys" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "oyB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
@@ -46524,6 +46509,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"oJo" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "oJz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -46875,13 +46867,6 @@
 	smooth = 1
 	},
 /area/f13/building/museum)
-"oTB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "oTE" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
@@ -47392,6 +47377,13 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
+"pmD" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "pnc" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -47555,13 +47547,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/legion)
-"psO" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "ptf" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -47637,6 +47622,13 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/ncr)
+"pvo" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "pvu" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -47707,12 +47699,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/hospital)
-"pyp" = (
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "pyq" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -47954,13 +47940,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
-"pDw" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "pDM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48106,6 +48085,12 @@
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"pKv" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "pKy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain3"
@@ -48296,7 +48281,7 @@
 "pRs" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "pRv" = (
@@ -48520,13 +48505,10 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland/east)
-"qbi" = (
-/obj/effect/spawner/lootdrop/low_tools,
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
+"qbg" = (
+/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "qbz" = (
@@ -48555,12 +48537,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland/west)
-"qcN" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "qcV" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -48626,6 +48602,12 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/firestation)
+"qeK" = (
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "qeN" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/road{
@@ -48638,6 +48620,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/quarry)
+"qfp" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "qft" = (
 /obj/machinery/light/small,
 /obj/item/clothing/head/cone,
@@ -48692,12 +48680,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building/nanotrasen)
-"qhe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "qhr" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -49101,6 +49083,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qtb" = (
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "qth" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
@@ -49134,6 +49125,12 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
+"qtW" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "quc" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -50036,6 +50033,13 @@
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
+"rbl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "rbE" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -50133,6 +50137,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/building/khanfort)
+"rdq" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "rdV" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/trash,
@@ -50957,9 +50968,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "rIJ" = (
-/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "rIT" = (
@@ -51333,7 +51344,7 @@
 "rUR" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "rVc" = (
@@ -51596,14 +51607,6 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"sfr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "sfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -51625,6 +51628,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
+"sgh" = (
+/obj/structure/closet/abductor{
+	desc = "A secure metal pod for storing protectrons.";
+	name = "protectron pod"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "sgr" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52033,15 +52048,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"sri" = (
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "srm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -52211,14 +52217,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
-"sAi" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "sAm" = (
 /obj/structure/chair/comfy{
 	color = "#ad0a0a";
@@ -52246,6 +52244,15 @@
 /obj/item/clothing/head/cueball,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"sBb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "sBl" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -52326,13 +52333,6 @@
 	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland/ncr)
-"sDk" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "sDn" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -52803,13 +52803,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
-"sWo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "sWu" = (
 /obj/effect/spawner/lootdrop/tool_box,
 /obj/structure/rack/shelf_metal{
@@ -53097,6 +53090,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
+"tgB" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "tgF" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -53442,6 +53443,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/firestation)
+"trS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "tsa" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert{
@@ -54026,6 +54033,12 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland/bighorn)
+"tJS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "tJV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -54819,6 +54832,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"uiv" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "uiC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -54914,7 +54934,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "umx" = (
@@ -55199,6 +55219,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"utO" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "uua" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/road{
@@ -55440,6 +55466,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
+"uBL" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "uCa" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/road{
@@ -55759,7 +55791,7 @@
 "uLZ" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "uMa" = (
@@ -55922,14 +55954,6 @@
 /obj/item/reagent_containers/glass/rag/towel,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
-"uSC" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "uSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/target/communist,
@@ -55954,6 +55978,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"uTV" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "uTY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -56300,11 +56330,6 @@
 "vdB" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland/hospital)
-"vdD" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "vdF" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 1
@@ -56344,6 +56369,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"vhJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "vic" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56517,17 +56549,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/west)
-"vlV" = (
-/obj/structure/closet/abductor{
-	desc = "A secure metal pod for storing protectrons.";
-	name = "protectron pod"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "vmf" = (
 /mob/living/simple_animal/chicken,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -56557,15 +56578,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
-"vmP" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "vnb" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -56611,6 +56623,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"vpk" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "vpl" = (
 /obj/structure/junk/locker,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -56982,12 +56999,6 @@
 /obj/item/clothing/under/f13/picnicdress50s,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"vBh" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "vBH" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/road{
@@ -57079,10 +57090,12 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/nanotrasen)
-"vGX" = (
-/obj/effect/decal/cleanable/dirt,
+"vHw" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
 "vHB" = (
@@ -57189,7 +57202,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "vLf" = (
@@ -57231,6 +57244,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building/khanfort)
+"vMV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "vNb" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
@@ -57487,6 +57506,12 @@
 "vVo" = (
 /turf/closed/wall/mineral/concrete,
 /area/f13/building/massfusion)
+"vVu" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "vVw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -57609,13 +57634,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/mall)
-"waG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "waH" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -57985,12 +58003,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
-"wnM" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "wnV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -57999,6 +58011,14 @@
 "wnX" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/mall)
+"wog" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/building/massfusion)
 "woj" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -58124,15 +58144,6 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland/nanotrasen)
-"wuB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "wvj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -58226,6 +58237,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
+"wze" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "wzf" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -58397,15 +58414,6 @@
 "wDk" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/bighornbunker)
-"wDr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "wDA" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -58432,16 +58440,6 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/mall)
-"wEa" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "wEd" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
@@ -58581,6 +58579,16 @@
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/carpet/purple,
 /area/f13/bar/heaven)
+"wHZ" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "wIc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -58596,6 +58604,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"wJe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "wJA" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -58603,15 +58618,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building/museum)
-"wKa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "wKb" = (
 /obj/structure/shuttle/engine/router,
 /obj/structure/lattice/catwalk,
@@ -58709,6 +58715,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
 /area/f13/legion)
+"wNM" = (
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "wNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -58751,6 +58763,12 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"wOC" = (
+/mob/living/simple_animal/hostile/molerat,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "wOD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
@@ -58878,7 +58896,7 @@
 /area/f13/building)
 "wSN" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
 "wTb" = (
@@ -59456,11 +59474,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13,
 /area/f13/building)
-"xpz" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "xpV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -59745,6 +59758,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"xzh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "xzq" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
@@ -59994,13 +60013,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/bighornbunker)
-"xHe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "xHh" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -60026,14 +60038,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/ncr)
-"xIa" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "xJf" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard,
 /turf/closed/wall/f13/tunnel,
@@ -60702,12 +60706,6 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/bighornbunker)
-"yfg" = (
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "yfR" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/sunset/brick_small_dark,
@@ -60909,6 +60907,12 @@
 	icon_state = "verticalleftborderlefttop"
 	},
 /area/f13/wasteland/east)
+"ylF" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "ylR" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -105682,7 +105686,7 @@ vVo
 dll
 aCt
 vIs
-mos
+ffN
 vVo
 aae
 aae
@@ -105936,10 +105940,10 @@ ahg
 ahg
 kzT
 jAn
-vGX
+trS
 mua
-vGX
-jgn
+trS
+qbg
 vVo
 aae
 aae
@@ -106193,10 +106197,10 @@ ahg
 kzT
 kzT
 jAn
-mos
-vGX
+ffN
+trS
 fNp
-vGX
+trS
 vVo
 aae
 aae
@@ -106450,10 +106454,10 @@ ahg
 kzT
 kzT
 jAn
-mos
-jgn
-vGX
-mos
+ffN
+qbg
+trS
+ffN
 vVo
 vVo
 aae
@@ -106689,9 +106693,9 @@ aae
 aae
 oBz
 oBz
-wuB
-sAi
-nhX
+sBb
+jCS
+wog
 qzL
 wjW
 tbY
@@ -106708,9 +106712,9 @@ iKB
 acd
 vVo
 uvP
-dfL
-fqA
-fqA
+wSN
+xzh
+xzh
 hkk
 vVo
 aae
@@ -106965,9 +106969,9 @@ wkF
 aaX
 vVo
 fJz
-dfL
+wSN
 cRJ
-dfL
+wSN
 fNY
 vVo
 aae
@@ -107204,11 +107208,11 @@ vVo
 vVo
 vVo
 yhr
-vmP
-wKa
+mzI
+mRw
 vVo
 ofH
-awY
+qtb
 wMb
 vVo
 iBU
@@ -107221,11 +107225,11 @@ kzT
 ahg
 aaX
 aKF
-fqA
-fqA
+xzh
+xzh
 wNV
-dfL
-fqA
+wSN
+xzh
 vVo
 aae
 aae
@@ -107457,16 +107461,16 @@ adD
 xco
 xco
 aaH
-oTB
-sWo
+vKX
+rbl
 cOR
 blL
-vGX
-ibb
+trS
+wze
 gBg
 aaH
-mos
-aXD
+ffN
+ylF
 vVo
 vVo
 vVo
@@ -107479,9 +107483,9 @@ hUq
 ojo
 vVo
 qxI
-dfL
-gtZ
-dfL
+wSN
+qeK
+wSN
 hkk
 vVo
 aae
@@ -107706,7 +107710,7 @@ aae
 aae
 vVo
 kNC
-pRs
+wNM
 afg
 afa
 vVo
@@ -107715,15 +107719,15 @@ fEv
 aVj
 aHV
 iCI
-iaT
+pvo
 dRL
 rWe
-waG
-sWo
+bfQ
+rbl
 gBg
-jsK
+dIm
 ajs
-vGX
+trS
 aXz
 xcF
 sWu
@@ -107736,9 +107740,9 @@ kJj
 pec
 vVo
 iGE
-dfL
-dfL
-dfL
+wSN
+wSN
+wSN
 rdV
 vVo
 aaa
@@ -107964,27 +107968,27 @@ aae
 vVo
 aBA
 aaN
-mFy
+bEZ
 aWw
 vVo
 fEv
 fEv
 fEv
 aaH
-sDk
+oJo
 trb
 cOR
 bZg
 acF
-sWo
+rbl
 gBg
 xNI
-mos
-vGX
-fkR
-mos
-vGX
-waG
+ffN
+trS
+qfp
+ffN
+trS
+bfQ
 vVo
 hSI
 lFy
@@ -107992,11 +107996,11 @@ bLP
 acZ
 hSI
 vVo
-ulY
-dfL
+pmD
+wSN
 nSC
-fqA
-dfL
+xzh
+wSN
 vVo
 aae
 aaa
@@ -108221,7 +108225,7 @@ aae
 vVo
 agq
 rcw
-mFy
+bEZ
 afa
 vVo
 vVo
@@ -108235,13 +108239,13 @@ vVo
 vVo
 vVo
 vVo
-aeO
-mos
-mos
-vGX
-oTB
-waG
-mos
+sgh
+ffN
+ffN
+trS
+vKX
+bfQ
+ffN
 vVo
 dNH
 mwp
@@ -108250,9 +108254,9 @@ mwp
 uzS
 vVo
 hkk
-fqA
+xzh
 dlI
-dfL
+wSN
 nSC
 vVo
 aae
@@ -108482,20 +108486,20 @@ aAM
 vVo
 vVo
 lKe
-mFy
+bEZ
 rcw
 lKe
 lKe
 jFL
-kuW
-mFy
+wJe
+bEZ
 lKe
 lKe
 vVo
 bjv
-vGX
+trS
 jRV
-mos
+ffN
 amr
 bmd
 wMb
@@ -108508,8 +108512,8 @@ ebg
 vVo
 pro
 irW
-ulY
-dfL
+pmD
+wSN
 wNV
 vVo
 aae
@@ -108735,24 +108739,24 @@ vVo
 kUV
 aXM
 wbw
-mFy
-vKX
+bEZ
+ffM
 vVo
 aaV
 twO
-mFy
-mFy
+bEZ
+bEZ
 mPL
-mFy
-mFy
-mFy
-mFy
-rIJ
+bEZ
+bEZ
+bEZ
+bEZ
+aXD
 vVo
-dBj
+kET
 aoh
 aoh
-dBj
+kET
 bjp
 aUe
 vVo
@@ -108993,25 +108997,25 @@ aXH
 hef
 bjc
 twO
-rUR
+lMB
 vVo
-cFE
-mFy
-mFy
-mFy
+fBA
+bEZ
+bEZ
+bEZ
 rcw
 rcw
-mFy
-lVo
+bEZ
+bQR
 twO
-cFE
+fBA
 vVo
-fqA
+xzh
 irW
 wno
 bkG
-dfL
-dfL
+wSN
+wSN
 vVo
 bGU
 aXt
@@ -109248,9 +109252,9 @@ aae
 vVo
 fSy
 rcw
-mFy
+bEZ
 rcw
-mFy
+bEZ
 vVo
 axf
 axf
@@ -109267,7 +109271,7 @@ aKF
 vVo
 eon
 bcv
-dfL
+wSN
 qBw
 vVo
 eIN
@@ -109504,27 +109508,27 @@ aae
 aae
 vVo
 tIE
-kET
+vHw
 aWG
-fog
-mFy
+uLZ
+bEZ
 vVo
 jjp
 wEs
-mFy
+bEZ
 twO
 xQT
-jPC
+vVu
 vVo
-ehb
-bZw
-wSN
+rUR
+rIJ
+mFy
 xJU
 cdl
 vVo
 eon
 bcv
-fqA
+xzh
 vGp
 vVo
 eIN
@@ -109763,21 +109767,21 @@ vVo
 kUV
 aXM
 wbw
-mFy
+bEZ
 rcw
 tMi
 gGQ
 agB
-xIa
+kSw
 rcw
 bkF
 bkF
 aAM
-hnB
-wSN
-wSN
-wSN
-wSN
+pKv
+mFy
+mFy
+mFy
+mFy
 vVo
 vVo
 vVo
@@ -109802,7 +109806,7 @@ eXO
 vVo
 jPo
 mTc
-psO
+uiv
 avS
 uGX
 bPL
@@ -110032,14 +110036,14 @@ aby
 aby
 aby
 aPC
-wSN
+mFy
 ykQ
-wSN
+mFy
 vVo
-wSN
+mFy
 kjm
-wSN
-gGl
+mFy
+jPC
 vVo
 eIN
 aXt
@@ -110057,8 +110061,8 @@ avS
 bPL
 vRh
 vVo
-psO
-psO
+uiv
+uiv
 vVo
 lUy
 bPL
@@ -110278,24 +110282,24 @@ aby
 rDt
 aXI
 aXI
-dxr
+utO
 msN
-lUp
-xpz
-wDr
-xpz
+aXT
+vpk
+jRn
+vpk
 laF
 afR
 fHL
 aby
 aEq
-wSN
-wSN
-wSN
+mFy
+mFy
+mFy
 gzj
-iXX
-bZw
-bZw
+ofE
+rIJ
+rIJ
 aLI
 vVo
 eIN
@@ -110537,22 +110541,22 @@ aWP
 ePK
 aLM
 kjS
-jEC
-vBh
-vBh
+kJa
+cjM
+cjM
 jTh
 ese
-wnM
-lUp
+nJm
+aXT
 aby
 tLD
-wSN
-wSN
+mFy
+mFy
 skP
 vVo
 mfo
 azJ
-bZw
+rIJ
 aLI
 vVo
 eIN
@@ -110572,9 +110576,9 @@ vUN
 vUN
 vUN
 nlp
-qcN
+uBL
 uRZ
-uSC
+tgB
 vUN
 vUN
 eeT
@@ -110791,7 +110795,7 @@ aby
 aby
 adG
 lwr
-vBh
+cjM
 aeP
 aeP
 aeP
@@ -110800,7 +110804,7 @@ aeP
 aeP
 aeP
 jQx
-xpz
+vpk
 adG
 vVo
 aKF
@@ -110829,9 +110833,9 @@ dKo
 dKo
 dKo
 dKo
-ish
+qtW
 feX
-ina
+oko
 dKo
 dKo
 gpP
@@ -111047,7 +111051,7 @@ aby
 cUS
 fNr
 aik
-lUp
+aXT
 abl
 aeP
 aeP
@@ -111057,16 +111061,16 @@ aeP
 aeP
 aeP
 lts
-xpz
+vpk
 agR
-wSN
-wSN
-wSN
-wSN
+mFy
+mFy
+mFy
+mFy
 asN
-wSN
-wSN
-wSN
+mFy
+mFy
+mFy
 vVo
 auF
 vJP
@@ -111086,9 +111090,9 @@ dKo
 dKo
 dKo
 dKo
-ish
+qtW
 feX
-ina
+oko
 dKo
 dKo
 owX
@@ -111302,9 +111306,9 @@ aae
 aae
 aby
 aaO
-lUp
+aXT
 afr
-lmX
+jEC
 nvc
 aeP
 aeP
@@ -111314,16 +111318,16 @@ aeP
 aeP
 aeP
 oFJ
-xpz
+vpk
 agR
 tEm
-cYO
-gZa
+dzC
+enO
 mNo
 bkW
-wSN
-fLX
-wSN
+mFy
+lVo
+mFy
 aKF
 uEz
 uEz
@@ -111343,9 +111347,9 @@ wsm
 ciV
 dKo
 dKo
-ish
+qtW
 feX
-ina
+oko
 dKo
 dKo
 ukW
@@ -111561,7 +111565,7 @@ aby
 adm
 cVW
 aik
-xpz
+vpk
 nvc
 aeP
 aeP
@@ -111571,16 +111575,16 @@ aeP
 aeP
 aeP
 oFJ
-xpz
+vpk
 agR
 xBl
-cYO
-gZa
-cYO
+dzC
+enO
+dzC
 bkW
 iBp
-jjm
-bZw
+vhJ
+rIJ
 vVo
 nOd
 swF
@@ -111600,9 +111604,9 @@ jDC
 veD
 iJK
 iJK
-iZc
+fOC
 vXY
-cXH
+jKB
 iJK
 iJK
 jDC
@@ -111816,9 +111820,9 @@ aae
 aae
 aby
 fCH
-lUp
+aXT
 acQ
-lUp
+aXT
 nvc
 aeP
 aeP
@@ -111828,16 +111832,16 @@ aeP
 aeP
 aeP
 oFJ
-dxr
+utO
 agR
 bxG
-cYO
-cYO
-cYO
+dzC
+dzC
+dzC
 bkW
-ehb
-oyc
-wSN
+rUR
+ulY
+mFy
 aKF
 xYE
 bQv
@@ -112075,7 +112079,7 @@ aby
 cUS
 abx
 aik
-xpz
+vpk
 nvc
 aeP
 aeP
@@ -112085,14 +112089,14 @@ aeP
 aeP
 aeP
 oFJ
-lUp
+aXT
 agR
-wSN
-wSN
+mFy
+mFy
 usw
-wSN
+mFy
 asN
-gky
+osj
 bja
 ykP
 vVo
@@ -112332,7 +112336,7 @@ aby
 aby
 aby
 adG
-xpz
+vpk
 ese
 aeP
 aeP
@@ -112342,7 +112346,7 @@ aeP
 aeP
 aeP
 aLW
-xpz
+vpk
 adG
 vVo
 aKF
@@ -112598,17 +112602,17 @@ ese
 ese
 crl
 ese
-qhe
+vMV
 usn
 aby
-wSN
-hnB
+mFy
+pKv
 vVo
-bZw
-qbi
+rIJ
+awY
 skP
 bmM
-wSN
+mFy
 aei
 vVo
 eIN
@@ -112626,8 +112630,8 @@ eLd
 cvN
 avS
 vVo
-mFy
-mFy
+bEZ
+bEZ
 rkf
 vVo
 uGX
@@ -112850,22 +112854,22 @@ aXI
 aXI
 bKK
 vLf
+ncX
 aXT
-lUp
 pZn
-xpz
-lUp
+vpk
+aXT
 afe
 vjB
 aby
-wSN
-ehb
+mFy
+rUR
 vVo
-bZw
-wSN
-wSN
-wSN
-hyS
+rIJ
+mFy
+mFy
+mFy
+nCK
 geU
 vVo
 eIN
@@ -112885,7 +112889,7 @@ avS
 vVo
 hAB
 ams
-mFy
+bEZ
 vVo
 aae
 aae
@@ -113115,14 +113119,14 @@ aby
 aby
 aby
 aby
-wSN
-bZw
+mFy
+rIJ
 vVo
 wiV
-wSN
+mFy
 ykQ
-wSN
-wSN
+mFy
+mFy
 abM
 vVo
 eIN
@@ -113361,26 +113365,26 @@ vVo
 kUV
 aXM
 wbw
-mFy
+bEZ
 twO
 aAM
 nRR
 aWf
-wEa
-mFy
+wHZ
+bEZ
 nRR
 nRR
 aAM
-wSN
-fLX
-wSN
+mFy
+lVo
+mFy
 vVo
-qbi
-wSN
-wSN
-bZw
-wSN
-wSN
+awY
+mFy
+mFy
+rIJ
+mFy
+mFy
 vVo
 eIN
 aXt
@@ -113400,7 +113404,7 @@ poA
 rcw
 gGk
 uUO
-sri
+hTO
 vVo
 aae
 aae
@@ -113618,25 +113622,25 @@ vVo
 awq
 hDW
 jif
-mFy
+bEZ
 rcw
 vVo
 wEs
 jjp
-mFy
+bEZ
 rcw
 hPG
 aHx
 vVo
-hnB
-wSN
-wSN
+pKv
+mFy
+mFy
 aKF
-hnB
-wSN
+pKv
+mFy
 awi
-bZw
-fLX
+rIJ
+lVo
 geU
 vVo
 eIN
@@ -113654,8 +113658,8 @@ kFB
 bsm
 vVo
 rcw
-xHe
-mFy
+mkQ
+bEZ
 rcw
 rkf
 vVo
@@ -113875,8 +113879,8 @@ vVo
 aof
 acU
 rcw
-rUR
-mFy
+lMB
+bEZ
 vVo
 axf
 axf
@@ -113890,10 +113894,10 @@ axf
 axf
 vVo
 cEF
-wSN
+mFy
 bkU
-wSN
-bZw
+mFy
+rIJ
 abM
 vVo
 eIN
@@ -113912,8 +113916,8 @@ ivh
 aAM
 rcw
 kxT
-lVo
-mFy
+bQR
+bEZ
 aFV
 vVo
 aae
@@ -114130,27 +114134,27 @@ abO
 aae
 vVo
 aXJ
-kET
+vHw
 aWG
-mFy
-mFy
+bEZ
+bEZ
 vVo
-cFE
-mFy
-pDw
+fBA
+bEZ
+rdq
 rcw
-mFy
-mFy
+bEZ
+bEZ
 rcw
 rcw
 rcw
-vKX
+ffM
 aAM
-wSN
-fLX
-bZw
+mFy
+lVo
+rIJ
 aFE
-wSN
+mFy
 geU
 vVo
 eIN
@@ -114167,9 +114171,9 @@ dKo
 nHR
 doD
 vVo
-cFE
-rUR
-mFy
+fBA
+lMB
+bEZ
 dEU
 exE
 vVo
@@ -114390,13 +114394,13 @@ kUV
 aXM
 wbw
 rcw
-cFE
+fBA
 vVo
 agG
 kxT
 rcw
-mFy
-mFy
+bEZ
+bEZ
 kxT
 rcw
 rcw
@@ -114404,8 +114408,8 @@ twO
 fbg
 vVo
 ksW
-wSN
-wSN
+mFy
+mFy
 vVo
 vVo
 vVo
@@ -114425,9 +114429,9 @@ eLd
 cvN
 vVo
 wEx
-vKX
-mFy
-cdP
+ffM
+bEZ
+imm
 ncO
 vVo
 aae
@@ -114650,21 +114654,21 @@ vVo
 aAM
 vVo
 lKe
-mFy
-pRs
+bEZ
+wNM
 lKe
 lKe
 lKe
-cFE
-mFy
+fBA
+bEZ
 lKe
 lKe
 vVo
-vlV
-wSN
-wSN
+aeO
+mFy
+mFy
 aKF
-vdD
+jEf
 bkD
 vCW
 vVo
@@ -114902,9 +114906,9 @@ aae
 aae
 aae
 vVo
-kuW
+wJe
 bjh
-mFy
+bEZ
 vVo
 vVo
 axf
@@ -114918,12 +114922,12 @@ vVo
 vVo
 vVo
 aTU
-uLZ
-wSN
+htq
+mFy
 vVo
-mAx
+tJS
 aWF
-eRx
+kQb
 vVo
 nbT
 nbT
@@ -114939,12 +114943,12 @@ nbT
 hSq
 aae
 vVo
-xHe
-mFy
+mkQ
+bEZ
 vVo
 fzT
 bix
-wSN
+mFy
 bkZ
 mfo
 hdd
@@ -115161,22 +115165,22 @@ aae
 vVo
 wYd
 rcw
-pDw
-mFy
+rdq
+bEZ
 adQ
 kbV
 adv
 adh
 kxT
 aAM
-mFy
-mFy
-mFy
-cFE
+bEZ
+bEZ
+bEZ
+fBA
 vVo
 awD
-wSN
-wSN
+mFy
+mFy
 vVo
 bjt
 vVo
@@ -115187,7 +115191,7 @@ aae
 vVo
 vVo
 vVo
-bUU
+mOg
 vVo
 vVo
 vVo
@@ -115197,14 +115201,14 @@ aae
 aae
 vVo
 reI
-cFE
+fBA
 vVo
 fGb
 aVi
-wSN
-imm
+mFy
+gSN
 oOh
-bZw
+rIJ
 vVo
 aae
 aaa
@@ -115426,14 +115430,14 @@ axs
 axs
 adh
 vVo
-pRs
+wNM
 anp
 lKe
 rcw
 vVo
 adw
-hyS
-hnB
+nCK
+pKv
 vVo
 lIO
 vVo
@@ -115443,9 +115447,9 @@ aae
 aae
 vVo
 peq
-wSN
-hyS
-sfr
+mFy
+nCK
+jAk
 aIh
 vVo
 aae
@@ -115457,11 +115461,11 @@ gGk
 rcw
 vVo
 aVD
-wSN
+mFy
 aeJ
 phY
 rcv
-wSN
+mFy
 vVo
 aae
 aaa
@@ -115683,7 +115687,7 @@ adv
 oJI
 kbV
 vVo
-mFy
+bEZ
 rcw
 twO
 lxJ
@@ -115700,8 +115704,8 @@ aae
 aae
 vVo
 nKG
-wSN
-wSN
+mFy
+mFy
 ayt
 bmL
 vVo
@@ -115710,15 +115714,15 @@ aae
 aae
 vVo
 afa
-mFy
-rIJ
+bEZ
+aXD
 vVo
-oys
-wSN
-wSN
+uTV
+mFy
+mFy
 usw
-oyc
-hyS
+ulY
+nCK
 vVo
 aae
 aaa
@@ -115956,10 +115960,10 @@ aae
 aae
 aae
 vVo
-iXX
-wSN
-bZw
-wSN
+ofE
+mFy
+rIJ
+mFy
 hYK
 vVo
 aae
@@ -115967,12 +115971,12 @@ aae
 aae
 vVo
 aWw
-mFy
-mFy
+bEZ
+bEZ
 vVo
 vVo
 vVo
-bUU
+mOg
 vVo
 vVo
 axU
@@ -116213,26 +116217,26 @@ aae
 vVo
 vVo
 vVo
-wSN
-wSN
-hyS
-wSN
-wSN
+mFy
+mFy
+nCK
+mFy
+mFy
 vVo
 aae
 aae
 aae
 vVo
 afa
-cFE
+fBA
 rcw
-mFy
+bEZ
 bAe
 rcw
 rcw
-xHe
+mkQ
 vVo
-wSN
+mFy
 vVo
 aae
 aae
@@ -116470,11 +116474,11 @@ aae
 vVo
 aXM
 jkj
-wSN
-bZw
-wSN
-bZw
-hnB
+mFy
+rIJ
+mFy
+rIJ
+pKv
 vVo
 aae
 aae
@@ -116482,12 +116486,12 @@ aae
 vVo
 vVo
 twO
-mFy
+bEZ
 gGk
 biX
 tTk
 bmx
-cFE
+fBA
 vVo
 afQ
 vVo
@@ -116727,11 +116731,11 @@ aae
 vVo
 aWu
 heK
-wSN
-wSN
+mFy
+mFy
 kUV
 kUV
-wSN
+mFy
 vVo
 aae
 vVo
@@ -116739,7 +116743,7 @@ vVo
 vVo
 vVo
 vVo
-bUU
+mOg
 vVo
 vVo
 vVo
@@ -116982,22 +116986,22 @@ aae
 aae
 aae
 vVo
-bZw
-wSN
-wSN
-hyS
-wSN
-wSN
-iXX
+rIJ
+mFy
+mFy
+nCK
+mFy
+mFy
+ofE
 vVo
 aae
 vVo
 afh
-gim
-wSN
-wSN
-bZw
-oys
+okb
+mFy
+mFy
+rIJ
+uTV
 vVo
 awO
 twO
@@ -117240,26 +117244,26 @@ aae
 aae
 vVo
 edw
-hyS
-wSN
-wSN
-wSN
-wSN
+nCK
+mFy
+mFy
+mFy
+mFy
 kea
 vVo
 aae
 vVo
-wSN
-wSN
-wSN
-wSN
+mFy
+mFy
+mFy
+mFy
 xgE
 iIo
 vVo
 agW
-mFy
-mFy
-mFy
+bEZ
+bEZ
+bEZ
 gLn
 vVo
 aae
@@ -117499,17 +117503,17 @@ vVo
 vVo
 uMW
 wjw
-hyS
-pyp
+nCK
+pRs
 pWD
 kKy
 vVo
 aae
 vVo
 ybo
-yfg
-wSN
-wSN
+wOC
+mFy
+mFy
 iIo
 mMt
 vVo
@@ -117764,10 +117768,10 @@ vVo
 aae
 vVo
 qdr
-bZw
-bZw
-wSN
-gky
+rIJ
+rIJ
+mFy
+osj
 pmh
 vVo
 vVo

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -146,10 +146,12 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel/southwest)
 "aaH" = (
-/obj/structure/fence{
-	dir = 4
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "aaI" = (
 /obj/effect/decal/cleanable/dirt{
@@ -198,7 +200,9 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aaO" = (
 /obj/item/storage/belt/utility{
@@ -212,7 +216,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "aaP" = (
 /obj/machinery/light{
@@ -231,7 +237,9 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/gloves/color/black,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aaS" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -252,7 +260,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aaW" = (
 /turf/open/transparent/openspace,
@@ -322,7 +332,9 @@
 	pixel_y = -8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "abn" = (
 /obj/structure/bed/mattress{
@@ -374,7 +386,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "aby" = (
 /turf/closed/wall/mineral/concrete,
@@ -432,7 +446,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "abI" = (
 /obj/effect/overlay/rockfloor_side,
@@ -449,7 +465,9 @@
 "abM" = (
 /obj/structure/closet,
 /obj/item/clothing/gloves/color/black,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "abN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -662,7 +680,9 @@
 /area/f13/wasteland/legion)
 "acy" = (
 /obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "acA" = (
 /obj/effect/decal/marking{
@@ -704,7 +724,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "acG" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -772,7 +794,9 @@
 "acQ" = (
 /obj/structure/fence/door/opened,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "acR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -786,12 +810,16 @@
 /area/f13/building)
 "acT" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "acU" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "acV" = (
 /turf/open/floor/f13/wood,
@@ -915,7 +943,9 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "adn" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -959,14 +989,18 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "adv" = (
 /turf/open/water,
 /area/f13/building/massfusion)
 "adw" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ady" = (
 /obj/structure/fence,
@@ -1077,7 +1111,9 @@
 /obj/structure/door_assembly/door_assembly_hatch{
 	anchored = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "adR" = (
 /obj/item/flag/followers,
@@ -1177,7 +1213,9 @@
 "aei" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aej" = (
 /obj/structure/closet/cabinet,
@@ -1338,7 +1376,9 @@
 /area/f13/wasteland/ncr)
 "aeJ" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aeK" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1373,7 +1413,9 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aeP" = (
 /turf/open/transparent/openspace,
@@ -1432,7 +1474,9 @@
 /area/f13/building)
 "afa" = (
 /obj/machinery/telecomms/processor/preset_four,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "afb" = (
 /obj/structure/table,
@@ -1456,7 +1500,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "aff" = (
 /obj/structure/fence{
@@ -1476,11 +1522,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "afh" = (
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "afi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1507,7 +1557,9 @@
 	pixel_y = -9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "afl" = (
 /turf/open/indestructible/ground/outside/road{
@@ -1535,7 +1587,9 @@
 /area/f13/followers)
 "afr" = (
 /obj/structure/fence/door,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "afs" = (
 /obj/effect/decal/marking{
@@ -1621,13 +1675,17 @@
 "afG" = (
 /obj/item/weldingtool,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "afH" = (
 /obj/structure/railing{
 	dir = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "afI" = (
 /obj/structure/table,
@@ -1680,7 +1738,9 @@
 /obj/item/stack/spacecash/c1000,
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/coin,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "afR" = (
 /obj/machinery/light{
@@ -1691,7 +1751,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "afS" = (
 /turf/open/floor/f13{
@@ -1767,7 +1829,9 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "age" = (
 /turf/open/indestructible/ground/outside/road{
@@ -1840,7 +1904,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "agr" = (
 /obj/structure/simple_door/metal/barred,
@@ -1907,7 +1973,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "agC" = (
 /turf/open/indestructible/ground/outside/road{
@@ -1934,7 +2002,9 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "agH" = (
 /obj/effect/decal/marking{
@@ -1996,7 +2066,9 @@
 "agR" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "agS" = (
 /obj/structure/table/reinforced,
@@ -2030,7 +2102,9 @@
 /area/f13/legion)
 "agW" = (
 /obj/item/trash/f13/dog,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "agX" = (
 /obj/structure/chair/stool{
@@ -2070,7 +2144,9 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "ahe" = (
 /obj/machinery/vending/snack,
@@ -2151,7 +2227,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "ahr" = (
 /obj/machinery/door/airlock/public/glass{
@@ -2457,7 +2535,9 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "ail" = (
 /obj/structure/simple_door/metal/store,
@@ -2886,7 +2966,9 @@
 "ajs" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "ajt" = (
 /obj/machinery/light/small{
@@ -3848,13 +3930,17 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "ams" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "amt" = (
 /obj/machinery/light{
@@ -4139,7 +4225,9 @@
 	name = "power unit"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "anq" = (
 /obj/structure/barricade/wooden,
@@ -4412,7 +4500,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aog" = (
 /obj/machinery/light/small{
@@ -4427,7 +4517,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "aoi" = (
 /obj/structure/table,
@@ -7205,7 +7297,9 @@
 	pixel_y = 8
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "awj" = (
 /obj/structure/car/rubbish2,
@@ -7263,7 +7357,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "awr" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -7345,7 +7441,9 @@
 /area/f13/building)
 "awD" = (
 /obj/effect/spawner/lootdrop/high_tools,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "awE" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7429,7 +7527,9 @@
 	pixel_x = -7;
 	pixel_y = 12
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "awP" = (
 /obj/structure/barricade/sandbags,
@@ -7487,7 +7587,12 @@
 /area/f13/tunnel/southwest)
 "awY" = (
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "awZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7524,7 +7629,9 @@
 "axf" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "axg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7604,7 +7711,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "axt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7764,7 +7873,9 @@
 /obj/structure/bookcase/manuals/engineering{
 	anchored = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "axV" = (
 /obj/effect/landmark/start/f13/wastelander,
@@ -7920,7 +8031,9 @@
 "ayt" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ayu" = (
 /obj/structure/car/rubbish2,
@@ -8338,7 +8451,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "azK" = (
 /obj/effect/decal/remains/human,
@@ -8683,7 +8798,9 @@
 /area/f13/village)
 "aAM" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aAN" = (
 /obj/item/paper_bin{
@@ -8919,7 +9036,9 @@
 /obj/machinery/computer/terminal{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aBB" = (
 /obj/structure/table/wood,
@@ -9210,7 +9329,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "aCv" = (
 /obj/structure/chair{
@@ -9896,7 +10017,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aEr" = (
 /obj/structure/car/rubbish2,
@@ -10324,7 +10447,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aFF" = (
 /obj/structure/chair{
@@ -10446,7 +10571,9 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aFW" = (
 /obj/structure/car,
@@ -10953,7 +11080,9 @@
 /obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aHy" = (
 /obj/structure/simple_door/room,
@@ -11073,10 +11202,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
 "aHV" = (
-/obj/structure/fence/door,
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "aHW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11151,7 +11284,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aIi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -11960,8 +12095,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "aKF" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/plasteel/f13/concrete/industrial,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aKH" = (
 /obj/structure/fluff/rails{
@@ -12367,7 +12503,9 @@
 /area/f13/village)
 "aLI" = (
 /obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aLJ" = (
 /obj/effect/decal/waste{
@@ -12399,7 +12537,9 @@
 	pixel_x = 14;
 	pixel_y = -9
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "aLN" = (
 /obj/structure/fence,
@@ -12468,7 +12608,9 @@
 	pixel_y = 18
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "aLX" = (
 /obj/effect/decal/cleanable/dirt{
@@ -13812,7 +13954,9 @@
 	pixel_y = 10
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aPD" = (
 /obj/item/ammo_casing/c9mm,
@@ -15147,7 +15291,9 @@
 "aTU" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aTV" = (
 /obj/structure/barricade/wooden/strong,
@@ -15208,7 +15354,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "aUf" = (
 /obj/structure/closet,
@@ -15536,7 +15684,9 @@
 "aVi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aVj" = (
 /obj/structure/lattice/catwalk,
@@ -15658,7 +15808,9 @@
 /obj/item/trash/plate{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aVE" = (
 /obj/structure/bed,
@@ -15858,7 +16010,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aWg" = (
 /obj/structure/window/fulltile/house,
@@ -15927,7 +16081,9 @@
 /area/f13/building/khanfort)
 "aWu" = (
 /obj/machinery/workbench/forge,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "aWv" = (
 /obj/structure/closet/crate/large,
@@ -15939,7 +16095,9 @@
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aWx" = (
 /obj/structure/tires,
@@ -16013,7 +16171,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/massfusion)
 "aWG" = (
 /obj/machinery/power/terminal{
@@ -16023,11 +16183,15 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aWH" = (
 /obj/item/clothing/shoes/f13/rag,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aWJ" = (
 /obj/structure/table/wood,
@@ -16078,7 +16242,9 @@
 /obj/structure/railing{
 	dir = 9
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "aWQ" = (
 /obj/effect/overlay/junk/toilet{
@@ -16320,7 +16486,9 @@
 "aXz" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "aXA" = (
 /obj/machinery/light{
@@ -16348,7 +16516,9 @@
 /area/f13/wasteland/east)
 "aXD" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "aXE" = (
 /obj/structure/table/wood/settler,
@@ -16374,7 +16544,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/structure/sign/warning/enginesafety{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aXI" = (
 /turf/open/floor/plasteel/stairs,
@@ -16388,7 +16563,12 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/obj/structure/sign/warning/enginesafety{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aXL" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -16399,7 +16579,9 @@
 /obj/machinery/smoke_machine{
 	name = "generator mechanism"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "aXN" = (
 /obj/structure/chair{
@@ -16425,7 +16607,9 @@
 /area/f13/building/bighornbunker)
 "aXT" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "aXU" = (
 /obj/structure/simple_door/wood{
@@ -17291,7 +17475,9 @@
 /obj/structure/closet,
 /obj/item/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "baf" = (
 /obj/item/storage/briefcase,
@@ -19873,7 +20059,9 @@
 /area/f13/wasteland/nanotrasen)
 "bix" = (
 /obj/item/pen,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "biy" = (
 /obj/structure/closet/crate/bin/trash_fallout,
@@ -20051,7 +20239,9 @@
 /area/f13/building)
 "biX" = (
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "biZ" = (
 /obj/structure/decoration/vent/rusty,
@@ -20065,7 +20255,9 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "bjb" = (
 /obj/structure/table/glass,
@@ -20087,7 +20279,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "bjd" = (
 /obj/structure/barricade/wooden,
@@ -20104,7 +20298,9 @@
 	id = "factory2";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "bjh" = (
 /obj/structure/rack/shelf_metal{
@@ -20115,7 +20311,9 @@
 	light_color = "#d8b1b1"
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bji" = (
 /turf/closed/wall/f13/wood,
@@ -20168,7 +20366,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "bjq" = (
 /turf/closed/wall/f13/wood/house,
@@ -20182,7 +20382,9 @@
 /area/f13/wasteland/bighorn)
 "bjt" = (
 /obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "bju" = (
 /obj/structure/window/fulltile/house{
@@ -20202,7 +20404,10 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "bjw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20221,7 +20426,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bjy" = (
 /obj/structure/chair{
@@ -20663,7 +20870,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/massfusion)
 "bkE" = (
 /obj/effect/decal/cleanable/oil{
@@ -20677,13 +20886,17 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bkG" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "bkH" = (
 /obj/item/paper_bin,
@@ -20692,7 +20905,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bkI" = (
 /turf/open/floor/carpet/green,
@@ -20704,7 +20919,9 @@
 	pixel_y = 5;
 	termtag = "Security"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bkK" = (
 /obj/structure/table/wood,
@@ -20794,7 +21011,9 @@
 	pixel_y = 9
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bkV" = (
 /obj/effect/decal/cleanable/oil{
@@ -20808,7 +21027,9 @@
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden/strong,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "bkX" = (
 /obj/structure/fence,
@@ -20832,7 +21053,9 @@
 /obj/item/flashlight/lamp{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "blb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21102,7 +21325,12 @@
 "blL" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "blM" = (
 /obj/structure/flora/grass/wasteland{
@@ -21210,7 +21438,12 @@
 	pixel_x = 3
 	},
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "bme" = (
 /obj/structure/chair/booth{
@@ -21332,13 +21565,17 @@
 /obj/item/trash/f13/steak{
 	pixel_x = -5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bmz" = (
 /obj/structure/stairs{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "bmA" = (
 /obj/effect/decal/cleanable/dirt{
@@ -21421,14 +21658,18 @@
 	dir = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bmM" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "bmN" = (
 /obj/structure/barricade/bars,
@@ -23795,7 +24036,9 @@
 "bxG" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "bxH" = (
 /mob/living/simple_animal/hostile/molerat,
@@ -24312,7 +24555,9 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "bAh" = (
 /obj/structure/table,
@@ -24384,6 +24629,12 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"bAz" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "bAA" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert{
@@ -24623,7 +24874,9 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "bFY" = (
 /obj/structure/car/rubbish4,
@@ -24796,7 +25049,9 @@
 	pixel_x = 28
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "bLM" = (
 /obj/structure/lamp_post,
@@ -25669,7 +25924,12 @@
 /area/f13/wasteland/bighorn)
 "bZg" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "bZh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26019,7 +26279,9 @@
 "cdl" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "cdm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26161,12 +26423,20 @@
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/khanfort)
+"cfb" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "cfd" = (
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_y = 15
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "cfl" = (
 /obj/structure/bed/mattress{
@@ -27436,7 +27706,9 @@
 	pixel_y = -14
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "crm" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -28096,6 +28368,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
+"cyE" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "cyJ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
@@ -28136,6 +28413,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"cAr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "cAM" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -28223,7 +28507,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "cFc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28340,6 +28626,12 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
 /area/f13/wasteland/ncr)
+"cJf" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "cJm" = (
 /obj/item/stock_parts/scanning_module/triphasic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28491,7 +28783,9 @@
 	id = "factory3";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "cOT" = (
 /obj/structure/fence/corner{
@@ -28581,7 +28875,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "cRP" = (
 /turf/open/indestructible/ground/outside/road{
@@ -28644,7 +28940,12 @@
 /area/f13/city/bighorn)
 "cUS" = (
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "cVk" = (
 /obj/structure/simple_door/metal/store,
@@ -28686,7 +28987,9 @@
 "cVW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "cWw" = (
 /obj/structure/barricade/sandbags,
@@ -29083,7 +29386,9 @@
 	name = "shutters button";
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "dlC" = (
 /obj/structure/chair/comfy/brown{
@@ -29095,7 +29400,9 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "dmq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29201,6 +29508,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
+"dps" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "dpD" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -29635,8 +29948,19 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
+"dEY" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "dEZ" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -29652,6 +29976,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"dFn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "dFy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/camera_assembly,
@@ -29991,7 +30321,9 @@
 	name = "shutters"
 	},
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "dRT" = (
 /obj/machinery/light/small/broken{
@@ -30283,7 +30615,9 @@
 /area/f13/building)
 "edw" = (
 /obj/structure/wreck/trash/five_tires,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "edZ" = (
 /obj/machinery/light/small,
@@ -30303,6 +30637,12 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "innermaincornerouter"
+	},
+/area/f13/wasteland/massfusion)
+"eeR" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/massfusion)
 "eeT" = (
@@ -30555,7 +30895,9 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/concrete/industrial,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "eoo" = (
 /obj/effect/decal/cleanable/dirt{
@@ -30623,7 +30965,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
 "ese" = (
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "esi" = (
 /obj/machinery/light{
@@ -30720,6 +31064,18 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/east)
+"euS" = (
+/obj/structure/closet/abductor{
+	desc = "A secure metal pod for storing protectrons.";
+	name = "protectron pod"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "evl" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
@@ -30820,7 +31176,9 @@
 "exE" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "exF" = (
 /obj/machinery/light/lampost,
@@ -31069,6 +31427,13 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
+"eHY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "eHZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -31099,6 +31464,14 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/massfusion)
+"eJc" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/building/massfusion)
 "eKc" = (
 /obj/item/mop,
 /turf/open/floor/f13{
@@ -31171,7 +31544,9 @@
 	pixel_x = -14;
 	pixel_y = -14
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "eMl" = (
 /obj/structure/table/wood/settler,
@@ -31289,7 +31664,9 @@
 	pixel_x = 14;
 	pixel_y = -14
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "ePL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31562,6 +31939,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eYq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "eYv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -31632,6 +32015,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
+"faV" = (
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fbb" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31648,7 +32040,9 @@
 "fbg" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "fbh" = (
 /obj/structure/table/wood,
@@ -32369,7 +32763,9 @@
 /area/f13/ncr)
 "fzT" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "fzV" = (
 /obj/structure/spider/stickyweb,
@@ -32462,7 +32858,9 @@
 	pixel_y = 10
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "fCN" = (
 /obj/structure/flora/grass/wasteland{
@@ -32568,7 +32966,9 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "fGd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32611,7 +33011,9 @@
 	icon_state = "ladder10";
 	id = "powerplantleft"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "fIh" = (
 /turf/closed/indestructible/fakeglass,
@@ -32639,7 +33041,9 @@
 "fJz" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "fJA" = (
 /obj/structure/flora/tree/tall{
@@ -32791,14 +33195,18 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "fNr" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "fNE" = (
 /obj/effect/decal/cleanable/dirt{
@@ -32826,7 +33234,9 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "fOA" = (
 /obj/structure/bed/mattress{
@@ -32919,7 +33329,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "fST" = (
 /obj/structure/closet/crate/trashcart,
@@ -33092,6 +33504,13 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/museum)
+"fYM" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fYR" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
@@ -33180,6 +33599,13 @@
 /obj/item/clothing/under/f13/legslave,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"gdF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "gdO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel/khanfort)
@@ -33220,7 +33646,9 @@
 "geU" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/mechanic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "gfb" = (
 /obj/structure/chair,
@@ -33491,6 +33919,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/east)
+"gqd" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "gqm" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
@@ -33568,6 +34002,9 @@
 /area/f13/building/firestation)
 "gtj" = (
 /obj/structure/wreck/trash/machinepile,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
@@ -33766,7 +34203,9 @@
 /area/f13/building/hospital)
 "gzj" = (
 /obj/structure/simple_door/brokenglass,
-/turf/open/floor/plasteel/f13/concrete/industrial,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "gzl" = (
 /turf/open/floor/plating/f13/outside/road{
@@ -33814,7 +34253,9 @@
 	id = "factory1";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "gBy" = (
 /obj/structure/rack,
@@ -33927,6 +34368,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"gGc" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "gGg" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/hospital)
@@ -33938,7 +34385,9 @@
 /area/f13/wasteland/east)
 "gGk" = (
 /mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "gGn" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -33972,7 +34421,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "gHa" = (
 /obj/structure/fence,
@@ -33991,6 +34442,15 @@
 /obj/item/stack/f13Cash/random/med,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"gHR" = (
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "gIc" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -34077,7 +34537,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "gLq" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -34536,6 +34998,11 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland/hospital)
+"ham" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "haK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -34631,7 +35098,9 @@
 /obj/item/clothing/neck/tie/blue,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "hdX" = (
 /obj/structure/decoration/rag,
@@ -34647,7 +35116,9 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "heu" = (
 /obj/structure/barricade/sandbags,
@@ -34667,7 +35138,9 @@
 "heK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "heQ" = (
 /obj/structure/rack,
@@ -34745,7 +35218,9 @@
 "hkk" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "hks" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -35127,10 +35602,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
+"hAr" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "hAB" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "hAP" = (
 /obj/structure/decoration/vent,
@@ -35146,6 +35628,11 @@
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"hBg" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "hBi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
@@ -35206,7 +35693,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "hEh" = (
 /turf/open/floor/wood_mosaic,
@@ -35319,6 +35808,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
+"hIR" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "hIS" = (
 /obj/structure/fence{
 	dir = 4
@@ -35461,6 +35957,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighornbunker)
+"hOY" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "hPh" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf{
@@ -35491,7 +35995,9 @@
 "hPG" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "hPK" = (
 /obj/machinery/vending/nukacolavend,
@@ -35639,6 +36145,15 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
+"hUz" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "hUJ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -35702,6 +36217,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
+"hWb" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "hWr" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -35792,7 +36314,9 @@
 "hYK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "hYN" = (
 /turf/open/indestructible/ground/outside/road{
@@ -36176,7 +36700,9 @@
 /obj/machinery/computer/terminal{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "imr" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -36355,7 +36881,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "isj" = (
 /mob/living/simple_animal/hostile/raider/ranged{
@@ -36594,7 +37122,9 @@
 	pixel_y = 7
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "izH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36673,7 +37203,9 @@
 "iBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/fokoff_sign,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "iBt" = (
 /obj/structure/table/optable,
@@ -36704,7 +37236,9 @@
 /area/f13/wasteland/legion)
 "iCI" = (
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "iCR" = (
 /obj/structure/junk/drawer{
@@ -36848,7 +37382,9 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "iHv" = (
 /obj/structure/simple_door/metal/store{
@@ -36901,7 +37437,9 @@
 "iIo" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "iIM" = (
 /obj/structure/decoration/rag{
@@ -37265,6 +37803,15 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland/hospital)
+"iSQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "iTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -37426,6 +37973,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
+"iYM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "iYP" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/road{
@@ -37742,7 +38295,9 @@
 	dir = 6
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "jiM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37769,7 +38324,9 @@
 "jjp" = (
 /obj/structure/closet,
 /obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "jjq" = (
 /obj/structure/closet/cabinet,
@@ -37833,7 +38390,9 @@
 /area/f13/caves)
 "jkj" = (
 /obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "jkz" = (
 /obj/structure/bed/mattress{
@@ -38203,7 +38762,9 @@
 	id = "factorywarehouse";
 	name = "shutters"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "jAv" = (
 /obj/structure/railing{
@@ -38284,6 +38845,9 @@
 /area/f13/wasteland/west)
 "jCL" = (
 /obj/item/storage/trash_stack,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -38338,7 +38902,9 @@
 /area/f13/wasteland/mall)
 "jEC" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jFG" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -38351,7 +38917,9 @@
 	name = "power unit"
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "jFZ" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -38562,7 +39130,9 @@
 /area/f13/wasteland/ncr)
 "jPo" = (
 /obj/structure/chair/office,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "jPv" = (
 /obj/structure/flora/tree/tall{
@@ -38583,7 +39153,9 @@
 /area/f13/wasteland/mall)
 "jPC" = (
 /obj/structure/closet,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "jPD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -38634,7 +39206,9 @@
 	pixel_x = -18;
 	pixel_y = 18
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jQQ" = (
 /turf/open/indestructible/ground/outside/road{
@@ -38668,7 +39242,9 @@
 "jRV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "jSv" = (
 /obj/effect/landmark/start/f13/ncrtrooper,
@@ -38702,7 +39278,9 @@
 	pixel_x = 14;
 	pixel_y = -14
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "jTC" = (
 /obj/machinery/defibrillator_mount/loaded{
@@ -38789,6 +39367,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"jWy" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "jWC" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -38853,7 +39437,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "kbA" = (
 /obj/structure/flora/tree/tall,
@@ -38954,7 +39540,9 @@
 /area/f13/ncr)
 "kea" = (
 /obj/structure/wreck/trash/two_barrels,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ken" = (
 /obj/structure/flora/stump,
@@ -39053,6 +39641,13 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"kiV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "kjm" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -39060,7 +39655,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "kjF" = (
 /obj/structure/barricade/wooden,
@@ -39082,7 +39679,9 @@
 	pixel_y = -8
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "kjU" = (
 /obj/structure/toilet,
@@ -39349,7 +39948,9 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ktc" = (
 /turf/open/indestructible/ground/outside/road{
@@ -39439,7 +40040,9 @@
 "kxT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "kyf" = (
 /turf/closed/wall/f13/wood/house/broken,
@@ -39584,7 +40187,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "kCB" = (
 /obj/structure/barricade/wooden,
@@ -39666,7 +40271,9 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "kFe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39729,7 +40336,9 @@
 /area/f13/building)
 "kGq" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks/low,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "kGv" = (
 /obj/structure/flora/wasteplant/wild_punga,
@@ -39817,6 +40426,9 @@
 /area/f13/legion)
 "kJj" = (
 /obj/structure/wreck/trash/two_barrels,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -39886,7 +40498,9 @@
 /area/f13/building/museum)
 "kKy" = (
 /obj/structure/wreck/trash/secway,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "kKH" = (
 /obj/machinery/iv_drip,
@@ -39970,7 +40584,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "kNZ" = (
 /turf/open/indestructible/ground/outside/road{
@@ -40019,6 +40635,12 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"kRQ" = (
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "kRU" = (
 /obj/structure/toilet{
 	dir = 1
@@ -40095,9 +40717,12 @@
 /area/f13/building/hospital)
 "kUV" = (
 /obj/machinery/power/port_gen/pacman{
-	name = "generator unit"
+	name = "generator unit";
+	anchored = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "kVc" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn,
@@ -40292,7 +40917,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "laZ" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -40568,6 +41195,12 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
+"lkJ" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "lkO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40837,7 +41470,9 @@
 	pixel_y = 18
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "ltX" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -40872,6 +41507,12 @@
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
+"lvn" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "lvp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -40891,6 +41532,12 @@
 	icon_state = "wide-broken6"
 	},
 /area/f13/building/khanfort)
+"lwi" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "lwl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40899,7 +41546,9 @@
 /area/f13/wasteland/firestation)
 "lwr" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "lwG" = (
 /obj/effect/landmark/start/f13/mangudai,
@@ -40925,7 +41574,9 @@
 "lxJ" = (
 /obj/machinery/light/small,
 /obj/structure/closet/crate/radiation,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "lxR" = (
 /obj/structure/chair/wood{
@@ -41282,7 +41933,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/massfusion)
 "lIS" = (
 /mob/living/simple_animal/cow/brahmin,
@@ -41315,7 +41968,9 @@
 /obj/machinery/teleport/station{
 	name = "power unit"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "lKi" = (
 /obj/structure/railing/wood,
@@ -41592,6 +42247,13 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/mall)
+"lRu" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "lRC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -41609,6 +42271,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"lSs" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "lSw" = (
 /obj/item/crafting/large_gear,
 /turf/open/indestructible/ground/outside/road{
@@ -41735,7 +42403,9 @@
 "lVo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "lVG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41870,6 +42540,12 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/firestation)
+"mbJ" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "mbM" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -42023,7 +42699,9 @@
 /area/f13/wasteland/west)
 "mfo" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mfE" = (
 /obj/effect/decal/cleanable/dirt{
@@ -42305,6 +42983,11 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland/hospital)
+"moG" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "moI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -42415,7 +43098,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "mta" = (
 /obj/structure/chair/wood{
@@ -42457,7 +43142,9 @@
 "mua" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "muJ" = (
 /turf/open/indestructible/ground/outside/road{
@@ -42521,6 +43208,9 @@
 /turf/open/floor/grass,
 /area/f13/building/museum)
 "mwp" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertopright"
 	},
@@ -42780,7 +43470,9 @@
 /area/f13/building)
 "mFy" = (
 /obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/building/massfusion)
 "mFC" = (
 /obj/structure/destructible/tribal_torch,
@@ -42977,7 +43669,9 @@
 /area/f13/building/mall)
 "mMt" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mML" = (
 /obj/structure/fence{
@@ -42992,7 +43686,9 @@
 /area/f13/legion)
 "mNo" = (
 /obj/effect/turf_decal/huge/massfusion,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
 /area/f13/building/massfusion)
 "mNv" = (
 /turf/open/indestructible/ground/outside/road{
@@ -43041,7 +43737,9 @@
 /area/f13/ncr)
 "mPL" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "mPP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43057,6 +43755,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"mQc" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "mQk" = (
 /obj/machinery/light/sign/heaven{
 	pixel_y = 32
@@ -43150,7 +43857,9 @@
 /obj/structure/table/reinforced,
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "mTp" = (
 /obj/structure/table/wood,
@@ -43398,7 +44107,9 @@
 /area/f13/village)
 "ncO" = (
 /obj/item/chair,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "ndc" = (
 /obj/machinery/light/small{
@@ -43919,7 +44630,9 @@
 /obj/structure/fence/handrail{
 	pixel_y = -8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "nvd" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -44086,6 +44799,13 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nzg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "nzi" = (
 /obj/structure/rack,
 /obj/item/cane,
@@ -44328,6 +45048,12 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"nHo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "nHC" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -44400,7 +45126,9 @@
 "nKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/autoshaft,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "nKT" = (
 /obj/structure/barricade/sandbags,
@@ -44637,7 +45365,9 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "nRY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -44669,7 +45399,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "nSQ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -44770,6 +45502,12 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/bighorn)
+"nXb" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "nXr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
@@ -44935,6 +45673,12 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland/hospital)
+"odQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "odX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -44997,6 +45741,12 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/firestation)
+"ofb" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building/massfusion)
 "ofk" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -45038,7 +45788,9 @@
 	pixel_y = 30
 	},
 /obj/item/stack/crafting/electronicparts/five,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "ofN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45709,7 +46461,9 @@
 /obj/structure/fence/handrail{
 	pixel_y = 18
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "oGh" = (
 /obj/machinery/light/small{
@@ -46039,7 +46793,9 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "oOx" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
@@ -46136,6 +46892,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oRF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "oRI" = (
 /obj/structure/fence{
 	dir = 8
@@ -46232,6 +46997,14 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oWE" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "oXp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -46475,7 +47248,9 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "pew" = (
 /obj/structure/reagent_dispensers/compostbin,
@@ -46530,6 +47305,13 @@
 "pgy" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/east)
+"pgJ" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "pgO" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -46546,7 +47328,9 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "pil" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46634,7 +47418,9 @@
 "pmh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "pmk" = (
 /obj/structure/table/wood,
@@ -46670,6 +47456,11 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/mall)
+"png" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "pnF" = (
 /obj/effect/decal/fakelattice{
 	pixel_x = 17
@@ -46713,7 +47504,9 @@
 /area/f13/building/museum)
 "poA" = (
 /obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "poN" = (
 /obj/structure/simple_door/metal/store,
@@ -46752,7 +47545,9 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "prz" = (
 /obj/structure/chair/stool{
@@ -46938,6 +47733,14 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/ncr)
+"pxa" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
 "pxv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -47542,7 +48345,9 @@
 /area/f13/wasteland/quarry)
 "pRs" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "pRv" = (
 /obj/machinery/door/unpowered/secure_legion{
@@ -47655,7 +48460,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "pWU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47703,7 +48510,9 @@
 /area/f13/wasteland/ncr)
 "pZn" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "pZM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47802,7 +48611,9 @@
 /obj/item/wirecutters{
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "qdy" = (
 /obj/effect/turf_decal/huge{
@@ -47963,6 +48774,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/east)
+"qiA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "qiH" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -47986,6 +48803,16 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
+"qjB" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "qjV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -48454,7 +49281,9 @@
 "qxI" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "qxR" = (
 /obj/machinery/light{
@@ -48552,7 +49381,9 @@
 "qBw" = (
 /obj/machinery/light,
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "qBD" = (
 /turf/open/floor/f13{
@@ -48593,6 +49424,13 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/bighorn)
+"qDS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "qDT" = (
 /mob/living/simple_animal/opossum,
 /turf/open/water,
@@ -48843,7 +49681,9 @@
 /obj/structure/table/reinforced,
 /obj/item/phone,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "qNu" = (
 /obj/item/storage/trash_stack,
@@ -48987,6 +49827,13 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/legion)
+"qSe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "qSh" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -49295,11 +50142,15 @@
 "rcv" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rcw" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rcz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -49316,6 +50167,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
+"rdl" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "rdm" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -49343,7 +50200,9 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "reb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -49363,7 +50222,9 @@
 	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "reU" = (
 /obj/structure/noticeboard{
@@ -49484,7 +50345,9 @@
 /area/f13/wasteland/firestation)
 "rkf" = (
 /obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "rkl" = (
 /turf/closed/wall/f13/tentwall,
@@ -49905,6 +50768,12 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/city/bighorn)
+"ryk" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "ryw" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/regular,
@@ -49925,6 +50794,9 @@
 /obj/structure/debris/v3{
 	pixel_x = 8;
 	pixel_y = -5
+	},
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertopright"
@@ -49988,7 +50860,9 @@
 /area/f13/wasteland/heaven)
 "rDt" = (
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "rDz" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -50224,6 +51098,12 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"rKG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "rKZ" = (
 /obj/structure/displaycase,
 /obj/item/clothing/head/helmet/knight/f13/metal,
@@ -50520,7 +51400,9 @@
 /area/f13/wasteland/heaven)
 "rUR" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "rVc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50601,7 +51483,19 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
+"rWn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "rWq" = (
 /obj/structure/legion_extractor,
@@ -50936,7 +51830,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "skW" = (
 /obj/structure/table/optable,
@@ -50987,6 +51883,12 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland/mall)
+"slE" = (
+/mob/living/simple_animal/hostile/molerat,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "slG" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -51253,6 +52155,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/museum)
+"sua" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "sub" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -51519,6 +52428,12 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/west)
+"sEF" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "sFb" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -51553,6 +52468,14 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/firestation)
+"sGa" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "sGd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
@@ -51952,7 +52875,12 @@
 /area/f13/wasteland/east)
 "sWu" = (
 /obj/effect/spawner/lootdrop/tool_box,
-/turf/open/floor/plasteel/f13,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "sWy" = (
 /obj/item/candle/tribal_torch,
@@ -52278,6 +53206,12 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/massfusion)
+"thO" = (
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "thW" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -52490,7 +53424,9 @@
 	pixel_x = -14;
 	pixel_y = -8
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/radiation)
 "tpP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52541,7 +53477,10 @@
 	pixel_x = 28
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "tro" = (
 /turf/open/floor/f13/wood{
@@ -52733,7 +53672,9 @@
 /area/f13/wasteland/hospital)
 "twO" = (
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "twV" = (
 /obj/structure/chair/bench,
@@ -53005,7 +53946,9 @@
 "tEm" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/engineer,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "tEq" = (
 /obj/structure/closet/fridge/cannibal,
@@ -53113,7 +54056,9 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "tIO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -53145,6 +54090,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/heaven)
+"tJE" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "tJO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
@@ -53250,7 +54201,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "tLF" = (
 /obj/structure/chair,
@@ -53260,7 +54213,9 @@
 "tMi" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "tMk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53476,7 +54431,9 @@
 /obj/machinery/light/broken{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "tTm" = (
 /obj/effect/decal/remains/human,
@@ -54031,7 +54988,16 @@
 "ulY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"uma" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "umx" = (
 /obj/effect/decal/cleanable/dirt{
@@ -54100,6 +55066,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"unM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "unR" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -11
@@ -54272,14 +55247,18 @@
 "usn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "usw" = (
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "usI" = (
 /obj/effect/decal/cleanable/generic,
@@ -54353,7 +55332,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "uvR" = (
 /obj/structure/rack,
@@ -54714,7 +55695,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "uGX" = (
 /turf/open/indestructible/ground/outside/desert{
@@ -54866,7 +55849,9 @@
 /area/f13/building/museum)
 "uLZ" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "uMa" = (
 /obj/structure/flora/grass/wasteland{
@@ -54896,7 +55881,9 @@
 "uMW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "uNm" = (
 /obj/structure/stacklifter,
@@ -55119,7 +56106,9 @@
 "uUO" = (
 /obj/effect/spawner/lootdrop/low_tools,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "uUP" = (
 /obj/structure/sign/plaques/long/vault{
@@ -55190,6 +56179,15 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"uWt" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "uWw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -55276,6 +56274,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
+"uZy" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "uZR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -55517,7 +56521,9 @@
 	icon_state = "ladder10";
 	id = "powerplantright"
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "vjK" = (
 /obj/structure/lamp_post,
@@ -56081,7 +57087,9 @@
 	pixel_x = -12
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/massfusion)
 "vDn" = (
 /obj/structure/flora/grass/wasteland{
@@ -56124,7 +57132,9 @@
 "vGp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "vGC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56176,7 +57186,9 @@
 /obj/structure/table/rolling,
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "vIz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56237,7 +57249,9 @@
 "vKX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "vLf" = (
 /obj/machinery/light{
@@ -56246,7 +57260,9 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/radiation)
 "vLl" = (
 /turf/open/indestructible/ground/outside/road{
@@ -56286,6 +57302,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
+"vNC" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "vNI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -56524,6 +57548,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"vUX" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "vVc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -56689,10 +57721,20 @@
 /area/f13/city/bighorn)
 "wbw" = (
 /obj/machinery/power/port_gen/pacman{
-	name = "generator unit"
+	name = "generator unit";
+	anchored = 1
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/massfusion)
+"wbz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "wcN" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -56827,7 +57869,9 @@
 	},
 /obj/effect/spawner/lootdrop/low_tools,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "whS" = (
 /obj/effect/overlay/desert_side{
@@ -56882,7 +57926,9 @@
 "wiV" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wjb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56898,7 +57944,9 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/engine,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wjA" = (
 /obj/effect/decal/cleanable/blood,
@@ -56999,7 +58047,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "wnw" = (
 /turf/open/indestructible/ground/outside/road{
@@ -57198,6 +58248,13 @@
 /obj/item/seeds/mutfruit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wwy" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "wwY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -57249,6 +58306,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"wzj" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "wzk" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
@@ -57342,6 +58405,15 @@
 	},
 /turf/open/floor/wood_worn/wood_worn_dark,
 /area/f13/wasteland/legion)
+"wBZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "wCs" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -57454,13 +58526,17 @@
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "wEx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "wFd" = (
 /obj/structure/table/wood,
@@ -57635,6 +58711,14 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wLT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "wLX" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -57646,7 +58730,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "wMi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -57698,7 +58784,9 @@
 "wNV" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building/massfusion)
 "wOa" = (
 /turf/open/floor/f13{
@@ -57793,6 +58881,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"wPF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "wPM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -57853,7 +58950,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wSN" = (
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "wTb" = (
 /obj/structure/sign/poster/prewar/poster60{
@@ -58004,7 +59103,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "wZY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -58095,7 +59196,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "xcN" = (
 /obj/structure/closet/cabinet,
@@ -58234,7 +59337,9 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "xgM" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -58289,7 +59394,9 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
 /area/f13/building/massfusion)
 "xjM" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -58747,7 +59854,9 @@
 /obj/machinery/computer/terminal{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "xBq" = (
 /obj/structure/car/rubbish3,
@@ -59017,7 +60126,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "xKc" = (
 /obj/structure/disposalpipe/segment{
@@ -59135,7 +60246,9 @@
 /area/f13/wasteland/bighorn)
 "xNI" = (
 /obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "xNL" = (
 /obj/structure/table,
@@ -59228,7 +60341,9 @@
 /obj/item/geiger_counter,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building/massfusion)
 "xRA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -59512,7 +60627,9 @@
 "ybo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/engineering,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ybs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -59691,7 +60808,12 @@
 	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
 /area/f13/building/massfusion)
 "yhA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -59799,11 +60921,15 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building/massfusion)
 "ykQ" = (
 /mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "ykY" = (
 /obj/structure/fence,
@@ -104600,7 +105726,7 @@ vVo
 dll
 aCt
 vIs
-wSN
+png
 vVo
 aae
 aae
@@ -104854,10 +105980,10 @@ ahg
 ahg
 kzT
 jAn
-rcw
+rKG
 mua
-rcw
-xNI
+rKG
+gGc
 vVo
 aae
 aae
@@ -105111,10 +106237,10 @@ ahg
 kzT
 kzT
 jAn
-wSN
-rcw
+png
+rKG
 fNp
-rcw
+rKG
 vVo
 aae
 aae
@@ -105368,10 +106494,10 @@ ahg
 kzT
 kzT
 jAn
-wSN
-xNI
-rcw
-wSN
+png
+gGc
+rKG
+png
 vVo
 vVo
 aae
@@ -105607,9 +106733,9 @@ aae
 aae
 oBz
 oBz
-uCn
-cBj
-lyu
+iSQ
+oWE
+eJc
 qzL
 wjW
 tbY
@@ -105626,9 +106752,9 @@ iKB
 acd
 vVo
 uvP
-wSN
-rcw
-rcw
+cyE
+iYM
+iYM
 hkk
 vVo
 aae
@@ -105883,9 +107009,9 @@ wkF
 aaX
 vVo
 fJz
-wSN
+cyE
 cRJ
-wSN
+cyE
 fNY
 vVo
 aae
@@ -106122,8 +107248,8 @@ vVo
 vVo
 vVo
 yhr
-twO
-wSN
+mQc
+wBZ
 vVo
 ofH
 awY
@@ -106139,11 +107265,11 @@ kzT
 ahg
 aaX
 mFy
-rcw
-rcw
+iYM
+iYM
 wNV
-wSN
-rcw
+cyE
+iYM
 vVo
 aae
 aae
@@ -106375,16 +107501,16 @@ adD
 xco
 xco
 aaH
-vKX
-wSN
+sua
+wbz
 cOR
 blL
-wSN
-wSN
+rKG
+lkJ
 gBg
-wSN
-wSN
-aXD
+aaH
+png
+wzj
 vVo
 vVo
 vVo
@@ -106397,9 +107523,9 @@ hUq
 ojo
 vVo
 qxI
-wSN
+cyE
 mPL
-wSN
+cyE
 hkk
 vVo
 aae
@@ -106633,15 +107759,15 @@ fEv
 aVj
 aHV
 iCI
-iCI
+hIR
 dRL
 rWe
-rcw
-rcw
+qDS
+wbz
 gBg
-rcw
+unM
 ajs
-rcw
+rKG
 aXz
 xcF
 sWu
@@ -106654,9 +107780,9 @@ kJj
 pec
 vVo
 iGE
-wSN
-wSN
-wSN
+cyE
+cyE
+cyE
 rdV
 vVo
 aaa
@@ -106882,27 +108008,27 @@ aae
 vVo
 aBA
 aaN
-wSN
+aKF
 aWw
 vVo
 fEv
 fEv
 fEv
 aaH
-twO
+lRu
 trb
 cOR
 bZg
 acF
-wSN
+wbz
 gBg
-xNI
-wSN
-rcw
-rUR
-wSN
-rcw
-rcw
+uWt
+png
+rKG
+tJE
+png
+rKG
+qDS
 vVo
 hSI
 lFy
@@ -106910,11 +108036,11 @@ bLP
 acZ
 hSI
 vVo
-ulY
-wSN
+wwy
+cyE
 nSC
-rcw
-wSN
+iYM
+cyE
 vVo
 aae
 aaa
@@ -107138,8 +108264,8 @@ aae
 aae
 vVo
 agq
-rcw
-wSN
+qiA
+aKF
 afa
 vVo
 vVo
@@ -107153,13 +108279,13 @@ vVo
 vVo
 vVo
 vVo
-aeO
-wSN
-wSN
-rcw
-vKX
-rcw
-wSN
+euS
+png
+png
+rKG
+sua
+qDS
+png
 vVo
 dNH
 mwp
@@ -107168,9 +108294,9 @@ mwp
 uzS
 vVo
 hkk
-rcw
+iYM
 dlI
-wSN
+cyE
 nSC
 vVo
 aae
@@ -107400,20 +108526,20 @@ aAM
 vVo
 vVo
 lKe
-wSN
-rcw
+aKF
+qiA
 lKe
 lKe
 jFL
 heK
-wSN
+aKF
 lKe
 lKe
 vVo
 bjv
-wSN
+rKG
 jRV
-wSN
+png
 amr
 bmd
 wMb
@@ -107426,8 +108552,8 @@ ebg
 vVo
 pro
 irW
-ulY
-wSN
+wwy
+cyE
 wNV
 vVo
 aae
@@ -107653,18 +108779,18 @@ vVo
 kUV
 aXM
 wbw
-wSN
-vKX
+aKF
+qSe
 vVo
 aaV
 twO
-wSN
-wSN
-mPL
-wSN
-wSN
-wSN
-wSN
+aKF
+aKF
+thO
+aKF
+aKF
+aKF
+aKF
 aXD
 vVo
 kET
@@ -107914,22 +109040,22 @@ twO
 rUR
 vVo
 xNI
-wSN
-wSN
-wSN
-rcw
-rcw
-wSN
+aKF
+aKF
+aKF
+qiA
+qiA
+aKF
 lVo
 twO
 xNI
 vVo
-rcw
+iYM
 irW
 wno
 bkG
-wSN
-wSN
+cyE
+cyE
 vVo
 bGU
 aXt
@@ -108165,10 +109291,10 @@ aae
 aae
 vVo
 fSy
-rcw
-wSN
-rcw
-wSN
+qiA
+aKF
+qiA
+aKF
 vVo
 axf
 axf
@@ -108185,7 +109311,7 @@ mFy
 vVo
 eon
 bcv
-wSN
+cyE
 qBw
 vVo
 eIN
@@ -108422,19 +109548,19 @@ aae
 aae
 vVo
 tIE
-kET
+pxa
 aWG
 uLZ
-wSN
+aKF
 vVo
 jjp
 wEs
-wSN
+aKF
 twO
 xQT
-jPC
+uZy
 vVo
-rUR
+dps
 rcw
 wSN
 xJU
@@ -108442,7 +109568,7 @@ cdl
 vVo
 eon
 bcv
-rcw
+iYM
 vGp
 vVo
 eIN
@@ -108681,17 +109807,17 @@ vVo
 kUV
 aXM
 wbw
-wSN
-rcw
+aKF
+qiA
 tMi
 gGQ
 agB
-wSN
-rcw
+vNC
+qiA
 bkF
 bkF
 aAM
-twO
+cJf
 wSN
 wSN
 wSN
@@ -108720,7 +109846,7 @@ eXO
 vVo
 jPo
 mTc
-axf
+pgJ
 avS
 uGX
 bPL
@@ -108975,8 +110101,8 @@ avS
 bPL
 vRh
 vVo
-axf
-axf
+pgJ
+pgJ
 vVo
 lUy
 bPL
@@ -109196,11 +110322,11 @@ aby
 rDt
 aXI
 aXI
-ese
+nXb
 msN
 aXT
 ese
-aXT
+wPF
 ese
 laF
 afR
@@ -109459,8 +110585,8 @@ jEC
 pZn
 pZn
 jTh
-ese
-lwr
+moG
+lwi
 aXT
 aby
 tLD
@@ -109490,9 +110616,9 @@ vUN
 vUN
 vUN
 nlp
-vUN
+cfb
 uRZ
-vUN
+vUX
 vUN
 vUN
 eeT
@@ -109747,9 +110873,9 @@ dKo
 dKo
 dKo
 dKo
-dKo
+ryk
 feX
-dKo
+sGa
 dKo
 dKo
 gpP
@@ -109977,14 +111103,14 @@ aeP
 lts
 ese
 agR
-wSN
-wSN
-wSN
-wSN
+hBg
+hBg
+hBg
+hBg
 asN
-wSN
-wSN
-wSN
+hBg
+hBg
+hBg
 vVo
 auF
 vJP
@@ -110004,9 +111130,9 @@ dKo
 dKo
 dKo
 dKo
-dKo
+ryk
 feX
-dKo
+sGa
 dKo
 dKo
 owX
@@ -110222,7 +111348,7 @@ aby
 aaO
 aXT
 afr
-jEC
+lSs
 nvc
 aeP
 aeP
@@ -110235,14 +111361,14 @@ oFJ
 ese
 agR
 tEm
-wSN
-rcw
+ham
+dFn
 mNo
 bkW
-wSN
-lVo
-wSN
-aKF
+hBg
+gdF
+hBg
+mFy
 uEz
 uEz
 wUQ
@@ -110261,9 +111387,9 @@ wsm
 ciV
 dKo
 dKo
-dKo
+ryk
 feX
-dKo
+sGa
 dKo
 dKo
 ukW
@@ -110492,13 +111618,13 @@ oFJ
 ese
 agR
 xBl
-wSN
-rcw
-wSN
+ham
+dFn
+ham
 bkW
 iBp
-kxT
-rcw
+nzg
+nHo
 vVo
 nOd
 swF
@@ -110518,9 +111644,9 @@ jDC
 veD
 iJK
 iJK
-iJK
+eeR
 vXY
-iJK
+hOY
 iJK
 iJK
 jDC
@@ -110746,17 +111872,17 @@ aeP
 aeP
 aeP
 oFJ
-ese
+nXb
 agR
 bxG
-wSN
-wSN
-wSN
+ham
+ham
+ham
 bkW
-rUR
-ulY
-wSN
-aKF
+ofb
+hWb
+hBg
+mFy
 xYE
 bQv
 xjZ
@@ -111005,10 +112131,10 @@ aeP
 oFJ
 aXT
 agR
-wSN
-wSN
+hBg
+hBg
 usw
-wSN
+hBg
 asN
 ncO
 bja
@@ -111251,7 +112377,7 @@ aby
 aby
 adG
 ese
-ese
+moG
 aeP
 aeP
 aeP
@@ -111511,19 +112637,19 @@ afH
 eMj
 afk
 tpH
-ese
-ese
-ese
+moG
+moG
+moG
 crl
-ese
-aXT
+moG
+eYq
 usn
 aby
 wSN
-twO
+cJf
 vVo
 rcw
-awY
+faV
 skP
 bmM
 wSN
@@ -111544,8 +112670,8 @@ eLd
 cvN
 avS
 vVo
-wSN
-wSN
+aKF
+aKF
 rkf
 vVo
 uGX
@@ -111764,26 +112890,26 @@ aae
 aae
 aby
 rDt
-ese
-ese
+aXI
+aXI
 bKK
 vLf
+cAr
 aXT
-aXT
-pZn
+dEY
 ese
 aXT
 afe
 vjB
 aby
 wSN
-rUR
+dps
 vVo
 rcw
 wSN
 wSN
 wSN
-xNI
+jWy
 geU
 vVo
 eIN
@@ -111803,7 +112929,7 @@ avS
 vVo
 hAB
 ams
-wSN
+aKF
 vVo
 aae
 aae
@@ -112279,21 +113405,21 @@ vVo
 kUV
 aXM
 wbw
-wSN
+aKF
 twO
 aAM
 nRR
 aWf
-ulY
-wSN
+qjB
+aKF
 nRR
 nRR
 aAM
 wSN
-lVo
+rWn
 wSN
 vVo
-awY
+faV
 wSN
 wSN
 rcw
@@ -112315,10 +113441,10 @@ sfu
 cvN
 vVo
 poA
-rcw
+qiA
 gGk
 uUO
-skP
+gHR
 vVo
 aae
 aae
@@ -112536,25 +113662,25 @@ vVo
 awq
 hDW
 jif
-wSN
-rcw
+aKF
+qiA
 vVo
 wEs
 jjp
-wSN
-rcw
+aKF
+qiA
 hPG
 aHx
 vVo
-twO
+cJf
 wSN
 wSN
 mFy
-twO
+cJf
 wSN
 awi
 rcw
-lVo
+rWn
 geU
 vVo
 eIN
@@ -112571,10 +113697,10 @@ dKo
 kFB
 bsm
 vVo
-rcw
+qiA
 aVi
-wSN
-rcw
+aKF
+qiA
 rkf
 vVo
 aae
@@ -112792,9 +113918,9 @@ aae
 vVo
 aof
 acU
-rcw
+qiA
 rUR
-wSN
+aKF
 vVo
 axf
 axf
@@ -112828,10 +113954,10 @@ dKo
 kFB
 ivh
 aAM
-rcw
+qiA
 kxT
 lVo
-wSN
+aKF
 aFV
 vVo
 aae
@@ -113048,24 +114174,24 @@ abO
 aae
 vVo
 aXJ
-kET
+pxa
 aWG
-wSN
-wSN
+aKF
+aKF
 vVo
 xNI
-wSN
+aKF
 ulY
-rcw
-wSN
-wSN
-rcw
-rcw
-rcw
-vKX
+qiA
+aKF
+aKF
+qiA
+qiA
+qiA
+qSe
 aAM
 wSN
-lVo
+rWn
 rcw
 aFE
 wSN
@@ -113087,9 +114213,9 @@ doD
 vVo
 xNI
 rUR
-wSN
+aKF
 dEU
-exE
+uma
 vVo
 aae
 aae
@@ -113307,17 +114433,17 @@ vVo
 kUV
 aXM
 wbw
-rcw
+qiA
 xNI
 vVo
 agG
 kxT
-rcw
-wSN
-wSN
+qiA
+aKF
+aKF
 kxT
-rcw
-rcw
+qiA
+qiA
 twO
 fbg
 vVo
@@ -113343,10 +114469,10 @@ eLd
 cvN
 vVo
 wEx
-vKX
-wSN
-imm
-ncO
+qSe
+aKF
+oRF
+mbJ
 vVo
 aae
 aae
@@ -113568,13 +114694,13 @@ vVo
 aAM
 vVo
 lKe
-wSN
+aKF
 pRs
 lKe
 lKe
 lKe
 xNI
-wSN
+aKF
 lKe
 lKe
 vVo
@@ -113582,7 +114708,7 @@ aeO
 wSN
 wSN
 mFy
-wSN
+hAr
 bkD
 vCW
 vVo
@@ -113822,7 +114948,7 @@ aae
 vVo
 heK
 bjh
-wSN
+aKF
 vVo
 vVo
 axf
@@ -113836,12 +114962,12 @@ vVo
 vVo
 vVo
 aTU
-uLZ
+lvn
 wSN
 vVo
-rcw
+odQ
 aWF
-xNI
+bAz
 vVo
 nbT
 nbT
@@ -113858,7 +114984,7 @@ hSq
 aae
 vVo
 aVi
-wSN
+aKF
 vVo
 fzT
 bix
@@ -114078,18 +115204,18 @@ aae
 aae
 vVo
 wYd
-rcw
+qiA
 ulY
-wSN
+aKF
 adQ
 kbV
 adv
 adh
 kxT
 aAM
-wSN
-wSN
-wSN
+aKF
+aKF
+aKF
 xNI
 vVo
 awD
@@ -114105,7 +115231,7 @@ aae
 vVo
 vVo
 vVo
-aAM
+gqd
 vVo
 vVo
 vVo
@@ -114115,10 +115241,10 @@ aae
 aae
 vVo
 reI
-wSN
+xNI
 vVo
 fGb
-aVi
+eHY
 wSN
 imm
 oOh
@@ -114347,11 +115473,11 @@ vVo
 pRs
 anp
 lKe
-rcw
+qiA
 vVo
 adw
-xNI
-twO
+jWy
+cJf
 vVo
 lIO
 vVo
@@ -114362,8 +115488,8 @@ aae
 vVo
 peq
 wSN
-wSN
-aCt
+jWy
+wLT
 aIh
 vVo
 aae
@@ -114372,7 +115498,7 @@ aae
 vVo
 vVo
 gGk
-rcw
+qiA
 vVo
 aVD
 wSN
@@ -114601,8 +115727,8 @@ adv
 oJI
 kbV
 vVo
-wSN
-rcw
+aKF
+qiA
 twO
 lxJ
 vVo
@@ -114627,16 +115753,16 @@ aae
 aae
 aae
 vVo
-wSN
-wSN
+afa
+aKF
 aXD
 vVo
-rkf
+sEF
 wSN
 wSN
-usw
-ulY
-xNI
+hUz
+fYM
+jWy
 vVo
 aae
 aaa
@@ -114884,13 +116010,13 @@ aae
 aae
 aae
 vVo
-wSN
-wSN
-wSN
+aWw
+aKF
+aKF
 vVo
 vVo
 vVo
-aAM
+gqd
 vVo
 vVo
 axU
@@ -115133,7 +116259,7 @@ vVo
 vVo
 wSN
 wSN
-wSN
+jWy
 wSN
 wSN
 vVo
@@ -115141,13 +116267,13 @@ aae
 aae
 aae
 vVo
-wSN
+afa
 xNI
-rcw
-wSN
+qiA
+aKF
 bAe
-rcw
-rcw
+qiA
+qiA
 aVi
 vVo
 wSN
@@ -115392,7 +116518,7 @@ wSN
 rcw
 wSN
 rcw
-twO
+cJf
 vVo
 aae
 aae
@@ -115400,12 +116526,12 @@ aae
 vVo
 vVo
 twO
-wSN
+aKF
 gGk
 biX
 tTk
 bmx
-wSN
+xNI
 vVo
 afQ
 vVo
@@ -115644,7 +116770,7 @@ aae
 aae
 vVo
 aWu
-heK
+kiV
 wSN
 wSN
 kUV
@@ -115657,7 +116783,7 @@ vVo
 vVo
 vVo
 vVo
-aAM
+gqd
 vVo
 vVo
 vVo
@@ -115903,7 +117029,7 @@ vVo
 rcw
 wSN
 wSN
-wSN
+jWy
 wSN
 wSN
 vKX
@@ -115915,7 +117041,7 @@ exE
 wSN
 wSN
 rcw
-rkf
+sEF
 vVo
 awO
 twO
@@ -116158,7 +117284,7 @@ aae
 aae
 vVo
 edw
-xNI
+jWy
 wSN
 wSN
 wSN
@@ -116175,9 +117301,9 @@ xgE
 iIo
 vVo
 agW
-wSN
-wSN
-wSN
+aKF
+aKF
+aKF
 gLn
 vVo
 aae
@@ -116417,15 +117543,15 @@ vVo
 vVo
 uMW
 wjw
-xNI
-pRs
+jWy
+kRQ
 pWD
 kKy
 vVo
 aae
 vVo
 ybo
-gGk
+slE
 wSN
 wSN
 iIo
@@ -116685,7 +117811,7 @@ qdr
 rcw
 rcw
 wSN
-ncO
+rdl
 pmh
 vVo
 vVo
@@ -116941,7 +118067,7 @@ aae
 lVN
 qaP
 nRf
-aVi
+eHY
 kBP
 hRI
 vVo

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1413,8 +1413,9 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "aeP" = (
@@ -7593,7 +7594,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "awZ" = (
@@ -9332,7 +9333,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "aCv" = (
@@ -15688,7 +15689,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "aVj" = (
@@ -19349,13 +19350,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/west)
-"bfQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "bfR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -22432,6 +22426,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/museum)
+"bpp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "bpu" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -24844,11 +24844,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
-"bEZ" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "bFz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25185,6 +25180,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/west)
+"bOE" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "bPg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25239,13 +25240,6 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland/massfusion)
-"bQR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "bQV" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -26714,12 +26708,6 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
-"cjM" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "cjX" = (
 /turf/open/floor/wood_common,
 /area/f13/village)
@@ -28445,6 +28433,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"cBG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "cBK" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -29402,6 +29399,15 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
+"dma" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "dmq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29561,6 +29567,13 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland/bighorn)
+"drI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "dsi" = (
 /obj/structure/junk/machinery,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -29792,6 +29805,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
+"dyw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "dyN" = (
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/indestructible/ground/outside/desert,
@@ -29815,11 +29835,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland/east)
-"dzC" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
-	},
-/area/f13/building/massfusion)
 "dAy" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/sosjerky/ration,
@@ -29879,6 +29894,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"dBY" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "dCu" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -30084,15 +30104,6 @@
 /obj/item/melee/onehanded/slavewhip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
-"dIm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "dIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -30468,6 +30479,13 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland/east)
+"dYI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "dYK" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -30489,6 +30507,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/museum)
+"dZF" = (
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "dZK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -30862,12 +30886,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/f13/building)
-"enO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
-	},
-/area/f13/building/massfusion)
 "enQ" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
@@ -30957,7 +30975,7 @@
 /area/f13/wasteland/bighorn)
 "ese" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
 "esi" = (
@@ -31156,7 +31174,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "exF" = (
@@ -31248,6 +31266,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
+"eBu" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "eBv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -31612,6 +31637,12 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/nanotrasen)
+"ePw" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "ePI" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -31668,6 +31699,14 @@
 "eQU" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/legion)
+"eRa" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "eRk" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/west)
@@ -31697,6 +31736,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
+"eRE" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "eRT" = (
 /obj/structure/fence{
 	dir = 4
@@ -31912,6 +31959,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
+"eYK" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "eZp" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -32105,18 +32158,6 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland/followers)
-"ffM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
-"ffN" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "fgf" = (
 /obj/item/flag/khan,
 /obj/structure/reagent_dispensers/barrel/three,
@@ -32186,6 +32227,17 @@
 /obj/item/pen,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fhP" = (
+/obj/structure/closet/abductor{
+	desc = "A secure metal pod for storing protectrons.";
+	name = "protectron pod"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fiv" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/desert,
@@ -32376,6 +32428,13 @@
 "fpg" = (
 /turf/open/water,
 /area/f13/wasteland/ncr)
+"fpj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fpt" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -32805,12 +32864,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/bighorn)
-"fBA" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "fCk" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
@@ -33220,12 +33273,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"fOC" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "fOH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33266,6 +33313,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"fPS" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "fQa" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -33565,14 +33619,34 @@
 /obj/item/clothing/under/f13/legslave,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"gdD" = (
+/mob/living/simple_animal/hostile/molerat,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "gdO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel/khanfort)
+"gdU" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "gdZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland/bighorn)
+"gef" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "geo" = (
 /obj/machinery/microwave{
 	pixel_y = 5
@@ -34416,6 +34490,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"gIP" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "gJe" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -34488,6 +34568,13 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland/museum)
+"gLN" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "gLV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/exhibit/future1{
@@ -34505,6 +34592,22 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/followers)
+"gMc" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"gMz" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "gMA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/house,
@@ -34705,15 +34808,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/firestation)
-"gSN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "gTk" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -35081,7 +35175,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "heQ" = (
@@ -35183,6 +35277,13 @@
 "hkC" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
+"hkO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "hkR" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -35353,12 +35454,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/mall)
-"htq" = (
-/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "htU" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -36051,15 +36146,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
-"hTO" = (
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "hUc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -36589,6 +36675,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/ncr)
+"iln" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "ilo" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -37152,6 +37243,7 @@
 /area/f13/wasteland/legion)
 "iCI" = (
 /obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustysolid"
 	},
@@ -37300,6 +37392,11 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
+"iGO" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
 	},
 /area/f13/building/massfusion)
 "iHv" = (
@@ -37874,6 +37971,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"iYa" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "iYc" = (
 /obj/structure/fence{
 	dir = 4
@@ -38137,6 +38240,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/west)
+"jgG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "jgS" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -38658,14 +38768,6 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland/bighorn)
-"jAk" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "jAn" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorywarehouse";
@@ -38761,14 +38863,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building/massfusion)
-"jCS" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "jCV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice{
@@ -38817,11 +38911,6 @@
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/mall)
-"jEf" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "jEC" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
@@ -38902,14 +38991,6 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"jKB" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "jKE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/cone,
@@ -39151,15 +39232,6 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/legion)
-"jRn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "jRM" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -39221,6 +39293,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"jTz" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "jTC" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -30
@@ -39619,6 +39698,12 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/legion)
+"kku" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "kkw" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken5"
@@ -39856,6 +39941,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood_common,
 /area/f13/city/bighorn)
+"krJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "ksk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "shadowleft"
@@ -40198,7 +40290,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
 "kFe" = (
@@ -40343,12 +40435,6 @@
 "kIS" = (
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
-"kJa" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "kJf" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -40553,12 +40639,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/mall)
-"kQb" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "kRx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -40592,14 +40672,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/museum)
-"kSw" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "kSV" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -40623,6 +40695,15 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/heaven)
+"kTD" = (
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "kUn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -41081,6 +41162,12 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland/west)
+"liL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "liM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -41368,6 +41455,14 @@
 "lrZ" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khanfort)
+"lsG" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "lsJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -41679,6 +41774,15 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland/east)
+"lDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "lEh" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -41975,12 +42079,6 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"lMB" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "lMY" = (
 /obj/machinery/smartfridge/bottlerack/alchemy_rack,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -42323,7 +42421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "lVG" = (
@@ -42678,6 +42776,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mia" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "mig" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
@@ -42754,13 +42858,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building/firestation)
-"mkQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "mkY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43208,15 +43305,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
-"mzI" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "mzO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -43394,7 +43482,7 @@
 /area/f13/building)
 "mFy" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "mFC" = (
@@ -43503,6 +43591,12 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
 /area/f13/wasteland/khanfort)
+"mIw" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "mIy" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -43633,12 +43727,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
-"mOg" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "mOh" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/tie/black,
@@ -43650,6 +43738,13 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
+"mOV" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "mPo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -43667,7 +43762,7 @@
 "mPL" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
 "mPP" = (
@@ -43731,15 +43826,6 @@
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mRw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "mSa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44040,13 +44126,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"ncX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "ndc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44717,6 +44796,12 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/train)
+"nyT" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "nyW" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -44849,12 +44934,6 @@
 "nCD" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland/khanfort)
-"nCK" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "nDc" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light/broken{
@@ -45030,12 +45109,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/quarry)
-"nJm" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "nJO" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -45691,13 +45764,6 @@
 "ofC" = (
 /turf/open/floor/wood_fancy,
 /area/f13/city/bighorn)
-"ofE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "ofG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -45779,6 +45845,15 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland/west)
+"oio" = (
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "oiq" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -45841,13 +45916,6 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/city/bighorn)
-"okb" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "okd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -45862,14 +45930,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"oko" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "okD" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -45995,6 +46055,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/nanotrasen)
+"oqd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "oqe" = (
 /obj/structure/fence/wooden,
 /obj/structure/fence/wooden{
@@ -46079,12 +46148,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"osj" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "osl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -46509,13 +46572,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"oJo" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "oJz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -46705,6 +46761,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/ncr)
+"oNI" = (
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "oNM" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -46867,6 +46929,11 @@
 	smooth = 1
 	},
 /area/f13/building/museum)
+"oTC" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "oTE" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
@@ -47377,13 +47444,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
-"pmD" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "pnc" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -47622,13 +47682,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/ncr)
-"pvo" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "pvu" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -48085,12 +48138,6 @@
 /obj/item/trash/f13/cram,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"pKv" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "pKy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain3"
@@ -48149,6 +48196,14 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/firestation)
+"pMs" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "pMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48405,6 +48460,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/bighorn)
+"pXk" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "pXv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
@@ -48445,11 +48506,8 @@
 /area/f13/wasteland/ncr)
 "pZn" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
 "pZM" = (
@@ -48505,12 +48563,6 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland/east)
-"qbg" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "qbz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48602,12 +48654,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/firestation)
-"qeK" = (
-/mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "qeN" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/road{
@@ -48620,12 +48666,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/quarry)
-"qfp" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "qft" = (
 /obj/machinery/light/small,
 /obj/item/clothing/head/cone,
@@ -49083,15 +49123,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qtb" = (
-/obj/effect/spawner/lootdrop/low_tools,
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "qth" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
@@ -49115,6 +49146,12 @@
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
+"qtQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "qtT" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -49125,12 +49162,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/building)
-"qtW" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "quc" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -49419,6 +49450,15 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/ncr)
+"qFI" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "qGs" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "hospitalgarage1";
@@ -50033,13 +50073,6 @@
 "rbg" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
-"rbl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "rbE" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -50097,7 +50130,7 @@
 "rcw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "rcz" = (
@@ -50137,13 +50170,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/building/khanfort)
-"rdq" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "rdV" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/trash,
@@ -50161,6 +50187,12 @@
 "rer" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
+"rew" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "reF" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 10
@@ -50295,7 +50327,7 @@
 "rkf" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "rkl" = (
@@ -50458,6 +50490,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rpJ" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "rpN" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
@@ -50698,6 +50739,12 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"rxB" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/building/massfusion)
 "rxE" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -50967,12 +51014,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"rIJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "rIT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -51054,6 +51095,12 @@
 /obj/item/twohanded/fireaxe/boneaxe,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"rLF" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "rLI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -51344,7 +51391,7 @@
 "rUR" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "rVc" = (
@@ -51628,18 +51675,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
-"sgh" = (
-/obj/structure/closet/abductor{
-	desc = "A secure metal pod for storing protectrons.";
-	name = "protectron pod"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "sgr" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52174,6 +52209,12 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"swY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "sxE" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -52244,15 +52285,6 @@
 /obj/item/clothing/head/cueball,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
-"sBb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "sBl" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -52295,6 +52327,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/firestation)
+"sBX" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "sCs" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaltop"
@@ -52372,6 +52410,13 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/west)
+"sEY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "sFb" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -52903,6 +52948,15 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"sZR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "sZT" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/desert,
@@ -53030,6 +53084,12 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13,
 /area/f13/building)
+"tey" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "teE" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -53090,14 +53150,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/quarry)
-"tgB" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "tgF" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -53443,12 +53495,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/firestation)
-"trS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "tsa" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert{
@@ -53611,7 +53657,7 @@
 "twO" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "twV" = (
@@ -53697,6 +53743,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/museum)
+"tyU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "tyX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -54033,12 +54085,6 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland/bighorn)
-"tJS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "tJV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -54352,6 +54398,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
+"tSL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "tTe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -54832,13 +54887,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
-"uiv" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "uiC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -54934,7 +54982,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
 "umx" = (
@@ -55123,6 +55171,12 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland/heaven)
+"uqJ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "ura" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -55219,12 +55273,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"utO" = (
-/obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "uua" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/road{
@@ -55267,6 +55315,9 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/trash,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustychess"
 	},
@@ -55407,6 +55458,13 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/building)
+"uAs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "uAz" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -55420,6 +55478,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"uAL" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "uAN" = (
 /obj/structure/table/wood,
 /obj/item/defibrillator/primitive,
@@ -55466,12 +55530,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
-"uBL" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "uCa" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/road{
@@ -55791,7 +55849,7 @@
 "uLZ" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "uMa" = (
@@ -55978,12 +56036,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uTV" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "uTY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -56369,11 +56421,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
-"vhJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+"vhS" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "vic" = (
@@ -56623,11 +56674,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"vpk" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "vpl" = (
 /obj/structure/junk/locker,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -56724,6 +56770,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/east)
+"vtq" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "vtM" = (
 /turf/open/floor/wood_worn,
 /area/f13/building/khanfort)
@@ -56988,6 +57040,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"vAW" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/building/massfusion)
 "vBd" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/civilian/lawyer/really_black/skirt,
@@ -57090,14 +57150,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/nanotrasen)
-"vHw" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building/massfusion)
 "vHB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -57202,7 +57254,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "vLf" = (
@@ -57244,12 +57296,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building/khanfort)
-"vMV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "vNb" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
@@ -57270,6 +57316,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
+"vNV" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "vNW" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -57505,12 +57560,6 @@
 /area/f13/wasteland/museum)
 "vVo" = (
 /turf/closed/wall/mineral/concrete,
-/area/f13/building/massfusion)
-"vVu" = (
-/obj/structure/closet,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
 /area/f13/building/massfusion)
 "vVw" = (
 /obj/effect/decal/cleanable/dirt{
@@ -58011,14 +58060,6 @@
 "wnX" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/mall)
-"wog" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/building/massfusion)
 "woj" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -58237,12 +58278,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/museum)
-"wze" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "wzf" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8";
@@ -58258,6 +58293,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
+"wzy" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "wzC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
@@ -58579,16 +58622,6 @@
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/carpet/purple,
 /area/f13/bar/heaven)
-"wHZ" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "wIc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -58604,13 +58637,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"wJe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "wJA" = (
 /obj/item/mop,
 /obj/structure/janitorialcart,
@@ -58715,12 +58741,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
 /area/f13/legion)
-"wNM" = (
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "wNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -58763,12 +58783,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"wOC" = (
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "wOD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
@@ -58896,7 +58910,7 @@
 /area/f13/building)
 "wSN" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "wTb" = (
@@ -59645,6 +59659,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building/firestation)
+"xwq" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "xwB" = (
 /obj/machinery/light{
 	dir = 1
@@ -59758,12 +59777,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
-"xzh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "xzq" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/light/small{
@@ -59922,6 +59935,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building/mall)
+"xEl" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "xEs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -60197,11 +60218,8 @@
 /area/f13/wasteland/bighorn)
 "xNI" = (
 /obj/effect/spawner/lootdrop/trash,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "xNL" = (
@@ -60706,6 +60724,12 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/bighornbunker)
+"yfo" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "yfR" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/sunset/brick_small_dark,
@@ -60907,12 +60931,6 @@
 	icon_state = "verticalleftborderlefttop"
 	},
 /area/f13/wasteland/east)
-"ylF" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "ylR" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -105684,9 +105702,9 @@ mLn
 mLn
 vVo
 dll
-aCt
+eRa
 vIs
-ffN
+iln
 vVo
 aae
 aae
@@ -105938,12 +105956,12 @@ kzT
 kzT
 ahg
 ahg
-kzT
+rxB
 jAn
-trS
+sZR
 mua
-trS
-qbg
+liL
+gIP
 vVo
 aae
 aae
@@ -106195,12 +106213,12 @@ kzT
 kUw
 ahg
 kzT
-kzT
+rxB
 jAn
-ffN
-trS
+aaH
+liL
 fNp
-trS
+liL
 vVo
 aae
 aae
@@ -106452,12 +106470,12 @@ kzT
 ahg
 ahg
 kzT
-kzT
+rxB
 jAn
-ffN
-qbg
-trS
-ffN
+aaH
+gIP
+liL
+iln
 vVo
 vVo
 aae
@@ -106693,9 +106711,9 @@ aae
 aae
 oBz
 oBz
-sBb
-jCS
-wog
+lDT
+lsG
+vAW
 qzL
 wjW
 tbY
@@ -106712,9 +106730,9 @@ iKB
 acd
 vVo
 uvP
-wSN
-xzh
-xzh
+xEl
+tSL
+tSL
 hkk
 vVo
 aae
@@ -106969,9 +106987,9 @@ wkF
 aaX
 vVo
 fJz
-wSN
+xwq
 cRJ
-wSN
+xwq
 fNY
 vVo
 aae
@@ -107208,11 +107226,11 @@ vVo
 vVo
 vVo
 yhr
-mzI
-mRw
+rpJ
+cBG
 vVo
 ofH
-qtb
+awY
 wMb
 vVo
 iBU
@@ -107225,11 +107243,11 @@ kzT
 ahg
 aaX
 aKF
-xzh
-xzh
+tyU
+tyU
 wNV
-wSN
-xzh
+xwq
+tyU
 vVo
 aae
 aae
@@ -107461,16 +107479,16 @@ adD
 xco
 xco
 aaH
-vKX
-rbl
+drI
+jgG
 cOR
 blL
-trS
-wze
+liL
+tey
 gBg
 aaH
-ffN
-ylF
+iln
+vhS
 vVo
 vVo
 vVo
@@ -107483,9 +107501,9 @@ hUq
 ojo
 vVo
 qxI
-wSN
-qeK
-wSN
+xwq
+mPL
+xwq
 hkk
 vVo
 aae
@@ -107710,7 +107728,7 @@ aae
 aae
 vVo
 kNC
-wNM
+oNI
 afg
 afa
 vVo
@@ -107718,16 +107736,16 @@ adt
 fEv
 aVj
 aHV
+pXk
 iCI
-pvo
 dRL
 rWe
-bfQ
-rbl
+krJ
+jgG
 gBg
-dIm
+sZR
 ajs
-trS
+liL
 aXz
 xcF
 sWu
@@ -107740,9 +107758,9 @@ kJj
 pec
 vVo
 iGE
-wSN
-wSN
-wSN
+xwq
+xwq
+xwq
 rdV
 vVo
 aaa
@@ -107968,27 +107986,27 @@ aae
 vVo
 aBA
 aaN
-bEZ
+mFy
 aWw
 vVo
 fEv
 fEv
 fEv
 aaH
-oJo
+fPS
 trb
 cOR
 bZg
 acF
-rbl
+jgG
 gBg
-xNI
-ffN
-trS
-qfp
-ffN
-trS
-bfQ
+qFI
+iln
+liL
+uAL
+iln
+liL
+krJ
 vVo
 hSI
 lFy
@@ -107996,11 +108014,11 @@ bLP
 acZ
 hSI
 vVo
-pmD
-wSN
+ulY
+xwq
 nSC
-xzh
-wSN
+tyU
+xwq
 vVo
 aae
 aaa
@@ -108224,8 +108242,8 @@ aae
 aae
 vVo
 agq
-rcw
-bEZ
+bpp
+mFy
 afa
 vVo
 vVo
@@ -108239,13 +108257,13 @@ vVo
 vVo
 vVo
 vVo
-sgh
-ffN
-ffN
-trS
-vKX
-bfQ
-ffN
+aeO
+iln
+iln
+liL
+drI
+krJ
+iln
 vVo
 dNH
 mwp
@@ -108254,9 +108272,9 @@ mwp
 uzS
 vVo
 hkk
-xzh
+tyU
 dlI
-wSN
+xwq
 nSC
 vVo
 aae
@@ -108486,20 +108504,20 @@ aAM
 vVo
 vVo
 lKe
-bEZ
-rcw
+mFy
+bpp
 lKe
 lKe
 jFL
-wJe
-bEZ
+heK
+mFy
 lKe
 lKe
 vVo
 bjv
-trS
+liL
 jRV
-ffN
+iln
 amr
 bmd
 wMb
@@ -108512,8 +108530,8 @@ ebg
 vVo
 pro
 irW
-pmD
-wSN
+ulY
+xwq
 wNV
 vVo
 aae
@@ -108739,24 +108757,24 @@ vVo
 kUV
 aXM
 wbw
-bEZ
-ffM
+mFy
+vKX
 vVo
 aaV
-twO
-bEZ
-bEZ
-mPL
-bEZ
-bEZ
-bEZ
-bEZ
+uqJ
+mFy
+mFy
+dZF
+mFy
+mFy
+mFy
+mFy
 aXD
 vVo
-kET
+xEl
 aoh
 aoh
-kET
+xEl
 bjp
 aUe
 vVo
@@ -108996,26 +109014,26 @@ vVo
 aXH
 hef
 bjc
-twO
-lMB
+uqJ
+rUR
 vVo
-fBA
-bEZ
-bEZ
-bEZ
-rcw
-rcw
-bEZ
-bQR
-twO
-fBA
+iYa
+mFy
+mFy
+mFy
+bpp
+bpp
+mFy
+lVo
+uqJ
+iYa
 vVo
-xzh
+tyU
 irW
 wno
 bkG
-wSN
-wSN
+xwq
+xwq
 vVo
 bGU
 aXt
@@ -109251,10 +109269,10 @@ aae
 aae
 vVo
 fSy
-rcw
-bEZ
-rcw
-bEZ
+bpp
+mFy
+bpp
+mFy
 vVo
 axf
 axf
@@ -109271,7 +109289,7 @@ aKF
 vVo
 eon
 bcv
-wSN
+xwq
 qBw
 vVo
 eIN
@@ -109508,27 +109526,27 @@ aae
 aae
 vVo
 tIE
-vHw
+kET
 aWG
-uLZ
-bEZ
+sBX
+mFy
 vVo
 jjp
 wEs
-bEZ
-twO
-xQT
-vVu
-vVo
-rUR
-rIJ
 mFy
+uqJ
+xQT
+ePw
+vVo
+mIw
+rcw
+wSN
 xJU
 cdl
 vVo
 eon
 bcv
-xzh
+tyU
 vGp
 vVo
 eIN
@@ -109767,21 +109785,21 @@ vVo
 kUV
 aXM
 wbw
-bEZ
-rcw
+mFy
+bpp
 tMi
 gGQ
 agB
-kSw
-rcw
+gef
+bpp
 bkF
 bkF
 aAM
-pKv
-mFy
-mFy
-mFy
-mFy
+twO
+wSN
+wSN
+wSN
+wSN
 vVo
 vVo
 vVo
@@ -109806,7 +109824,7 @@ eXO
 vVo
 jPo
 mTc
-uiv
+eBu
 avS
 uGX
 bPL
@@ -110036,13 +110054,13 @@ aby
 aby
 aby
 aPC
-mFy
+wSN
 ykQ
-mFy
+wSN
 vVo
-mFy
+wSN
 kjm
-mFy
+wSN
 jPC
 vVo
 eIN
@@ -110061,8 +110079,8 @@ avS
 bPL
 vRh
 vVo
-uiv
-uiv
+eBu
+eBu
 vVo
 lUy
 bPL
@@ -110282,24 +110300,24 @@ aby
 rDt
 aXI
 aXI
-utO
+bOE
 msN
 aXT
-vpk
-jRn
-vpk
+ese
+dma
+ese
 laF
 afR
 fHL
 aby
 aEq
-mFy
-mFy
-mFy
+wSN
+wSN
+wSN
 gzj
-ofE
-rIJ
-rIJ
+uAs
+rcw
+rcw
 aLI
 vVo
 eIN
@@ -110541,22 +110559,22 @@ aWP
 ePK
 aLM
 kjS
-kJa
-cjM
-cjM
+yfo
+pZn
+pZn
 jTh
-ese
-nJm
+dBY
+eYK
 aXT
 aby
 tLD
-mFy
-mFy
+wSN
+wSN
 skP
 vVo
 mfo
 azJ
-rIJ
+rcw
 aLI
 vVo
 eIN
@@ -110576,9 +110594,9 @@ vUN
 vUN
 vUN
 nlp
-uBL
+nyT
 uRZ
-tgB
+wzy
 vUN
 vUN
 eeT
@@ -110795,7 +110813,7 @@ aby
 aby
 adG
 lwr
-cjM
+pZn
 aeP
 aeP
 aeP
@@ -110804,7 +110822,7 @@ aeP
 aeP
 aeP
 jQx
-vpk
+ese
 adG
 vVo
 aKF
@@ -110833,9 +110851,9 @@ dKo
 dKo
 dKo
 dKo
-qtW
+kku
 feX
-oko
+eRE
 dKo
 dKo
 gpP
@@ -111061,16 +111079,16 @@ aeP
 aeP
 aeP
 lts
-vpk
+ese
 agR
-mFy
-mFy
-mFy
-mFy
+wSN
+wSN
+wSN
+wSN
 asN
-mFy
-mFy
-mFy
+wSN
+wSN
+wSN
 vVo
 auF
 vJP
@@ -111090,9 +111108,9 @@ dKo
 dKo
 dKo
 dKo
-qtW
+kku
 feX
-oko
+eRE
 dKo
 dKo
 owX
@@ -111318,16 +111336,16 @@ aeP
 aeP
 aeP
 oFJ
-vpk
+ese
 agR
 tEm
-dzC
-enO
+iGO
+qtQ
 mNo
 bkW
-mFy
-lVo
-mFy
+wSN
+dyw
+wSN
 aKF
 uEz
 uEz
@@ -111347,9 +111365,9 @@ wsm
 ciV
 dKo
 dKo
-qtW
+kku
 feX
-oko
+eRE
 dKo
 dKo
 ukW
@@ -111565,7 +111583,7 @@ aby
 adm
 cVW
 aik
-vpk
+ese
 nvc
 aeP
 aeP
@@ -111575,16 +111593,16 @@ aeP
 aeP
 aeP
 oFJ
-vpk
+ese
 agR
 xBl
-dzC
-enO
-dzC
+iGO
+qtQ
+iGO
 bkW
 iBp
-vhJ
-rIJ
+dYI
+rcw
 vVo
 nOd
 swF
@@ -111604,9 +111622,9 @@ jDC
 veD
 iJK
 iJK
-fOC
+gdU
 vXY
-jKB
+pMs
 iJK
 iJK
 jDC
@@ -111832,16 +111850,16 @@ aeP
 aeP
 aeP
 oFJ
-utO
+bOE
 agR
 bxG
-dzC
-dzC
-dzC
+iGO
+iGO
+iGO
 bkW
-rUR
-ulY
-mFy
+mIw
+gLN
+wSN
 aKF
 xYE
 bQv
@@ -112079,7 +112097,7 @@ aby
 cUS
 abx
 aik
-vpk
+ese
 nvc
 aeP
 aeP
@@ -112091,12 +112109,12 @@ aeP
 oFJ
 aXT
 agR
-mFy
-mFy
+wSN
+wSN
 usw
-mFy
+wSN
 asN
-osj
+rLF
 bja
 ykP
 vVo
@@ -112336,8 +112354,8 @@ aby
 aby
 aby
 adG
-vpk
 ese
+dBY
 aeP
 aeP
 aeP
@@ -112346,7 +112364,7 @@ aeP
 aeP
 aeP
 aLW
-vpk
+ese
 adG
 vVo
 aKF
@@ -112597,22 +112615,22 @@ afH
 eMj
 afk
 tpH
-ese
-ese
-ese
+dBY
+dBY
+dBY
 crl
-ese
-vMV
+dBY
+mia
 usn
 aby
-mFy
-pKv
+wSN
+twO
 vVo
-rIJ
-awY
+rcw
+kTD
 skP
 bmM
-mFy
+wSN
 aei
 vVo
 eIN
@@ -112630,9 +112648,9 @@ eLd
 cvN
 avS
 vVo
-bEZ
-bEZ
-rkf
+mFy
+mFy
+gMc
 vVo
 uGX
 avS
@@ -112854,22 +112872,22 @@ aXI
 aXI
 bKK
 vLf
-ncX
+hkO
 aXT
-pZn
-vpk
+vNV
+ese
 aXT
 afe
 vjB
 aby
-mFy
-rUR
+wSN
+mIw
 vVo
-rIJ
-mFy
-mFy
-mFy
-nCK
+rcw
+wSN
+wSN
+wSN
+xNI
 geU
 vVo
 eIN
@@ -112889,7 +112907,7 @@ avS
 vVo
 hAB
 ams
-bEZ
+mFy
 vVo
 aae
 aae
@@ -113119,14 +113137,14 @@ aby
 aby
 aby
 aby
-mFy
-rIJ
+wSN
+rcw
 vVo
 wiV
-mFy
+wSN
 ykQ
-mFy
-mFy
+wSN
+wSN
 abM
 vVo
 eIN
@@ -113365,26 +113383,26 @@ vVo
 kUV
 aXM
 wbw
-bEZ
-twO
+mFy
+uqJ
 aAM
 nRR
 aWf
-wHZ
-bEZ
+gMz
+mFy
 nRR
 nRR
 aAM
-mFy
-lVo
-mFy
+wSN
+dyw
+wSN
 vVo
-awY
-mFy
-mFy
-rIJ
-mFy
-mFy
+kTD
+wSN
+wSN
+rcw
+wSN
+wSN
 vVo
 eIN
 aXt
@@ -113401,10 +113419,10 @@ sfu
 cvN
 vVo
 poA
-rcw
+bpp
 gGk
 uUO
-hTO
+oio
 vVo
 aae
 aae
@@ -113622,25 +113640,25 @@ vVo
 awq
 hDW
 jif
-bEZ
-rcw
+mFy
+bpp
 vVo
 wEs
 jjp
-bEZ
-rcw
+mFy
+bpp
 hPG
 aHx
 vVo
-pKv
-mFy
-mFy
+twO
+wSN
+wSN
 aKF
-pKv
-mFy
+twO
+wSN
 awi
-rIJ
-lVo
+rcw
+dyw
 geU
 vVo
 eIN
@@ -113657,11 +113675,11 @@ dKo
 kFB
 bsm
 vVo
-rcw
-mkQ
-bEZ
-rcw
-rkf
+bpp
+aVi
+mFy
+bpp
+gMc
 vVo
 aae
 aae
@@ -113878,9 +113896,9 @@ aae
 vVo
 aof
 acU
-rcw
-lMB
-bEZ
+bpp
+rUR
+mFy
 vVo
 axf
 axf
@@ -113894,10 +113912,10 @@ axf
 axf
 vVo
 cEF
-mFy
+wSN
 bkU
-mFy
-rIJ
+wSN
+rcw
 abM
 vVo
 eIN
@@ -113914,10 +113932,10 @@ dKo
 kFB
 ivh
 aAM
-rcw
+bpp
 kxT
-bQR
-bEZ
+lVo
+mFy
 aFV
 vVo
 aae
@@ -114134,27 +114152,27 @@ abO
 aae
 vVo
 aXJ
-vHw
+kET
 aWG
-bEZ
-bEZ
+mFy
+mFy
 vVo
-fBA
-bEZ
-rdq
-rcw
-bEZ
-bEZ
-rcw
-rcw
-rcw
-ffM
+iYa
+mFy
+mOV
+bpp
+mFy
+mFy
+bpp
+bpp
+bpp
+vKX
 aAM
-mFy
-lVo
-rIJ
+wSN
+dyw
+rcw
 aFE
-mFy
+wSN
 geU
 vVo
 eIN
@@ -114171,11 +114189,11 @@ dKo
 nHR
 doD
 vVo
-fBA
-lMB
-bEZ
+iYa
+rUR
+mFy
 dEU
-exE
+jTz
 vVo
 aae
 aae
@@ -114393,23 +114411,23 @@ vVo
 kUV
 aXM
 wbw
-rcw
-fBA
+bpp
+iYa
 vVo
 agG
 kxT
-rcw
-bEZ
-bEZ
+bpp
+mFy
+mFy
 kxT
-rcw
-rcw
-twO
+bpp
+bpp
+uqJ
 fbg
 vVo
 ksW
-mFy
-mFy
+wSN
+wSN
 vVo
 vVo
 vVo
@@ -114429,8 +114447,8 @@ eLd
 cvN
 vVo
 wEx
-ffM
-bEZ
+vKX
+mFy
 imm
 ncO
 vVo
@@ -114654,21 +114672,21 @@ vVo
 aAM
 vVo
 lKe
-bEZ
-wNM
+mFy
+oNI
 lKe
 lKe
 lKe
-fBA
-bEZ
+iYa
+mFy
 lKe
 lKe
 vVo
-aeO
-mFy
-mFy
+fhP
+wSN
+wSN
 aKF
-jEf
+oTC
 bkD
 vCW
 vVo
@@ -114906,9 +114924,9 @@ aae
 aae
 aae
 vVo
-wJe
+heK
 bjh
-bEZ
+mFy
 vVo
 vVo
 axf
@@ -114922,12 +114940,12 @@ vVo
 vVo
 vVo
 aTU
-htq
-mFy
+uLZ
+wSN
 vVo
-tJS
+swY
 aWF
-kQb
+rew
 vVo
 nbT
 nbT
@@ -114943,12 +114961,12 @@ nbT
 hSq
 aae
 vVo
-mkQ
-bEZ
+aVi
+mFy
 vVo
 fzT
 bix
-mFy
+wSN
 bkZ
 mfo
 hdd
@@ -115164,23 +115182,23 @@ aae
 aae
 vVo
 wYd
-rcw
-rdq
-bEZ
+bpp
+mOV
+mFy
 adQ
 kbV
 adv
 adh
 kxT
 aAM
-bEZ
-bEZ
-bEZ
-fBA
+mFy
+mFy
+mFy
+iYa
 vVo
 awD
-mFy
-mFy
+wSN
+wSN
 vVo
 bjt
 vVo
@@ -115191,7 +115209,7 @@ aae
 vVo
 vVo
 vVo
-mOg
+vtq
 vVo
 vVo
 vVo
@@ -115201,14 +115219,14 @@ aae
 aae
 vVo
 reI
-fBA
+iYa
 vVo
 fGb
-aVi
-mFy
-gSN
+sEY
+wSN
+oqd
 oOh
-rIJ
+rcw
 vVo
 aae
 aaa
@@ -115430,14 +115448,14 @@ axs
 axs
 adh
 vVo
-wNM
+oNI
 anp
 lKe
-rcw
+bpp
 vVo
 adw
-nCK
-pKv
+xNI
+twO
 vVo
 lIO
 vVo
@@ -115447,9 +115465,9 @@ aae
 aae
 vVo
 peq
-mFy
-nCK
-jAk
+wSN
+xNI
+aCt
 aIh
 vVo
 aae
@@ -115458,14 +115476,14 @@ aae
 vVo
 vVo
 gGk
-rcw
+bpp
 vVo
 aVD
-mFy
+wSN
 aeJ
 phY
 rcv
-mFy
+wSN
 vVo
 aae
 aaa
@@ -115687,9 +115705,9 @@ adv
 oJI
 kbV
 vVo
-bEZ
-rcw
-twO
+mFy
+bpp
+uqJ
 lxJ
 vVo
 abH
@@ -115704,8 +115722,8 @@ aae
 aae
 vVo
 nKG
-mFy
-mFy
+wSN
+wSN
 ayt
 bmL
 vVo
@@ -115714,15 +115732,15 @@ aae
 aae
 vVo
 afa
-bEZ
+mFy
 aXD
 vVo
-uTV
-mFy
-mFy
+rkf
+wSN
+wSN
 usw
-ulY
-nCK
+gLN
+xNI
 vVo
 aae
 aaa
@@ -115960,10 +115978,10 @@ aae
 aae
 aae
 vVo
-ofE
-mFy
-rIJ
-mFy
+uAs
+wSN
+rcw
+wSN
 hYK
 vVo
 aae
@@ -115971,12 +115989,12 @@ aae
 aae
 vVo
 aWw
-bEZ
-bEZ
+mFy
+mFy
 vVo
 vVo
 vVo
-mOg
+vtq
 vVo
 vVo
 axU
@@ -116217,26 +116235,26 @@ aae
 vVo
 vVo
 vVo
-mFy
-mFy
-nCK
-mFy
-mFy
+wSN
+wSN
+xNI
+wSN
+wSN
 vVo
 aae
 aae
 aae
 vVo
 afa
-fBA
-rcw
-bEZ
-bAe
-rcw
-rcw
-mkQ
-vVo
+iYa
+bpp
 mFy
+bAe
+bpp
+bpp
+aVi
+vVo
+wSN
 vVo
 aae
 aae
@@ -116474,24 +116492,24 @@ aae
 vVo
 aXM
 jkj
-mFy
-rIJ
-mFy
-rIJ
-pKv
-vVo
-aae
-aae
-aae
-vVo
-vVo
+wSN
+rcw
+wSN
+rcw
 twO
-bEZ
+vVo
+aae
+aae
+aae
+vVo
+vVo
+uqJ
+mFy
 gGk
 biX
 tTk
 bmx
-fBA
+iYa
 vVo
 afQ
 vVo
@@ -116730,12 +116748,12 @@ aae
 aae
 vVo
 aWu
-heK
-mFy
-mFy
+fpj
+wSN
+wSN
 kUV
 kUV
-mFy
+wSN
 vVo
 aae
 vVo
@@ -116743,7 +116761,7 @@ vVo
 vVo
 vVo
 vVo
-mOg
+vtq
 vVo
 vVo
 vVo
@@ -116986,25 +117004,25 @@ aae
 aae
 aae
 vVo
-rIJ
-mFy
-mFy
-nCK
-mFy
-mFy
-ofE
+rcw
+wSN
+wSN
+xNI
+wSN
+wSN
+uAs
 vVo
 aae
 vVo
 afh
-okb
-mFy
-mFy
-rIJ
-uTV
+exE
+wSN
+wSN
+rcw
+rkf
 vVo
 awO
-twO
+uqJ
 kaZ
 acy
 ahd
@@ -117244,26 +117262,26 @@ aae
 aae
 vVo
 edw
-nCK
-mFy
-mFy
-mFy
-mFy
+xNI
+wSN
+wSN
+wSN
+wSN
 kea
 vVo
 aae
 vVo
-mFy
-mFy
-mFy
-mFy
+wSN
+wSN
+wSN
+wSN
 xgE
 iIo
 vVo
 agW
-bEZ
-bEZ
-bEZ
+mFy
+mFy
+mFy
 gLn
 vVo
 aae
@@ -117503,7 +117521,7 @@ vVo
 vVo
 uMW
 wjw
-nCK
+xNI
 pRs
 pWD
 kKy
@@ -117511,9 +117529,9 @@ vVo
 aae
 vVo
 ybo
-wOC
-mFy
-mFy
+gdD
+wSN
+wSN
 iIo
 mMt
 vVo
@@ -117768,10 +117786,10 @@ vVo
 aae
 vVo
 qdr
-rIJ
-rIJ
-mFy
-osj
+rcw
+rcw
+wSN
+rLF
 pmh
 vVo
 vVo
@@ -118027,7 +118045,7 @@ aae
 lVN
 qaP
 nRf
-aVi
+sEY
 kBP
 hRI
 vVo

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1413,8 +1413,9 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "aeP" = (
@@ -6054,7 +6055,9 @@
 /area/f13/building)
 "asN" = (
 /obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/store,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
 /area/f13/building/massfusion)
 "asP" = (
 /obj/structure/closet/cabinet,
@@ -12095,8 +12098,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "aKF" = (
+/obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/building/massfusion)
 "aKH" = (
@@ -15685,7 +15689,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "aVj" = (
@@ -16517,7 +16521,7 @@
 "aXD" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "aXE" = (
@@ -16607,6 +16611,7 @@
 /area/f13/building/bighornbunker)
 "aXT" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
@@ -20256,7 +20261,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "bjb" = (
@@ -21028,7 +21033,7 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "bkX" = (
@@ -24037,7 +24042,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "bxH" = (
@@ -24629,12 +24634,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood_common,
 /area/f13/ncr)
-"bAz" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "bAA" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/desert{
@@ -25501,6 +25500,12 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland/bighorn)
+"bUU" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "bUV" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25955,6 +25960,12 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"bZw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "bZL" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
@@ -26345,6 +26356,15 @@
 	icon_state = "verticalrightborderright2bottom"
 	},
 /area/f13/wasteland/bighorn)
+"cdP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "cdQ" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
@@ -26423,12 +26443,6 @@
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel/khanfort)
-"cfb" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "cfd" = (
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_y = 15
@@ -28368,11 +28382,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
-"cyE" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "cyJ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
@@ -28413,13 +28422,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
-"cAr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "cAM" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
@@ -28533,6 +28535,12 @@
 	icon_state = "verticalleftborderright2top"
 	},
 /area/f13/wasteland/west)
+"cFE" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "cGc" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt{
@@ -28626,12 +28634,6 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
 /area/f13/wasteland/ncr)
-"cJf" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "cJm" = (
 /obj/item/stock_parts/scanning_module/triphasic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29022,6 +29024,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/mall)
+"cXH" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "cYd" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29029,6 +29039,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"cYO" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "cZg" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -29231,6 +29246,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"dfL" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "dfM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -29508,12 +29528,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/village)
-"dps" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "dpD" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -29764,6 +29778,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"dxr" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "dxs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/attachments,
@@ -29854,6 +29874,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/quarry)
+"dBj" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "dBk" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2";
@@ -29952,15 +29980,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"dEY" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "dEZ" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -29976,12 +29995,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
-"dFn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
-	},
-/area/f13/building/massfusion)
 "dFy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/camera_assembly,
@@ -30639,12 +30652,6 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland/massfusion)
-"eeR" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "eeT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -30706,6 +30713,12 @@
 /obj/item/melee/onehanded/machete/training,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"ehb" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "ehL" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
@@ -30966,7 +30979,7 @@
 /area/f13/wasteland/bighorn)
 "ese" = (
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
 "esi" = (
@@ -31064,18 +31077,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/east)
-"euS" = (
-/obj/structure/closet/abductor{
-	desc = "A secure metal pod for storing protectrons.";
-	name = "protectron pod"
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "evl" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert{
@@ -31177,7 +31178,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "exF" = (
@@ -31427,13 +31428,6 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
-"eHY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "eHZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -31464,14 +31458,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/massfusion)
-"eJc" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/building/massfusion)
 "eKc" = (
 /obj/item/mop,
 /turf/open/floor/f13{
@@ -31707,6 +31693,12 @@
 "eRk" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/west)
+"eRx" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "eRz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -31939,12 +31931,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eYq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "eYv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -32015,15 +32001,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
-"faV" = (
-/obj/effect/spawner/lootdrop/low_tools,
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "fbb" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -32317,6 +32294,12 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland/massfusion)
+"fkR" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "fkV" = (
 /obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32395,6 +32378,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
+"fog" = (
+/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "foi" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -32448,6 +32437,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"fqA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "fqM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -33154,6 +33149,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/ncr)
+"fLX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "fMc" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33504,13 +33506,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/museum)
-"fYM" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "fYR" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
@@ -33599,13 +33594,6 @@
 /obj/item/clothing/under/f13/legslave,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"gdF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "gdO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel/khanfort)
@@ -33716,6 +33704,13 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/heaven)
+"gim" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "giX" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33769,6 +33764,12 @@
 	icon_state = "hole"
 	},
 /area/f13/wasteland/firestation)
+"gky" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "gkA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33919,12 +33920,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/east)
-"gqd" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "gqm" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
@@ -34045,6 +34040,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"gtZ" = (
+/mob/living/simple_animal/hostile/raider/junker/creator,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/massfusion)
 "guj" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34368,12 +34369,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"gGc" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "gGg" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/hospital)
@@ -34387,6 +34382,12 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
+"gGl" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "gGn" = (
@@ -34442,15 +34443,6 @@
 /obj/item/stack/f13Cash/random/med,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"gHR" = (
-/obj/structure/rack/shelf_metal{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "gIc" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -34949,6 +34941,12 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/building/massfusion)
+"gZa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustysolid"
+	},
+/area/f13/building/massfusion)
 "gZb" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -34998,11 +34996,6 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland/hospital)
-"ham" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustysolid"
-	},
-/area/f13/building/massfusion)
 "haK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -35139,7 +35132,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "heQ" = (
@@ -35306,6 +35299,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"hnB" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "hnO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
@@ -35520,6 +35519,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/heaven)
+"hyS" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "hyV" = (
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt{
@@ -35602,11 +35607,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building)
-"hAr" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "hAB" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/item/reagent_containers/glass/bucket,
@@ -35628,11 +35628,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"hBg" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "hBi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
@@ -35808,13 +35803,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
-"hIR" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "hIS" = (
 /obj/structure/fence{
 	dir = 4
@@ -35957,14 +35945,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighornbunker)
-"hOY" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/massfusion)
 "hPh" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/wolf{
@@ -36145,15 +36125,6 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
-"hUz" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "hUJ" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -36217,13 +36188,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
-"hWb" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "hWr" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -36349,6 +36313,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
 /area/f13/legion)
+"iaT" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
+"ibb" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "ibe" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/heaven)
@@ -36749,6 +36726,14 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland/west)
+"ina" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "inx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowleft"
@@ -36885,6 +36870,12 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
+"ish" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "isj" = (
 /mob/living/simple_animal/hostile/raider/ranged{
 	name = "City Boys Raider"
@@ -37204,7 +37195,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "iBt" = (
@@ -37803,15 +37794,6 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland/hospital)
-"iSQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "iTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -37967,18 +37949,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"iXX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "iYc" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
-"iYM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "iYP" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/road{
@@ -38012,6 +37995,12 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/f13/building)
+"iZc" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "iZd" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38231,6 +38220,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/ncr)
+"jgn" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "jgz" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -38321,6 +38316,13 @@
 	icon_state = "horizontalbottomborderbottomleft"
 	},
 /area/f13/wasteland/east)
+"jjm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "jjp" = (
 /obj/structure/closet,
 /obj/item/geiger_counter,
@@ -38594,6 +38596,15 @@
 "jsB" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland/legion)
+"jsK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "jsX" = (
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
@@ -39154,7 +39165,7 @@
 "jPC" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "jPD" = (
@@ -39367,12 +39378,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"jWy" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "jWC" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -39641,13 +39646,6 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
-"kiV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "kjm" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -39976,6 +39974,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"kuW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "kvl" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -40272,7 +40277,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
+	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
 "kFe" = (
@@ -40635,12 +40640,6 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
-"kRQ" = (
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "kRU" = (
 /obj/structure/toilet{
 	dir = 1
@@ -41195,12 +41194,6 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
-"lkJ" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "lkO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41264,6 +41257,12 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/building/khanfort)
+"lmX" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "lnc" = (
 /obj/effect/landmark/start/f13/vexillarius,
 /turf/open/floor/wood_mosaic,
@@ -41507,12 +41506,6 @@
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
-"lvn" = (
-/mob/living/simple_animal/hostile/raider/ranged/boss/junker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "lvp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -41532,12 +41525,6 @@
 	icon_state = "wide-broken6"
 	},
 /area/f13/building/khanfort)
-"lwi" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "lwl" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -42247,13 +42234,6 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/mall)
-"lRu" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "lRC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -42271,12 +42251,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/mall)
-"lSs" = (
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "lSw" = (
 /obj/item/crafting/large_gear,
 /turf/open/indestructible/ground/outside/road{
@@ -42375,6 +42349,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/mall)
+"lUp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "lUy" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -42540,12 +42520,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/firestation)
-"mbJ" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "mbM" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -42967,6 +42941,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"mos" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "mox" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt{
@@ -42983,11 +42962,6 @@
 	icon_state = "verticalleftborderleft2top"
 	},
 /area/f13/wasteland/hospital)
-"moG" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/radiation)
 "moI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -43328,6 +43302,12 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/wood_worn,
 /area/f13/building/khanfort)
+"mAx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "mAA" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -43469,9 +43449,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mFy" = (
-/obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "mFC" = (
@@ -43738,7 +43717,7 @@
 "mPL" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "mPP" = (
@@ -43755,15 +43734,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
-"mQc" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "mQk" = (
 /obj/machinery/light/sign/heaven{
 	pixel_y = 32
@@ -44108,7 +44078,7 @@
 "ncO" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "ndc" = (
@@ -44225,6 +44195,14 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/bighorn)
+"nhX" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/building/massfusion)
 "niB" = (
 /turf/closed/wall/f13/store,
 /area/f13/tunnel)
@@ -44799,13 +44777,6 @@
 /obj/structure/decoration/rag,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nzg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "nzi" = (
 /obj/structure/rack,
 /obj/item/cane,
@@ -45048,12 +45019,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"nHo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "nHC" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -45502,12 +45467,6 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/bighorn)
-"nXb" = (
-/obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "nXr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
@@ -45673,12 +45632,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland/hospital)
-"odQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/massfusion)
 "odX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
@@ -45741,12 +45694,6 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/firestation)
-"ofb" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/massfusion)
 "ofk" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -46287,12 +46234,25 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/firestation)
+"oyc" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "oym" = (
 /obj/structure/rack,
 /obj/item/clothing/under/suit/charcoal,
 /obj/item/clothing/under/suit/navy,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"oys" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "oyB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
@@ -46892,15 +46852,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oRF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "oRI" = (
 /obj/structure/fence{
 	dir = 8
@@ -46924,6 +46875,13 @@
 	smooth = 1
 	},
 /area/f13/building/museum)
+"oTB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "oTE" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
@@ -46997,14 +46955,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"oWE" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/building/massfusion)
 "oXp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -47305,13 +47255,6 @@
 "pgy" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/east)
-"pgJ" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building/massfusion)
 "pgO" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -47456,11 +47399,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/mall)
-"png" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "pnF" = (
 /obj/effect/decal/fakelattice{
 	pixel_x = 17
@@ -47617,6 +47555,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/legion)
+"psO" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/building/massfusion)
 "ptf" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil{
@@ -47733,14 +47678,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/ncr)
-"pxa" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building/massfusion)
 "pxv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermainleft"
@@ -47770,6 +47707,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/hospital)
+"pyp" = (
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "pyq" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -48011,6 +47954,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/legion)
+"pDw" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "pDM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48510,8 +48460,11 @@
 /area/f13/wasteland/ncr)
 "pZn" = (
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
 "pZM" = (
@@ -48567,6 +48520,15 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland/east)
+"qbi" = (
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "qbz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48593,6 +48555,12 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland/west)
+"qcN" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "qcV" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -48724,6 +48692,12 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building/nanotrasen)
+"qhe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "qhr" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -48774,12 +48748,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/east)
-"qiA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "qiH" = (
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -48803,16 +48771,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
-"qjB" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "qjV" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -49424,13 +49382,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland/bighorn)
-"qDS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "qDT" = (
 /mob/living/simple_animal/opossum,
 /turf/open/water,
@@ -49827,13 +49778,6 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/legion)
-"qSe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "qSh" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -50149,7 +50093,7 @@
 "rcw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "rcz" = (
@@ -50167,12 +50111,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
-"rdl" = (
-/obj/item/chair,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "rdm" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -50768,12 +50706,6 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/city/bighorn)
-"ryk" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "ryw" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/regular,
@@ -51024,6 +50956,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"rIJ" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "rIT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -51098,12 +51036,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"rKG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "rKZ" = (
 /obj/structure/displaycase,
 /obj/item/clothing/head/helmet/knight/f13/metal,
@@ -51490,13 +51422,6 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
-"rWn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "rWq" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
@@ -51671,6 +51596,14 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sfr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "sfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -51883,12 +51816,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland/mall)
-"slE" = (
-/mob/living/simple_animal/hostile/molerat,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "slG" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -52106,6 +52033,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"sri" = (
+/obj/structure/rack/shelf_metal{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "srm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -52155,13 +52091,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/museum)
-"sua" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "sub" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -52282,6 +52211,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"sAi" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "sAm" = (
 /obj/structure/chair/comfy{
 	color = "#ad0a0a";
@@ -52389,6 +52326,13 @@
 	icon_state = "verticalleftborderleftbottom"
 	},
 /area/f13/wasteland/ncr)
+"sDk" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "sDn" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -52428,12 +52372,6 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/wasteland/west)
-"sEF" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "sFb" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -52468,14 +52406,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/firestation)
-"sGa" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/massfusion)
 "sGd" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert,
@@ -52873,6 +52803,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"sWo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "sWu" = (
 /obj/effect/spawner/lootdrop/tool_box,
 /obj/structure/rack/shelf_metal{
@@ -53206,12 +53143,6 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/massfusion)
-"thO" = (
-/mob/living/simple_animal/hostile/raider/junker/creator,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "thW" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -53947,7 +53878,7 @@
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/engineer,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "tEq" = (
@@ -54090,12 +54021,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/heaven)
-"tJE" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "tJO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
@@ -54989,14 +54914,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
-"uma" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "yellowrustychess"
 	},
 /area/f13/building/massfusion)
 "umx" = (
@@ -55066,15 +54984,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
-"unM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "unR" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -11
@@ -55257,7 +55166,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "usI" = (
@@ -55850,7 +55759,7 @@
 "uLZ" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "uMa" = (
@@ -56013,6 +55922,14 @@
 /obj/item/reagent_containers/glass/rag/towel,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"uSC" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "uSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/target/communist,
@@ -56179,15 +56096,6 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
-"uWt" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "uWw" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainleft"
@@ -56274,12 +56182,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
-"uZy" = (
-/obj/structure/closet,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "uZR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -56398,6 +56300,11 @@
 "vdB" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland/hospital)
+"vdD" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/massfusion)
 "vdF" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 1
@@ -56610,6 +56517,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/west)
+"vlV" = (
+/obj/structure/closet/abductor{
+	desc = "A secure metal pod for storing protectrons.";
+	name = "protectron pod"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "vmf" = (
 /mob/living/simple_animal/chicken,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -56639,6 +56557,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
+"vmP" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "vnb" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -57055,6 +56982,12 @@
 /obj/item/clothing/under/f13/picnicdress50s,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"vBh" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "vBH" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/road{
@@ -57146,6 +57079,12 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/wasteland/nanotrasen)
+"vGX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "vHB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -57250,7 +57189,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
+	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
 "vLf" = (
@@ -57302,14 +57241,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
-"vNC" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "vNI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -57548,14 +57479,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
-"vUX" = (
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/massfusion)
 "vVc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -57686,6 +57609,13 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/mall)
+"waG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "waH" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -57727,13 +57657,6 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
-	},
-/area/f13/building/massfusion)
-"wbz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "wcN" = (
@@ -58062,6 +57985,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
+"wnM" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "wnV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -58195,6 +58124,15 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland/nanotrasen)
+"wuB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/building/massfusion)
 "wvj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -58248,13 +58186,6 @@
 /obj/item/seeds/mutfruit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wwy" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building/massfusion)
 "wwY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -58306,12 +58237,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
-"wzj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "wzk" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
@@ -58405,15 +58330,6 @@
 	},
 /turf/open/floor/wood_worn/wood_worn_dark,
 /area/f13/wasteland/legion)
-"wBZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/building/massfusion)
 "wCs" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4
@@ -58481,6 +58397,15 @@
 "wDk" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/bighornbunker)
+"wDr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "wDA" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -58507,6 +58432,16 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/mall)
+"wEa" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "wEd" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
@@ -58668,6 +58603,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/building/museum)
+"wKa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustysolid"
+	},
+/area/f13/building/massfusion)
 "wKb" = (
 /obj/structure/shuttle/engine/router,
 /obj/structure/lattice/catwalk,
@@ -58711,14 +58655,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wLT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "greenrustychess"
-	},
-/area/f13/building/massfusion)
 "wLX" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
@@ -58881,15 +58817,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
-"wPF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/radiation)
 "wPM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -59529,6 +59456,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
 /turf/open/floor/f13,
 /area/f13/building)
+"xpz" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "xpV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -59855,7 +59787,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "xBq" = (
@@ -60062,6 +59994,13 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/bighornbunker)
+"xHe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "xHh" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -60087,6 +60026,14 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/ncr)
+"xIa" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building/massfusion)
 "xJf" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard,
 /turf/closed/wall/f13/tunnel,
@@ -60246,8 +60193,11 @@
 /area/f13/wasteland/bighorn)
 "xNI" = (
 /obj/effect/spawner/lootdrop/trash,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
+	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
 "xNL" = (
@@ -60752,6 +60702,12 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/bighornbunker)
+"yfg" = (
+/mob/living/simple_animal/hostile/molerat,
+/turf/open/floor/plasteel/f13{
+	icon_state = "greenrustychess"
+	},
+/area/f13/building/massfusion)
 "yfR" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/sunset/brick_small_dark,
@@ -60922,7 +60878,7 @@
 	},
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
 "ykQ" = (
@@ -105726,7 +105682,7 @@ vVo
 dll
 aCt
 vIs
-png
+mos
 vVo
 aae
 aae
@@ -105980,10 +105936,10 @@ ahg
 ahg
 kzT
 jAn
-rKG
+vGX
 mua
-rKG
-gGc
+vGX
+jgn
 vVo
 aae
 aae
@@ -106237,10 +106193,10 @@ ahg
 kzT
 kzT
 jAn
-png
-rKG
+mos
+vGX
 fNp
-rKG
+vGX
 vVo
 aae
 aae
@@ -106494,10 +106450,10 @@ ahg
 kzT
 kzT
 jAn
-png
-gGc
-rKG
-png
+mos
+jgn
+vGX
+mos
 vVo
 vVo
 aae
@@ -106733,9 +106689,9 @@ aae
 aae
 oBz
 oBz
-iSQ
-oWE
-eJc
+wuB
+sAi
+nhX
 qzL
 wjW
 tbY
@@ -106752,9 +106708,9 @@ iKB
 acd
 vVo
 uvP
-cyE
-iYM
-iYM
+dfL
+fqA
+fqA
 hkk
 vVo
 aae
@@ -107009,9 +106965,9 @@ wkF
 aaX
 vVo
 fJz
-cyE
+dfL
 cRJ
-cyE
+dfL
 fNY
 vVo
 aae
@@ -107248,8 +107204,8 @@ vVo
 vVo
 vVo
 yhr
-mQc
-wBZ
+vmP
+wKa
 vVo
 ofH
 awY
@@ -107264,12 +107220,12 @@ ktc
 kzT
 ahg
 aaX
-mFy
-iYM
-iYM
+aKF
+fqA
+fqA
 wNV
-cyE
-iYM
+dfL
+fqA
 vVo
 aae
 aae
@@ -107501,16 +107457,16 @@ adD
 xco
 xco
 aaH
-sua
-wbz
+oTB
+sWo
 cOR
 blL
-rKG
-lkJ
+vGX
+ibb
 gBg
 aaH
-png
-wzj
+mos
+aXD
 vVo
 vVo
 vVo
@@ -107523,9 +107479,9 @@ hUq
 ojo
 vVo
 qxI
-cyE
-mPL
-cyE
+dfL
+gtZ
+dfL
 hkk
 vVo
 aae
@@ -107759,15 +107715,15 @@ fEv
 aVj
 aHV
 iCI
-hIR
+iaT
 dRL
 rWe
-qDS
-wbz
+waG
+sWo
 gBg
-unM
+jsK
 ajs
-rKG
+vGX
 aXz
 xcF
 sWu
@@ -107780,9 +107736,9 @@ kJj
 pec
 vVo
 iGE
-cyE
-cyE
-cyE
+dfL
+dfL
+dfL
 rdV
 vVo
 aaa
@@ -108008,27 +107964,27 @@ aae
 vVo
 aBA
 aaN
-aKF
+mFy
 aWw
 vVo
 fEv
 fEv
 fEv
 aaH
-lRu
+sDk
 trb
 cOR
 bZg
 acF
-wbz
+sWo
 gBg
-uWt
-png
-rKG
-tJE
-png
-rKG
-qDS
+xNI
+mos
+vGX
+fkR
+mos
+vGX
+waG
 vVo
 hSI
 lFy
@@ -108036,11 +107992,11 @@ bLP
 acZ
 hSI
 vVo
-wwy
-cyE
+ulY
+dfL
 nSC
-iYM
-cyE
+fqA
+dfL
 vVo
 aae
 aaa
@@ -108264,8 +108220,8 @@ aae
 aae
 vVo
 agq
-qiA
-aKF
+rcw
+mFy
 afa
 vVo
 vVo
@@ -108279,13 +108235,13 @@ vVo
 vVo
 vVo
 vVo
-euS
-png
-png
-rKG
-sua
-qDS
-png
+aeO
+mos
+mos
+vGX
+oTB
+waG
+mos
 vVo
 dNH
 mwp
@@ -108294,9 +108250,9 @@ mwp
 uzS
 vVo
 hkk
-iYM
+fqA
 dlI
-cyE
+dfL
 nSC
 vVo
 aae
@@ -108526,20 +108482,20 @@ aAM
 vVo
 vVo
 lKe
-aKF
-qiA
+mFy
+rcw
 lKe
 lKe
 jFL
-heK
-aKF
+kuW
+mFy
 lKe
 lKe
 vVo
 bjv
-rKG
+vGX
 jRV
-png
+mos
 amr
 bmd
 wMb
@@ -108552,8 +108508,8 @@ ebg
 vVo
 pro
 irW
-wwy
-cyE
+ulY
+dfL
 wNV
 vVo
 aae
@@ -108779,24 +108735,24 @@ vVo
 kUV
 aXM
 wbw
-aKF
-qSe
+mFy
+vKX
 vVo
 aaV
 twO
-aKF
-aKF
-thO
-aKF
-aKF
-aKF
-aKF
-aXD
+mFy
+mFy
+mPL
+mFy
+mFy
+mFy
+mFy
+rIJ
 vVo
-kET
+dBj
 aoh
 aoh
-kET
+dBj
 bjp
 aUe
 vVo
@@ -109039,23 +108995,23 @@ bjc
 twO
 rUR
 vVo
-xNI
-aKF
-aKF
-aKF
-qiA
-qiA
-aKF
+cFE
+mFy
+mFy
+mFy
+rcw
+rcw
+mFy
 lVo
 twO
-xNI
+cFE
 vVo
-iYM
+fqA
 irW
 wno
 bkG
-cyE
-cyE
+dfL
+dfL
 vVo
 bGU
 aXt
@@ -109291,27 +109247,27 @@ aae
 aae
 vVo
 fSy
-qiA
-aKF
-qiA
-aKF
-vVo
-axf
-axf
-aAM
-axf
-axf
-axf
-vVo
-aAM
-axf
-axf
-vVo
+rcw
 mFy
+rcw
+mFy
+vVo
+axf
+axf
+aAM
+axf
+axf
+axf
+vVo
+aAM
+axf
+axf
+vVo
+aKF
 vVo
 eon
 bcv
-cyE
+dfL
 qBw
 vVo
 eIN
@@ -109548,27 +109504,27 @@ aae
 aae
 vVo
 tIE
-pxa
+kET
 aWG
-uLZ
-aKF
+fog
+mFy
 vVo
 jjp
 wEs
-aKF
+mFy
 twO
 xQT
-uZy
+jPC
 vVo
-dps
-rcw
+ehb
+bZw
 wSN
 xJU
 cdl
 vVo
 eon
 bcv
-iYM
+fqA
 vGp
 vVo
 eIN
@@ -109586,7 +109542,7 @@ aae
 aae
 avS
 avS
-mFy
+aKF
 uGH
 qMS
 bFO
@@ -109807,17 +109763,17 @@ vVo
 kUV
 aXM
 wbw
-aKF
-qiA
+mFy
+rcw
 tMi
 gGQ
 agB
-vNC
-qiA
+xIa
+rcw
 bkF
 bkF
 aAM
-cJf
+hnB
 wSN
 wSN
 wSN
@@ -109846,7 +109802,7 @@ eXO
 vVo
 jPo
 mTc
-pgJ
+psO
 avS
 uGX
 bPL
@@ -110083,7 +110039,7 @@ vVo
 wSN
 kjm
 wSN
-jPC
+gGl
 vVo
 eIN
 aXt
@@ -110101,8 +110057,8 @@ avS
 bPL
 vRh
 vVo
-pgJ
-pgJ
+psO
+psO
 vVo
 lUy
 bPL
@@ -110322,12 +110278,12 @@ aby
 rDt
 aXI
 aXI
-nXb
+dxr
 msN
-aXT
-ese
-wPF
-ese
+lUp
+xpz
+wDr
+xpz
 laF
 afR
 fHL
@@ -110337,9 +110293,9 @@ wSN
 wSN
 wSN
 gzj
-vKX
-rcw
-rcw
+iXX
+bZw
+bZw
 aLI
 vVo
 eIN
@@ -110582,12 +110538,12 @@ ePK
 aLM
 kjS
 jEC
-pZn
-pZn
+vBh
+vBh
 jTh
-moG
-lwi
-aXT
+ese
+wnM
+lUp
 aby
 tLD
 wSN
@@ -110596,7 +110552,7 @@ skP
 vVo
 mfo
 azJ
-rcw
+bZw
 aLI
 vVo
 eIN
@@ -110616,9 +110572,9 @@ vUN
 vUN
 vUN
 nlp
-cfb
+qcN
 uRZ
-vUX
+uSC
 vUN
 vUN
 eeT
@@ -110835,7 +110791,7 @@ aby
 aby
 adG
 lwr
-pZn
+vBh
 aeP
 aeP
 aeP
@@ -110844,10 +110800,10 @@ aeP
 aeP
 aeP
 jQx
-ese
+xpz
 adG
 vVo
-mFy
+aKF
 vVo
 vVo
 vVo
@@ -110873,9 +110829,9 @@ dKo
 dKo
 dKo
 dKo
-ryk
+ish
 feX
-sGa
+ina
 dKo
 dKo
 gpP
@@ -111091,7 +111047,7 @@ aby
 cUS
 fNr
 aik
-aXT
+lUp
 abl
 aeP
 aeP
@@ -111101,16 +111057,16 @@ aeP
 aeP
 aeP
 lts
-ese
+xpz
 agR
-hBg
-hBg
-hBg
-hBg
+wSN
+wSN
+wSN
+wSN
 asN
-hBg
-hBg
-hBg
+wSN
+wSN
+wSN
 vVo
 auF
 vJP
@@ -111130,9 +111086,9 @@ dKo
 dKo
 dKo
 dKo
-ryk
+ish
 feX
-sGa
+ina
 dKo
 dKo
 owX
@@ -111346,9 +111302,9 @@ aae
 aae
 aby
 aaO
-aXT
+lUp
 afr
-lSs
+lmX
 nvc
 aeP
 aeP
@@ -111358,17 +111314,17 @@ aeP
 aeP
 aeP
 oFJ
-ese
+xpz
 agR
 tEm
-ham
-dFn
+cYO
+gZa
 mNo
 bkW
-hBg
-gdF
-hBg
-mFy
+wSN
+fLX
+wSN
+aKF
 uEz
 uEz
 wUQ
@@ -111387,9 +111343,9 @@ wsm
 ciV
 dKo
 dKo
-ryk
+ish
 feX
-sGa
+ina
 dKo
 dKo
 ukW
@@ -111605,7 +111561,7 @@ aby
 adm
 cVW
 aik
-ese
+xpz
 nvc
 aeP
 aeP
@@ -111615,16 +111571,16 @@ aeP
 aeP
 aeP
 oFJ
-ese
+xpz
 agR
 xBl
-ham
-dFn
-ham
+cYO
+gZa
+cYO
 bkW
 iBp
-nzg
-nHo
+jjm
+bZw
 vVo
 nOd
 swF
@@ -111644,9 +111600,9 @@ jDC
 veD
 iJK
 iJK
-eeR
+iZc
 vXY
-hOY
+cXH
 iJK
 iJK
 jDC
@@ -111860,9 +111816,9 @@ aae
 aae
 aby
 fCH
-aXT
+lUp
 acQ
-aXT
+lUp
 nvc
 aeP
 aeP
@@ -111872,17 +111828,17 @@ aeP
 aeP
 aeP
 oFJ
-nXb
+dxr
 agR
 bxG
-ham
-ham
-ham
+cYO
+cYO
+cYO
 bkW
-ofb
-hWb
-hBg
-mFy
+ehb
+oyc
+wSN
+aKF
 xYE
 bQv
 xjZ
@@ -112119,7 +112075,7 @@ aby
 cUS
 abx
 aik
-ese
+xpz
 nvc
 aeP
 aeP
@@ -112129,14 +112085,14 @@ aeP
 aeP
 aeP
 oFJ
-aXT
+lUp
 agR
-hBg
-hBg
+wSN
+wSN
 usw
-hBg
+wSN
 asN
-ncO
+gky
 bja
 ykP
 vVo
@@ -112376,8 +112332,8 @@ aby
 aby
 aby
 adG
+xpz
 ese
-moG
 aeP
 aeP
 aeP
@@ -112386,12 +112342,12 @@ aeP
 aeP
 aeP
 aLW
-ese
+xpz
 adG
 vVo
-mFy
+aKF
 vVo
-mFy
+aKF
 vVo
 vVo
 vVo
@@ -112637,19 +112593,19 @@ afH
 eMj
 afk
 tpH
-moG
-moG
-moG
+ese
+ese
+ese
 crl
-moG
-eYq
+ese
+qhe
 usn
 aby
 wSN
-cJf
+hnB
 vVo
-rcw
-faV
+bZw
+qbi
 skP
 bmM
 wSN
@@ -112670,8 +112626,8 @@ eLd
 cvN
 avS
 vVo
-aKF
-aKF
+mFy
+mFy
 rkf
 vVo
 uGX
@@ -112894,22 +112850,22 @@ aXI
 aXI
 bKK
 vLf
-cAr
 aXT
-dEY
-ese
-aXT
+lUp
+pZn
+xpz
+lUp
 afe
 vjB
 aby
 wSN
-dps
+ehb
 vVo
-rcw
+bZw
 wSN
 wSN
 wSN
-jWy
+hyS
 geU
 vVo
 eIN
@@ -112929,7 +112885,7 @@ avS
 vVo
 hAB
 ams
-aKF
+mFy
 vVo
 aae
 aae
@@ -113160,7 +113116,7 @@ aby
 aby
 aby
 wSN
-rcw
+bZw
 vVo
 wiV
 wSN
@@ -113405,24 +113361,24 @@ vVo
 kUV
 aXM
 wbw
-aKF
+mFy
 twO
 aAM
 nRR
 aWf
-qjB
-aKF
+wEa
+mFy
 nRR
 nRR
 aAM
 wSN
-rWn
+fLX
 wSN
 vVo
-faV
+qbi
 wSN
 wSN
-rcw
+bZw
 wSN
 wSN
 vVo
@@ -113441,10 +113397,10 @@ sfu
 cvN
 vVo
 poA
-qiA
+rcw
 gGk
 uUO
-gHR
+sri
 vVo
 aae
 aae
@@ -113662,25 +113618,25 @@ vVo
 awq
 hDW
 jif
-aKF
-qiA
+mFy
+rcw
 vVo
 wEs
 jjp
-aKF
-qiA
+mFy
+rcw
 hPG
 aHx
 vVo
-cJf
+hnB
 wSN
 wSN
-mFy
-cJf
+aKF
+hnB
 wSN
 awi
-rcw
-rWn
+bZw
+fLX
 geU
 vVo
 eIN
@@ -113697,10 +113653,10 @@ dKo
 kFB
 bsm
 vVo
-qiA
-aVi
-aKF
-qiA
+rcw
+xHe
+mFy
+rcw
 rkf
 vVo
 aae
@@ -113918,9 +113874,9 @@ aae
 vVo
 aof
 acU
-qiA
+rcw
 rUR
-aKF
+mFy
 vVo
 axf
 axf
@@ -113937,7 +113893,7 @@ cEF
 wSN
 bkU
 wSN
-rcw
+bZw
 abM
 vVo
 eIN
@@ -113954,10 +113910,10 @@ dKo
 kFB
 ivh
 aAM
-qiA
+rcw
 kxT
 lVo
-aKF
+mFy
 aFV
 vVo
 aae
@@ -114174,25 +114130,25 @@ abO
 aae
 vVo
 aXJ
-pxa
+kET
 aWG
-aKF
-aKF
+mFy
+mFy
 vVo
-xNI
-aKF
-ulY
-qiA
-aKF
-aKF
-qiA
-qiA
-qiA
-qSe
+cFE
+mFy
+pDw
+rcw
+mFy
+mFy
+rcw
+rcw
+rcw
+vKX
 aAM
 wSN
-rWn
-rcw
+fLX
+bZw
 aFE
 wSN
 geU
@@ -114211,11 +114167,11 @@ dKo
 nHR
 doD
 vVo
-xNI
+cFE
 rUR
-aKF
+mFy
 dEU
-uma
+exE
 vVo
 aae
 aae
@@ -114433,17 +114389,17 @@ vVo
 kUV
 aXM
 wbw
-qiA
-xNI
+rcw
+cFE
 vVo
 agG
 kxT
-qiA
-aKF
-aKF
+rcw
+mFy
+mFy
 kxT
-qiA
-qiA
+rcw
+rcw
 twO
 fbg
 vVo
@@ -114469,10 +114425,10 @@ eLd
 cvN
 vVo
 wEx
-qSe
-aKF
-oRF
-mbJ
+vKX
+mFy
+cdP
+ncO
 vVo
 aae
 aae
@@ -114694,21 +114650,21 @@ vVo
 aAM
 vVo
 lKe
-aKF
+mFy
 pRs
 lKe
 lKe
 lKe
-xNI
-aKF
+cFE
+mFy
 lKe
 lKe
 vVo
-aeO
+vlV
 wSN
 wSN
-mFy
-hAr
+aKF
+vdD
 bkD
 vCW
 vVo
@@ -114946,9 +114902,9 @@ aae
 aae
 aae
 vVo
-heK
+kuW
 bjh
-aKF
+mFy
 vVo
 vVo
 axf
@@ -114962,12 +114918,12 @@ vVo
 vVo
 vVo
 aTU
-lvn
+uLZ
 wSN
 vVo
-odQ
+mAx
 aWF
-bAz
+eRx
 vVo
 nbT
 nbT
@@ -114983,8 +114939,8 @@ nbT
 hSq
 aae
 vVo
-aVi
-aKF
+xHe
+mFy
 vVo
 fzT
 bix
@@ -115204,19 +115160,19 @@ aae
 aae
 vVo
 wYd
-qiA
-ulY
-aKF
+rcw
+pDw
+mFy
 adQ
 kbV
 adv
 adh
 kxT
 aAM
-aKF
-aKF
-aKF
-xNI
+mFy
+mFy
+mFy
+cFE
 vVo
 awD
 wSN
@@ -115231,7 +115187,7 @@ aae
 vVo
 vVo
 vVo
-gqd
+bUU
 vVo
 vVo
 vVo
@@ -115241,14 +115197,14 @@ aae
 aae
 vVo
 reI
-xNI
+cFE
 vVo
 fGb
-eHY
+aVi
 wSN
 imm
 oOh
-rcw
+bZw
 vVo
 aae
 aaa
@@ -115473,11 +115429,11 @@ vVo
 pRs
 anp
 lKe
-qiA
+rcw
 vVo
 adw
-jWy
-cJf
+hyS
+hnB
 vVo
 lIO
 vVo
@@ -115488,8 +115444,8 @@ aae
 vVo
 peq
 wSN
-jWy
-wLT
+hyS
+sfr
 aIh
 vVo
 aae
@@ -115498,7 +115454,7 @@ aae
 vVo
 vVo
 gGk
-qiA
+rcw
 vVo
 aVD
 wSN
@@ -115727,8 +115683,8 @@ adv
 oJI
 kbV
 vVo
-aKF
-qiA
+mFy
+rcw
 twO
 lxJ
 vVo
@@ -115754,15 +115710,15 @@ aae
 aae
 vVo
 afa
-aKF
-aXD
+mFy
+rIJ
 vVo
-sEF
+oys
 wSN
 wSN
-hUz
-fYM
-jWy
+usw
+oyc
+hyS
 vVo
 aae
 aaa
@@ -116000,9 +115956,9 @@ aae
 aae
 aae
 vVo
-vKX
+iXX
 wSN
-rcw
+bZw
 wSN
 hYK
 vVo
@@ -116011,12 +115967,12 @@ aae
 aae
 vVo
 aWw
-aKF
-aKF
+mFy
+mFy
 vVo
 vVo
 vVo
-gqd
+bUU
 vVo
 vVo
 axU
@@ -116259,7 +116215,7 @@ vVo
 vVo
 wSN
 wSN
-jWy
+hyS
 wSN
 wSN
 vVo
@@ -116268,13 +116224,13 @@ aae
 aae
 vVo
 afa
-xNI
-qiA
-aKF
+cFE
+rcw
+mFy
 bAe
-qiA
-qiA
-aVi
+rcw
+rcw
+xHe
 vVo
 wSN
 vVo
@@ -116515,10 +116471,10 @@ vVo
 aXM
 jkj
 wSN
-rcw
+bZw
 wSN
-rcw
-cJf
+bZw
+hnB
 vVo
 aae
 aae
@@ -116526,12 +116482,12 @@ aae
 vVo
 vVo
 twO
-aKF
+mFy
 gGk
 biX
 tTk
 bmx
-xNI
+cFE
 vVo
 afQ
 vVo
@@ -116770,7 +116726,7 @@ aae
 aae
 vVo
 aWu
-kiV
+heK
 wSN
 wSN
 kUV
@@ -116783,7 +116739,7 @@ vVo
 vVo
 vVo
 vVo
-gqd
+bUU
 vVo
 vVo
 vVo
@@ -117026,22 +116982,22 @@ aae
 aae
 aae
 vVo
-rcw
+bZw
 wSN
 wSN
-jWy
+hyS
 wSN
 wSN
-vKX
+iXX
 vVo
 aae
 vVo
 afh
-exE
+gim
 wSN
 wSN
-rcw
-sEF
+bZw
+oys
 vVo
 awO
 twO
@@ -117284,7 +117240,7 @@ aae
 aae
 vVo
 edw
-jWy
+hyS
 wSN
 wSN
 wSN
@@ -117301,9 +117257,9 @@ xgE
 iIo
 vVo
 agW
-aKF
-aKF
-aKF
+mFy
+mFy
+mFy
 gLn
 vVo
 aae
@@ -117543,15 +117499,15 @@ vVo
 vVo
 uMW
 wjw
-jWy
-kRQ
+hyS
+pyp
 pWD
 kKy
 vVo
 aae
 vVo
 ybo
-slE
+yfg
 wSN
 wSN
 iIo
@@ -117808,10 +117764,10 @@ vVo
 aae
 vVo
 qdr
-rcw
-rcw
+bZw
+bZw
 wSN
-rdl
+gky
 pmh
 vVo
 vVo
@@ -118067,7 +118023,7 @@ aae
 lVN
 qaP
 nRf
-eHY
+aVi
 kBP
 hRI
 vVo


### PR DESCRIPTION
-Much better tiles for all Mass Fusion buildings
-Fixed nothing tiles beneath catwalks (now open space)
-Fixed some machines in the facility not being anchored
-Some decals and decor added
-Actually a button in the basement now to open the shutters