### PR TITLE
Show gun attachment info on examine

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -188,10 +188,10 @@ ATTACHMENTS
 	var/inaccuracy_modifier = 1
 	var/extra_speed = 0
 
-	var/obj/item/attachments/scope
-	var/obj/item/attachments/recoil_decrease
-	var/obj/item/attachments/burst_improvement
-	var/obj/item/attachments/auto_sear
+	var/obj/item/attachments/scope/scope
+	var/obj/item/attachments/recoil_decrease/recoil_decrease
+	var/obj/item/attachments/burst_improvement/burst_improvement
+	var/obj/item/attachments/auto_sear/auto_sear
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -305,6 +305,32 @@ ATTACHMENTS
 			. += "<span class='info'>[gun_light] looks like it can be <b>unscrewed</b> from [src].</span>"
 	else if(can_flashlight)
 		. += "It has a mounting point for a <b>seclite</b>."
+	if(can_scope)
+		if(scope)
+			. += "It has a scope mounted on its rail."
+		else
+			. += "It has a rail, suitable for a <b>scope</b>."
+	if(can_bayonet)
+		if (bayonet)
+			. += "It has a bayonet attached at the front of its barrel."
+		else
+			. += "It has a bayonet lug, suitable for a <b>bayonet</b>."
+	if (suppressed)
+		. += "It has a [can_unsuppress ? "built-in " : ""]suppressor mounted on its muzzle."
+	else if (can_suppress)
+		. += "It has a threaded barrel exterior suitable for installing a <b>[can_unsuppress ? "permanent " : ""]suppressor</b>."
+	if (can_attachments)
+		var/free_slots = 2 // update if more are added, or refactor this to use a list of attachments
+		if(burst_improvement)
+			. += "It has a modified burst cam installed."
+			free_slots--
+		if(recoil_decrease)
+			. += "It has a recoil compensator installed."
+			free_slots--
+		if(free_slots > 0)
+			. += "It has [free_slots] empty mounting point\s for miscellaneous attachments."
+
+
 
 //called after the gun has successfully fired its chambered ammo.
 /obj/item/gun/proc/process_chamber(mob/living/user)
@@ -645,7 +671,6 @@ ATTACHMENTS
 			if(!user.transferItemToLoc(I, src))
 				return
 			recoil_decrease = R
-			src.desc += " It has a recoil compensator installed."
 			if (src.spread > 10)
 				src.spread -= 4
 			else
@@ -659,7 +684,6 @@ ATTACHMENTS
 			if(!user.transferItemToLoc(I, src))
 				return
 			burst_improvement = T
-			src.desc += " It has a modified burst cam installed."
 			src.burst_size += 2
 			src.spread += 5
 			src.burst_shot_delay += 0.25

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -28,6 +28,13 @@
 	can_suppress = FALSE
 	equipsound = 'sound/f13weapons/equipsounds/riflequip.ogg'
 
+/obj/item/gun/ballistic/automatic/examine(mob/user)
+	. = ..()
+	if (auto_sear)
+		. += "It has an automatic sear installed."
+	else if (can_automatic && semi_auto)
+		. += "It has room to install an extra <b>automatic sear</b> for select-fire capabilities."
+
 /obj/item/gun/ballistic/automatic/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
@@ -37,7 +44,6 @@
 			if(!user.transferItemToLoc(I, src))
 				return
 			auto_sear = A
-			src.desc += " It has an automatic sear installed."
 			src.burst_size += 1
 			src.spread += 6
 			src.recoil += 0.1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Add on-examine text to guns to show what attachments a weapon can take, as well as what attachments it currently has.
Currently supported:
- Gun lights
- Scopes
- Bayonets
- Suppressors
- Burst cams
- Recoil compensators
- Automatic sears

The descriptions given are the best I could manage after searching each of the attachments. If someone has better alternatives or would rather just have it only say what attachment it can take, just say so.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes some gross description-mutating code in favor of examine overrides.
General quality of life; lets players know what attachments a gun can take. I was asked for this on the Discord.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Guns now state what attachments they have and can take on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
