### PR TITLE
E-Tool Assistance

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -878,7 +878,7 @@ obj/item/melee/unarmed/punchdagger/cyborg
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	icon_state = "entrenching_tool"
 	item_state = "trench"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	force = 30
 	throwforce = 15
 	toolspeed = 0.7


### PR DESCRIPTION
- - -
Changes the E-Tool from a normal item size to a small, so it can be put onto belts. As you'd expect such to be possible. I 'unno. Minor change or whatever. I think this also permits some stupid stuff, as a consequence, but, again, it's so minor and more of a QoL change that it shouldn't matter.
- - -