### PR TITLE
Several runtime fixes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -3359,7 +3359,6 @@
 "dyE" = (
 /obj/structure/stairs/north{
 	dir = 2;
-	id = "vaultc1";
 	name = "Cell 1"
 	},
 /obj/structure/cable{
@@ -7688,7 +7687,6 @@
 "hNV" = (
 /obj/structure/stairs/north{
 	dir = 2;
-	id = "vaultc2";
 	name = "Cell 2"
 	},
 /obj/structure/cable{

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -14309,7 +14309,7 @@
 "uFQ" = (
 /mob/living/simple_animal/hostile/lizard{
 	name = "Licks-The-Transistors";
-	AIStatus = 0;
+	AIStatus = 3;
 	desc = "A very crispy looking lizard."
 	},
 /turf/open/indestructible,

--- a/code/__DEFINES/footsteps.dm
+++ b/code/__DEFINES/footsteps.dm
@@ -172,7 +172,34 @@ GLOBAL_LIST_INIT(barefootstep, list(
 	FOOTSTEP_MEAT = list(list(
 		'sound/effects/meatslap.ogg'), 100, 0),
 	FOOTSTEP_RUST = list(list(
-		'sound/effects/footstep/rustystep1.ogg'), 100, 0)
+		'sound/effects/footstep/hull1.ogg',
+		'sound/effects/footstep/hull2.ogg',
+		'sound/effects/footstep/hull3.ogg',
+		'sound/effects/footstep/hull4.ogg',
+		'sound/effects/footstep/hull5.ogg'), 100, 1),
+	FOOTSTEP_SNOW = list(list(
+		'sound/effects/footstep/snow1.ogg',
+		'sound/effects/footstep/snow2.ogg',
+		'sound/effects/footstep/snow3.ogg',
+		'sound/effects/footstep/snow4.ogg',
+		'sound/effects/footstep/snow5.ogg'), 100, 1),
+	FOOTSTEP_GRAVEL = list(list(
+		'sound/effects/footstep/gravel1.ogg',
+		'sound/effects/footstep/gravel2.ogg',
+		'sound/effects/footstep/gravel3.ogg',
+		'sound/effects/footstep/gravel4.ogg'), 100, 1),
+	FOOTSTEP_LOOSE_SAND = list(list(
+		'sound/effects/footstep/sand1.ogg',
+		'sound/effects/footstep/sand2.ogg',
+		'sound/effects/footstep/sand3.ogg',
+		'sound/effects/footstep/sand4.ogg'), 100, 1),
+	FOOTSTEP_ROAD = list(list(
+		'sound/f13effects/footstep/Road/road_walk1.ogg',
+		'sound/f13effects/footstep/Road/road_walk2.ogg',
+		'sound/f13effects/footstep/Road/road_walk3.ogg',
+		'sound/f13effects/footstep/Road/road_walk4.ogg',
+		'sound/f13effects/footstep/Road/road_walk5.ogg',
+		'sound/f13effects/footstep/Road/road_walk6.ogg'), 50, 1)
 ))
 
 //claw footsteps lists
@@ -218,7 +245,34 @@ GLOBAL_LIST_INIT(clawfootstep, list(
 	FOOTSTEP_MEAT = list(list(
 		'sound/effects/meatslap.ogg'), 100, 0),
 	FOOTSTEP_RUST = list(list(
-		'sound/effects/footstep/rustystep1.ogg'), 100, 0)
+		'sound/effects/footstep/hull1.ogg',
+		'sound/effects/footstep/hull2.ogg',
+		'sound/effects/footstep/hull3.ogg',
+		'sound/effects/footstep/hull4.ogg',
+		'sound/effects/footstep/hull5.ogg'), 100, 1),
+	FOOTSTEP_SNOW = list(list(
+		'sound/effects/footstep/snow1.ogg',
+		'sound/effects/footstep/snow2.ogg',
+		'sound/effects/footstep/snow3.ogg',
+		'sound/effects/footstep/snow4.ogg',
+		'sound/effects/footstep/snow5.ogg'), 100, 1),
+	FOOTSTEP_GRAVEL = list(list(
+		'sound/effects/footstep/gravel1.ogg',
+		'sound/effects/footstep/gravel2.ogg',
+		'sound/effects/footstep/gravel3.ogg',
+		'sound/effects/footstep/gravel4.ogg'), 100, 1),
+	FOOTSTEP_LOOSE_SAND = list(list(
+		'sound/effects/footstep/sand1.ogg',
+		'sound/effects/footstep/sand2.ogg',
+		'sound/effects/footstep/sand3.ogg',
+		'sound/effects/footstep/sand4.ogg'), 100, 1),
+	FOOTSTEP_ROAD = list(list(
+		'sound/f13effects/footstep/Road/road_walk1.ogg',
+		'sound/f13effects/footstep/Road/road_walk2.ogg',
+		'sound/f13effects/footstep/Road/road_walk3.ogg',
+		'sound/f13effects/footstep/Road/road_walk4.ogg',
+		'sound/f13effects/footstep/Road/road_walk5.ogg',
+		'sound/f13effects/footstep/Road/road_walk6.ogg'), 50, 1)
 ))
 
 //heavy footsteps list
@@ -238,5 +292,32 @@ GLOBAL_LIST_INIT(heavyfootstep, list(
 	FOOTSTEP_MEAT = list(list(
 		'sound/effects/meatslap.ogg'), 100, 0),
 	FOOTSTEP_RUST = list(list(
-		'sound/effects/footstep/rustystep1.ogg'), 150, 2)
+		'sound/effects/footstep/hull1.ogg',
+		'sound/effects/footstep/hull2.ogg',
+		'sound/effects/footstep/hull3.ogg',
+		'sound/effects/footstep/hull4.ogg',
+		'sound/effects/footstep/hull5.ogg'), 100, 1),
+	FOOTSTEP_SNOW = list(list(
+		'sound/effects/footstep/snow1.ogg',
+		'sound/effects/footstep/snow2.ogg',
+		'sound/effects/footstep/snow3.ogg',
+		'sound/effects/footstep/snow4.ogg',
+		'sound/effects/footstep/snow5.ogg'), 100, 1),
+	FOOTSTEP_GRAVEL = list(list(
+		'sound/effects/footstep/gravel1.ogg',
+		'sound/effects/footstep/gravel2.ogg',
+		'sound/effects/footstep/gravel3.ogg',
+		'sound/effects/footstep/gravel4.ogg'), 100, 1),
+	FOOTSTEP_LOOSE_SAND = list(list(
+		'sound/effects/footstep/sand1.ogg',
+		'sound/effects/footstep/sand2.ogg',
+		'sound/effects/footstep/sand3.ogg',
+		'sound/effects/footstep/sand4.ogg'), 100, 1),
+	FOOTSTEP_ROAD = list(list(
+		'sound/f13effects/footstep/Road/road_walk1.ogg',
+		'sound/f13effects/footstep/Road/road_walk2.ogg',
+		'sound/f13effects/footstep/Road/road_walk3.ogg',
+		'sound/f13effects/footstep/Road/road_walk4.ogg',
+		'sound/f13effects/footstep/Road/road_walk5.ogg',
+		'sound/f13effects/footstep/Road/road_walk6.ogg'), 50, 1),
 ))

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -70,5 +70,5 @@
 
 /obj/machinery/teleport/hub/attack_ghost(mob/user)
 	if(power_station && power_station.engaged && power_station.teleporter_console && power_station.teleporter_console.target)
-		user.forceMove(get_turf(power_station.teleporter_console.target))
+		user.abstract_move(get_turf(power_station.teleporter_console.target))
 	return ..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -392,10 +392,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(glide_size_override)
 		set_glide_size(glide_size_override)
 	if(NewLoc)
-		forceMove(NewLoc)
+		abstract_move(NewLoc)
 		update_parallax_contents()
 	else
-		forceMove(get_turf(src))  //Get out of closets and such as a ghost
+		abstract_move(get_turf(src))  //Get out of closets and such as a ghost
 		if((direct & NORTH) && y < world.maxy)
 			y++
 		else if((direct & SOUTH) && y > 1)
@@ -778,7 +778,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/tz = text2num(href_list["z"])
 			var/turf/target = locate(tx, ty, tz)
 			if(istype(target))
-				forceMove(target)
+				abstract_move(target)
 				return
 		if(href_list["reenter"])
 			reenter_corpse()


### PR DESCRIPTION
- Adds missing footstep sounds to bare, heavy, and clawed footstep sound groups—if we don't want them in those lists we should make sure they're not assigned to `barefootstep` or `clawfootstep` in the first place.
- Fixes observer movement spamming runtimes.
- Fixes invalid AIStatus value in RockSprings.dmm.
- Removes nonexistent id var override in Dungeons.dmm.