### PR TITLE
Bunny head removal.

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -7010,7 +7010,6 @@
 /area/f13/building)
 "avI" = (
 /obj/structure/rack,
-/obj/item/clothing/head/bunnyhead,
 /obj/item/clothing/head/nursehat,
 /obj/item/clothing/under/schoolgirl,
 /obj/item/clothing/under/schoolgirl/red,


### PR DESCRIPTION
Removed stupid bunny head from the costume shop because it makes you zoom.