### PR TITLE
Fix scope zoom buttons persisting after removing a gun's scope

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -724,7 +724,7 @@ ATTACHMENTS
 		var/obj/item/attachments/scope/C = scope
 		C.forceMove(get_turf(user))
 		src.zoomable = FALSE
-		azoom.Remove(user)
+		QDEL_NULL(azoom) // removes it + stops it from being re-added until we readd the scope
 		scope = null
 		update_icon()
 		return TRUE
@@ -805,7 +805,7 @@ ATTACHMENTS
 	. = ..()
 	if(user.get_active_held_item() != src) //we can only stay zoomed in if it's in our hands	//yeah and we only unzoom if we're actually zoomed using the gun!!
 		zoom(user, FALSE)
-		if(zoomable == TRUE)
+		if(azoom)
 			azoom.Remove(user)
 
 /obj/item/gun/dropped(mob/user)


### PR DESCRIPTION
Fixes issue 167 by qdel_nulling the zoom action button when the scope is removed; it's readded when the scope is readded.

Tested with all sorts of combinations of things, like moving while removing the scope, scoped in or out while removing it, dropping it and picking it up after moving it, etc. It all worked for me.