### PR TITLE
Fixes the bad grammar on the sandstorm event text

### DIFF
--- a/modular_sunset/code/game/objects/sunsetmisc.dm
+++ b/modular_sunset/code/game/objects/sunsetmisc.dm
@@ -30,3 +30,10 @@ obj/item/trade_sign
 	anchored = 1
 	w_class = 4
 	layer = 5
+
+/datum/weather/ash_storm/sandstorm
+	telegraph_message = "<span class='userdanger'>A sandstorm is coming to the area, decreasing overall visibility outside.</span>"
+
+	weather_message = "<span class='boldannounce'>The sand wafts down around you like grotesque, thick snow. The sandstorm is here...</span>"
+
+	end_message = "<span class='boldannounce'>The sandstorm slows before stopping. Adding another layer of sand to the ground beneath your feet.</span>"


### PR DESCRIPTION
Changes the sandstorm event text slightly. 

Before : Sandstorm is coming to the area, decreasing overall visibility outside.
After : A sandstorm is coming to the area, decreasing overall visibility outside.

Before : Sand waft down around you like grotesque snow. The sandstorm is here...
After : The sand wafts down around you like grotesque, thick snow. The sandstorm is here...

And finally

Before : The sandstorm slows, stops. Another layer of sand to the ground beneath your feet.

After : The sandstorm slows before stopping. Adding another layer of sand to the ground beneath your feet.

