### PR TITLE
Buffs Legendary Deathclaw and gives it a unique drop again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -83,15 +83,16 @@
 /mob/living/simple_animal/hostile/deathclaw/legendary
 	name = "legendary deathclaw"
 	desc = "A massive, reptilian creature with powerful muscles, razor-sharp claws, and aggression to match. This one is a legendary enemy."
-	maxHealth = 1200
-	health = 1200
+	maxHealth = 1500
+	health = 1500
 	color = "#FFFF00"
 	stat_attack = UNCONSCIOUS
 	melee_damage_lower = 55
 	melee_damage_upper = 55
-	armour_penetration = 0.5
+	armour_penetration = 0.55
 	footstep_type = FOOTSTEP_MOB_HEAVY
-
+	guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1,
+							/obj/item/stack/sheet/animalhide/deathclaw = 6)
 
 /mob/living/simple_animal/hostile/deathclaw/legendary/death(gibbed)
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -53,11 +53,6 @@
 	aggrosound = list('sound/f13npc/deathclaw/aggro1.ogg', 'sound/f13npc/deathclaw/aggro2.ogg', )
 	idlesound = list('sound/f13npc/deathclaw/idle.ogg',)
 	death_sound = 'sound/f13npc/deathclaw/death.ogg'
-	
-/mob/living/simple_animal/hostile/deathclaw/Initialize()
-    . = ..()
-    if(prob(1))
-        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 /mob/living/simple_animal/hostile/deathclaw/playable
 	emote_taunt_sound = null
@@ -83,11 +78,6 @@
 	color = rgb(95,104,94)
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/deathclaw = 6,
 							/obj/item/stack/sheet/animalhide/deathclaw = 3)
-
-/mob/living/simple_animal/hostile/deathclaw/mother/Initialize()
-    . = ..()
-    if(prob(5))
-        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 //Legendary Deathclaw
 /mob/living/simple_animal/hostile/deathclaw/legendary

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -91,14 +91,12 @@
 	melee_damage_upper = 55
 	armour_penetration = 0.55
 	footstep_type = FOOTSTEP_MOB_HEAVY
-	guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1,
-							/obj/item/stack/sheet/animalhide/deathclaw = 6)
+	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/deathclaw = 6)
 
-/mob/living/simple_animal/hostile/deathclaw/legendary/death(gibbed)
-	var/turf/T = get_turf(src)
-	if(prob(60))
-		new /obj/item/melee/unarmed/deathclawgauntlet(T)
-	. = ..()
+/mob/living/simple_animal/hostile/deathclaw/legendary/Initialize()
+    . = ..()
+    if(prob(37))
+        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 //Power Armor Deathclaw the tankest and the scariest deathclaw in the West. One mistake will end you. May the choice be with you.
 /mob/living/simple_animal/hostile/deathclaw/power_armor

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -94,9 +94,9 @@
 	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/deathclaw = 6)
 
 /mob/living/simple_animal/hostile/deathclaw/legendary/Initialize()
-    . = ..()
-    if(prob(37))
-        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
+	. = ..()
+	if(prob(37))
+		guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 //Power Armor Deathclaw the tankest and the scariest deathclaw in the West. One mistake will end you. May the choice be with you.
 /mob/living/simple_animal/hostile/deathclaw/power_armor

--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -53,6 +53,11 @@
 	aggrosound = list('sound/f13npc/deathclaw/aggro1.ogg', 'sound/f13npc/deathclaw/aggro2.ogg', )
 	idlesound = list('sound/f13npc/deathclaw/idle.ogg',)
 	death_sound = 'sound/f13npc/deathclaw/death.ogg'
+	
+/mob/living/simple_animal/hostile/deathclaw/Initialize()
+    . = ..()
+    if(prob(1))
+        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 /mob/living/simple_animal/hostile/deathclaw/playable
 	emote_taunt_sound = null
@@ -78,6 +83,11 @@
 	color = rgb(95,104,94)
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/deathclaw = 6,
 							/obj/item/stack/sheet/animalhide/deathclaw = 3)
+
+/mob/living/simple_animal/hostile/deathclaw/mother/Initialize()
+    . = ..()
+    if(prob(5))
+        guaranteed_butcher_results = list(/obj/item/melee/unarmed/deathclawgauntlet = 1)
 
 //Legendary Deathclaw
 /mob/living/simple_animal/hostile/deathclaw/legendary


### PR DESCRIPTION
-Legendary deathclaws now have 1500HP (up from 1200) and 55% AP (up from 50%)
-They will drop 6 individual pieces of deathclaw hide instead of the standard 2
-With a 37% chance, they will drop one deathclaw gauntlet when butchered, hitting for 28 damage at 100% AP.