### PR TITLE
Fix gib spawners not deleting after spawning gibs

### DIFF
--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -18,9 +18,7 @@
 	if(gibamounts.len != gibdirections.len)
 		stack_trace("Gib list dir length mismatch!")
 		return
-	INVOKE_ASYNC(src, .proc/do_gibs) // shitty hack
 
-/obj/effect/gibspawner/proc/do_gibs(mob/living/source_mob, list/datum/disease/diseases, list/blood_dna)
 	var/obj/effect/decal/cleanable/blood/gibs/gib = null
 
 	if(sound_to_play && isnum(sound_vol))
@@ -61,7 +59,6 @@
 		qdel(temp_mob)
 	else
 		dna_to_add = list("Non-human DNA" = random_blood_type()) //else, generate a random bloodtype for it.
-
 
 	for(var/i = 1, i<= gibtypes.len, i++)
 		if(gibamounts[i])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Fixes #288. The initialize functionality of gib spawners got split into a separate proc, which meant they weren't being qdel'd on init. Now they are.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Buggy ghost objects on alt click are annoying and make the server look bad to players.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->