### PR TITLE
Fixes Mr.Sanderp custom loadout option

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -27,7 +27,7 @@
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/book/granter/crafting_recipe/happysharky
 	category = LOADOUT_CATEGORY_BACKPACK
-	ckeywhitelist = list("mrsanderp")
+	ckeywhitelist = list("mr.sanderp")
 	cost = 0
 
 /////////////////////


### PR DESCRIPTION
Mr.Sanderp's ckey was incorrectly written as "mrsanderp". This commit adds a period to correctly look for "mr.sanderp"
