### PR TITLE
This is just silly

### DIFF
--- a/code/modules/client/border_control.dm
+++ b/code/modules/client/border_control.dm
@@ -175,7 +175,7 @@ proc/BC_RemoveKey(var/key)
 	if(!GLOB.borderControlFile)
 		return 0
 
-	GLOB.borderControlFile["whitelistedCkeys"] >> GLOB.whitelistedCkeys
+	GLOB.borderControlFile["WhitelistedCkeys"] >> GLOB.whitelistedCkeys
 
 	GLOB.whitelistLoaded = 1
 
@@ -188,4 +188,4 @@ proc/BC_SaveWhitelist()
 	if(!GLOB.borderControlFile)
 		return 0
 
-	GLOB.borderControlFile["whitelistedCkeys"] << GLOB.whitelistedCkeys
+	GLOB.borderControlFile["WhitelistedCkeys"] << GLOB.whitelistedCkeys


### PR DESCRIPTION
## About The Pull Request

Apparently, the bordercontrol file uses `WhitelistedCkeys` with a capital W, not `whitelistedCkeys`

## Why It's Good For The Game

Makes the BC use the right thing.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
server: Makes the BC file use the original db array
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
