### PR TITLE
Updated *insult list

### DIFF
--- a/strings/insult.json
+++ b/strings/insult.json
@@ -24,7 +24,10 @@
 		"beat",
 		"tackle",
 		"destroy",
-		"vore"
+		"salvage",
+		"scavenge",
+		"stab",
+		"shoot"
     ],
 
     "verbs_touch": [
@@ -37,7 +40,10 @@
         "slap",
         "grab",
 		"choke",
-		"vore"
+		"slam",
+		"stab",
+		"whack",
+		"beat"
     ],
 	
     "verbs_move": [
@@ -57,26 +63,28 @@
     ],
 
     "nouns_insult": [
-        "gaylord",
-        "shitcurity",
+        "brahmin-sniffer",
+        "raider",
         "noob",
-        "comdom",
+        "dummy",
         "cuck",
-        "greytider",
-        "tator",
-        "lingbin",
+        "scum-sucker",
+        "mutie",
+        "headass",
 		"bitch",
 		"whorelord",
-		"cluwn",
-		"monkey",
-		"cheesmonger",
+		"dumbass",
+		"ghoul",
+		"cheesemonger",
 		"milkdrinker",
 		"cally-breek tattie",
 		"clype deep bachle",
 		"blethering gomeril Jessie",
 		"oaf-lookin' schooner",
 		"worm-eyed hotten blaugh",
-		"vile stoochie"
+		"vile stoochie",
+		"tribal",
+		"Kitten looking ass"
     ],
 
     "nouns_generic": [
@@ -129,7 +137,7 @@
         "asinine",
         "mongoloid",
         "childish",
-        "captain-like",
+        "Knight-like",
         "whoreish",
 		"dimwit",
 		"jerk-face",
@@ -160,7 +168,8 @@
         "ugly",
         "bad",
         "okay",
-        "stupid"
+        "stupid",
+		"dumb"
     ],
 	
     "curse_words": [
@@ -172,6 +181,9 @@
 		"jerk",
 		"bitch",
 		"cuck",
-		"moron"
+		"moron",
+		"fuck",
+		"bitch",
+		"woman"
     ]
 }


### PR DESCRIPTION
Removed
-vore
-gaylord
-shitcurity
-comdom
-greytider
-tator
-lingbin
-cluwn
-monkey

Modified or fixed
-Cheesemonger spelling
-Knight-like from Captain-like
-Comdom to dummy

Added
-Bramin-sniffer
-Raider
-scum-sucker
-mutie
-headass
-dumbass
-ghoul
-Kitten looking ass, added with Kit8bits permission

Now get your @pick(nouns_body) off my lawn.

This is fun code, and would be easy to bloat up to ridiculousness, but I don't think it would hurt to add a few more insult bases some time in the future.  It's very funny.