### PR TITLE
Implement assaultron sprites

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -652,8 +652,8 @@
 			return FALSE
 	return ..()
 
-/obj/item/robot_module/gutsy
-	name = "Gutsy"
+	/obj/item/robot_module/gutsy
+	name = "Military"
 	basic_modules = list( //Security borg
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -670,8 +670,17 @@
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	borghealth = 300
 	cyborg_base_icon = "gutsy"
-	moduleselect_icon = "standard"
+	moduleselect_icon = "gutsy"
 	hat_offset = -2
+
+/obj/item/robot_module/gutsy/be_transformed_to(obj/item/robot_module/old_module)
+	var/mob/living/silicon/robot/R = loc
+	var/static/list/gutsy_icons
+	if(!gutsy_icons)
+		gutsy_icons = list(
+		"Gutsy" = image(icon = 'icons/mob/robots.dmi', icon_state = "gutsy"),
+		"Assaultron" = image(icon = 'icons/mob/robots.dmi', icon_state = "assaultron"),
+		)
 
 /obj/item/robot_module/assaultron
 	name = "Assaultron"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -331,7 +331,7 @@
 	var/static/list/med_icons
 	if(!med_icons)
 		med_icons = list(
-		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "medical"
+		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "medical")
 		"Medical Assaultron" = image(icon = 'icons/mob/robots.dmi', icon_state = "assaultron_sase")
 		)
 		med_icons = sortList(med_icons)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -331,7 +331,8 @@
 	var/static/list/med_icons
 	if(!med_icons)
 		med_icons = list(
-		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "medical")
+		"Default" = image(icon = 'icons/mob/robots.dmi', icon_state = "medical"
+		"Medical Assaultron" = image(icon = 'icons/mob/robots.dmi', icon_state = "assaultron_sase")
 		)
 		med_icons = sortList(med_icons)
 	var/med_borg_icon = show_radial_menu(R, R , med_icons, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -653,7 +653,7 @@
 			return FALSE
 	return ..()
 
-	/obj/item/robot_module/gutsy
+/obj/item/robot_module/gutsy
 	name = "Military"
 	basic_modules = list( //Security borg
 		/obj/item/assembly/flash/cyborg,


### PR DESCRIPTION
Lets the gutsy and medical cyborg modules use the already existing combat and medical assaultron sprites

## Why It's Good For The Game

You cant stop the **ass**aultron erp now, Planetary.   - seriously though what am I supposed to put here? It stops the cool sprites going to waste?

### Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
:cl: Malware
add: Implemented existing assaultron sprites to be selectable by gutsy and medical modules respectively.
/:cl: