### PR TITLE
Disables sweating/shivering indicators

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2003,7 +2003,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	if(istype(H.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 		return
 
-	var/loc_temp = H.get_temperature(environment)
+	/* var/loc_temp = H.get_temperature(environment) // SUNSET CHANGE - This is less consistently useful information than the temperature indicators we already have, and actively provides unintuitive information that confuses players
 
 	//Body temperature is adjusted in two parts: first there your body tries to naturally preserve homeostasis (shivering/sweating), then it reacts to the surrounding environment
 	//Thermal protection (insulation) has mixed benefits in two situations (hot in hot places, cold in hot places)
@@ -2038,7 +2038,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			if(15 to 30)
 				H.throw_alert("tempfeel", /obj/screen/alert/sweat, 2)
 			if(30 to INFINITY)
-				H.throw_alert("tempfeel", /obj/screen/alert/sweat, 3)
+				H.throw_alert("tempfeel", /obj/screen/alert/sweat, 3) */ 
 
 	// +/- 50 degrees from 310K is the 'safe' zone, where no damage is dealt.
 	if(H.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTHEAT))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

This feature is intended to provide the player with information but unfortunately it consistently does the opposite. The way it is supposed to work is by causing the player to sweat when the temperature outside is significantly higher than their body temperature, and making them shiver when the temperature outside is significantly lower. 

However, the wasteland is by and large one temperature, and events that are intended to simulate changes in temperature (heat waves, cold waves) _set the player's body temperature_. In practice, this means that a cold wave (which lowers your body temperature) makes the air outside warmer than you are, and causes you to... sweat. 

We already have indicators for when your body temperature is significantly higher or lower than normal, and the sweating/shivering indicators only confuse the issue by providing conflicting information. 

## Why It's Good For The Game

Indicators should fairly consistently provide accurate and usable information. Because of our server environment, these indicators do not. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog

Shouldn't be necessary, this is a cleanup of misleading information.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
