### PR TITLE
Legion Venator role fix

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -85,6 +85,7 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "BoS Off-Duty",
 
 "Legion Centurion",
+"Legion Venator",
 "Legion Explorer",
 "Legion Slavemaster",
 "Legion Veteran Decanus",
@@ -167,6 +168,7 @@ GLOBAL_LIST_INIT(legion_command_positions, list(
 GLOBAL_LIST_INIT(legion_positions, list(
 	"Legion Orator",
 	"Legion Centurion",
+	"Legion Venator",
 	"Legion Veteran Decanus",
 	"Legion Prime Decanus",
 	"Legion Recruit Decanus",


### PR DESCRIPTION
Makes the Legion Venator role once more selectable after PR #95 disabled it.