### PR TITLE
lets ghouls join MW bos per lore accuracy

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -64,8 +64,6 @@
 /datum/species/ghoul/qualifies_for_rank(rank, list/features)
 	if(rank in GLOB.legion_positions) /* legion HATES these ghoul */
 		return 0
-	if(rank in GLOB.brotherhood_positions) //don't hate them, just tolorate. 
-		return 0
 	if(rank in GLOB.vault_positions) //purest humans left in america. supposedly.
 		return 0
 	return ..()


### PR DESCRIPTION
pugilist said so


## About The Pull Request

ghouls can now join the bos

## Why It's Good For The Game

lore, ig

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelogs don't even work LOL

:cl:
tweak: Ghouls can join the bos.
/:cl:

