### PR TITLE
Rewrites desert edge code to reduce init time

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -25,6 +25,21 @@
 /turf/open/water/Initialize()
 	. = ..()
 	update_icon()
+	// Moved from /turf/open/indestructible/ground/outside/desert to reduce lag.
+	for(var/direction in GLOB.cardinals)
+		var/turf/turf_to_check = get_step(src, direction)
+		if(turf_to_check.type == /turf/open/indestructible/ground/outside/desert) // don't do it for subtypes!
+			var/obj/effect/overlay/desert_side/DS = new /obj/effect/overlay/desert_side(turf_to_check)
+			switch(direction)
+				if(NORTH)
+					DS.pixel_y = -32
+				if(SOUTH)
+					DS.pixel_y = 32
+				if(EAST)
+					DS.pixel_x = -32
+				if(WEST)
+					DS.pixel_x = 32
+			DS.dir = direction
 
 /turf/open/water/update_icon()
 	. = ..()

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -196,30 +196,6 @@
 		plantGrass()
 	if(icon_state != "wasteland")
 		icon_state = "wasteland[rand(1,31)]"
-	for(var/direction in GLOB.cardinals)
-		var/turf/turf_to_check = get_step(src, direction)
-		if(istype(turf_to_check, /turf/open/water))
-			var/obj/effect/overlay/desert_side/DS = new /obj/effect/overlay/desert_side(src)
-			switch(direction)
-				if(NORTH)
-					DS.pixel_y = 32
-				if(SOUTH)
-					DS.pixel_y = -32
-				if(EAST)
-					DS.pixel_x = 32
-				if(WEST)
-					DS.pixel_x = -32
-			DS.dir = dir = turn(direction, 180)
-
-/turf/open/indestructible/ground/outside/desert/harsh/Initialize()
-	. = ..()
-	if(prob(2))
-		var/obj/derp = pickweight(loots)
-		salvage = new derp()
-	if(!((locate(/obj/structure) in src) || (locate(/obj/machinery) in src)))
-		plantGrass()
-	if(icon_state != "wasteland")
-		icon_state = "wasteland[rand(1,31)]"
 
 /obj/effect/overlay/desert_side
 	name = "desert"


### PR DESCRIPTION
## About The Pull Request
Rewrites code for desert edge spawning to reduce lag.
Before, 43415 desert turfs would individually check each of their four cardinal neighbors, for approximately 173660 turfs checked. Each turf would be checked to see if it was a water turf (of which there are only 4245).
This PR instead makes water turfs check their adjacent turfs (of which there are about 16980) for desert turfs, meaning about 150,000 fewer turf iterations during the initial SSatoms initialize flush.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
150,000 fewer iterations during startup sounds good to me!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->