### PR TITLE
[NEEDS TESTING] Overhaul SSResearch for custom techwebs/networks

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -8,26 +8,17 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_nodes = list()				//associative id = node datum
 	var/list/techweb_designs = list()			//associative id = node datum
 	var/list/datum/techweb/techwebs = list()
-	var/datum/techweb/science/science_tech
-	var/datum/techweb/admin/admin_tech
 	var/datum/techweb_node/error_node/error_node	//These two are what you get if a node/design is deleted and somehow still stored in a console.
 	var/datum/design/error_design/error_design
-
-	var/datum/techweb/bos/bos_tech //BoS starting tech
-	var/datum/techweb/enclave/enclave_tech //Could probably be used if enclave ever gets implemented as a faction
-	var/datum/techweb/unknown/unknown_tech //Global tech; all newly built consoles, departmental crafters, imprinters and servers will use this
-	var/datum/techweb/followers/followers_tech //Followers starting tech
-
-
 
 	//ERROR LOGGING
 	var/list/invalid_design_ids = list()		//associative id = number of times
 	var/list/invalid_node_ids = list()			//associative id = number of times
 	var/list/invalid_node_boost = list()		//associative id = error message
 
+	var/list/datum/techweb/technets = list() // network key = techweb
+	var/list/obj/machinery/rnd/server/servernets = list() // network key = list of servers
 	var/list/obj/machinery/rnd/server/servers = list()
-	var/list/obj/machinery/rnd/server/VAULTservers = list()
-	var/list/obj/machinery/rnd/server/BOSservers = list()
 
 
 	var/list/techweb_nodes_starting = list()	//associative id = TRUE
@@ -298,8 +289,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/BOSsingle_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 7)	//citadel edit - techwebs nerf
-	var/list/VAULTsingle_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 35)
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 7)	//citadel edit - techwebs nerf
 	var/multiserver_calculation = FALSE
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
@@ -323,16 +313,17 @@ SUBSYSTEM_DEF(research)
 	point_types = TECHWEB_POINT_TYPE_LIST_ASSOCIATIVE_NAMES
 	initialize_all_techweb_designs()
 	initialize_all_techweb_nodes()
-	science_tech = new /datum/techweb/science
-	admin_tech = new /datum/techweb/admin
+	
+	for(var/techweb_type in subtypesof(/datum/techweb))
+		var/datum/techweb/candidate_techweb = techweb_type
+		if (!initial(candidate_techweb.create_roundstart))
+			continue
+		candidate_techweb = new techweb_type
+		technets[candidate_techweb.id] = candidate_techweb
+	
 	autosort_categories()
 	error_design = new
 	error_node = new
-
-	bos_tech = new /datum/techweb/bos
-	enclave_tech = new /datum/techweb/enclave
-	unknown_tech = new /datum/techweb/unknown
-	followers_tech = new /datum/techweb/followers
 
 	for(var/A in subtypesof(/obj/item/seeds))
 		var/obj/item/seeds/S = A
@@ -347,43 +338,26 @@ SUBSYSTEM_DEF(research)
 	return ..()
 
 /datum/controller/subsystem/research/fire()
-	var/list/bitcoins = list()
-	var/list/BOSbitcoins = list()
-	var/list/VAULTbitcoins = list()
-	if(multiserver_calculation)
-		var/eff = calculate_server_coefficient()
-		for(var/obj/machinery/rnd/server/miner in servers)
-			var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.
-			for(var/i in result)
-				result[i] *= eff
-				bitcoins[i] = bitcoins[i]? bitcoins[i] + result[i] : result[i]
-	else
-		for(var/obj/machinery/rnd/server/miner in BOSservers)
-			if(miner.working)
-				BOSbitcoins = BOSsingle_server_income.Copy()
-				break
-		for(var/obj/machinery/rnd/server/miner in VAULTservers)
-			if(miner.working)
-				VAULTbitcoins = VAULTsingle_server_income.Copy()
-				break
 	var/income_time_difference = world.time - last_income
-
-	science_tech.last_bitcoins = VAULTbitcoins  // Doesn't take tick drift into account
-	bos_tech.last_bitcoins = BOSbitcoins
-	unknown_tech.last_bitcoins = bitcoins
-	followers_tech.last_bitcoins = bitcoins
-
-	for(var/i in bitcoins)
-		bitcoins[i] *= income_time_difference / 10
-	for(var/i in BOSbitcoins)
-		BOSbitcoins[i] *= income_time_difference / 10
-	for(var/i in VAULTbitcoins)
-		VAULTbitcoins[i] *= income_time_difference / 10
-
-	science_tech.add_point_list(VAULTbitcoins)
-	bos_tech.add_point_list(BOSbitcoins)
-	unknown_tech.add_point_list(bitcoins) //tbh these guys can get a fuckton of points, because it isn't even being used
-	followers_tech.add_point_list(bitcoins)
+	for(var/network in servernets)
+		var/list/bitcoins = list()
+		if(multiserver_calculation)
+			var/eff = calculate_server_coefficient()
+			for(var/obj/machinery/rnd/server/miner in servernets[network])
+				var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.
+				for(var/i in result)
+					result[i] *= eff
+					bitcoins[i] = bitcoins[i]? bitcoins[i] + result[i] : result[i]
+		else
+			for(var/obj/machinery/rnd/server/miner in servernets[network])
+				if(miner.working)
+					bitcoins = single_server_income.Copy()
+					break			//Just need one to work.
+		var/datum/techweb/our_tech = SSresearch.get_techweb_by_id(network)
+		our_tech.last_bitcoins = bitcoins // pre tick-drift correction
+		for(var/i in bitcoins)
+			bitcoins[i] *= income_time_difference / 10 // correction for tick drift; can't use wait / 10 here
+		our_tech.add_point_list(bitcoins)
 
 	last_income = world.time
 
@@ -590,3 +564,7 @@ SUBSYSTEM_DEF(research)
 			else
 				techweb_boost_items[path] = list(node.id = node.boost_item_paths[path])
 		CHECK_TICK
+
+/datum/controller/subsystem/research/proc/get_techweb_by_id(id)
+	RETURN_TYPE(/datum/techweb)
+	return technets[id]

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -16,6 +16,7 @@
 	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
+	var/research_id = "SCIENCE"
 
 /datum/component/nanites/Initialize(amount = 100, cloud = 0)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
@@ -297,7 +298,7 @@
 		research_value *= 0.5
 	if(host_mob.stat == DEAD)
 		research_value *= 0.75
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
+	SSresearch.get_techweb_by_id(research_id).add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
 
 /datum/component/nanites/proc/nanite_scan(datum/source, mob/user, full_scan)
 	if(!full_scan)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -10,20 +10,22 @@
 	var/mob/living/carbon/human/patient
 	var/obj/structure/table/optable/table
 	var/list/advanced_surgeries = list()
+	var/research_id = "SCIENCE"
 	var/datum/techweb/linked_techweb
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/operating/Initialize()
 	. = ..()
-	linked_techweb = SSresearch.science_tech
+	update_techweb()
 	find_table()
+
+/obj/machinery/computer/operating/proc/update_techweb(new_research_id = null)
+	if (istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/computer/operating/bos
-
-/obj/machinery/computer/operating/bos/Initialize()
-	. = ..()
-	linked_techweb = SSresearch.bos_tech
-	find_table()
+	research_id = "BOS"
 
 /obj/machinery/computer/operating/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/disk/surgery))

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -47,6 +47,8 @@
 	active_power_usage = 400
 	light_color = LIGHT_COLOR_BLUE
 
+	/// ID of the techweb we want to connect to. TODO: COMPONENTIZE TECHWEB CONNECTION
+	var/research_id = "SCIENCE"
 	/// Link to the techweb's stored research. Used to retrieve stored mutations
 	var/datum/techweb/stored_research
 	/// Maximum number of mutations that DNA Consoles are able to store
@@ -213,9 +215,12 @@
 	// Set the default tgui state
 	set_default_state()
 
+/obj/machinery/computer/scan_consolenew/proc/update_techweb(new_research_id = null)
+	if (istext(new_research_id))
+		research_id = new_research_id
 	// Link machine with research techweb. Used for discovering and accessing
 	//  already discovered mutations
-	stored_research = SSresearch.science_tech
+	stored_research = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/computer/scan_consolenew/ui_interact(mob/user, datum/tgui/ui)
 	// Most of ui_interact is spent setting variables for passing to the tgui

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -142,6 +142,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 /obj/machinery/doppler_array/research
 	name = "tachyon-doppler research array"
 	desc = "A specialized tachyon-doppler bomb detection array that uses the results of the highest yield of explosions for research."
+	var/research_id = "SCIENCE" // TODO: Config with multitool? DCS component?
 	var/datum/techweb/linked_techweb
 
 /obj/machinery/doppler_array/research/sense_explosion(turf/epicenter, dev, heavy, light, time, orig_dev, orig_heavy, orig_light)	//probably needs a way to ignore admin explosives later on
@@ -179,7 +180,11 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		say("Data already captured. Aborting.")
 		return
 
-
-/obj/machinery/doppler_array/research/science/Initialize()
+/obj/machinery/doppler_array/research/Initialize()
 	. = ..()
-	linked_techweb = SSresearch.science_tech
+	update_techweb()
+
+/obj/machinery/doppler_array/research/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -566,7 +566,9 @@
 	air.adjust_moles(GAS_NITROUS, -reaction_efficency)
 	air.adjust_moles(GAS_PLASMA, -2*reaction_efficency)
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((reaction_efficency**2)*BZ_RESEARCH_SCALE),BZ_RESEARCH_MAX_AMOUNT)
+	// no way to tell who to benefit, so we just don't give research for it at all
+	// todo: move this to a special gas sensor research machine or something
+	// SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((reaction_efficency**2)*BZ_RESEARCH_SCALE),BZ_RESEARCH_MAX_AMOUNT)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -612,7 +614,9 @@
 	air.adjust_moles(GAS_PLASMA, -heat_scale)
 	air.adjust_moles(GAS_NITRYL, -heat_scale)
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, STIMULUM_RESEARCH_AMOUNT*max(stim_energy_change,0))
+	// no way to tell who to benefit, so we just don't give research for it at all
+	// todo: move this to a special gas sensor research machine or something
+	// SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, STIMULUM_RESEARCH_AMOUNT*max(stim_energy_change,0))
 	if(stim_energy_change)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -659,7 +663,9 @@
 	air.adjust_moles(GAS_N2, -20*nob_formed)
 	air.adjust_moles(GAS_HYPERNOB,nob_formed)
 
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*NOBLIUM_RESEARCH_AMOUNT)
+	// no way to tell who to benefit, so we just don't give research for it at all
+	// todo: move this to a special gas sensor research machine or something
+	// SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*NOBLIUM_RESEARCH_AMOUNT)
 
 	if (nob_formed)
 		var/new_heat_capacity = air.heat_capacity()
@@ -703,7 +709,10 @@
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.set_temperature(air.return_temperature() + cleaned_air * 0.002)
-	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
+	
+	// no way to tell who to benefit, so we just don't give research for it at all
+	// todo: move this to a special gas sensor research machine or something
+	// SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
 
 /datum/gas_reaction/miaster/test()
 	var/datum/gas_mixture/G = new

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -587,22 +587,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				adjustBruteLoss(-0.12, FALSE)
 				adjustFireLoss(-0.06, FALSE)
 
-		if(mind && (mind.assigned_role == "Scientist" || mind.assigned_role == "Research Director"))
-			if(SSresearch.science_tech)
-				if(drunkenness >= 12.9 && drunkenness <= 13.8)
-					drunkenness = round(drunkenness, 0.01)
-					var/ballmer_percent = 0
-					if(drunkenness == 13.35) // why run math if I dont have to
-						ballmer_percent = 1
-					else
-						ballmer_percent = (-abs(drunkenness - 13.35) / 0.9) + 1
-					if(prob(5))
-						say(pick(GLOB.ballmer_good_msg), forced = "ballmer")
-					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS * ballmer_percent))
-				if(drunkenness > 26) // by this point you're into windows ME territory
-					if(prob(5))
-						SSresearch.science_tech.remove_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS))
-						say(pick(GLOB.ballmer_windows_me_msg), forced = "ballmer")
+		// todo: reimplement ballmer peak but for non-hardcoded techwebs
 
 		if(drunkenness >= 41)
 			if(prob(25))

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -18,6 +18,7 @@
 	var/zap_cooldown = 100
 	var/last_zap = 0
 
+	var/research_id = "SCIENCE" // TODO: Config with multitool? DCS component?
 	var/datum/techweb/linked_techweb
 
 /obj/machinery/power/tesla_coil/power
@@ -26,7 +27,12 @@
 /obj/machinery/power/tesla_coil/Initialize()
 	. = ..()
 	wires = new /datum/wires/tesla_coil(src)
-	linked_techweb = SSresearch.science_tech
+	update_techweb()
+
+/obj/machinery/power/tesla_coil/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/power/tesla_coil/RefreshParts()
 	var/power_multiplier = 0

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -34,6 +34,8 @@
 	var/list/item_reactions = list()
 	var/list/valid_items = list() //valid items for special reactions like transforming
 	var/list/critical_items = list() //items that can cause critical reactions
+	var/research_id = "SCIENCE" // this should really be a component or something
+	var/datum/techweb/linked_techweb // ditto
 
 /obj/machinery/rnd/experimentor/proc/ConvertReqString2List(list/source_list)
 	var/list/temp_list = params2list(source_list)
@@ -72,6 +74,12 @@
 	trackedIan = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
 	trackedRuntime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
 	SetTypeReactions()
+	update_techweb()
+
+/obj/machinery/rnd/experimentor/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/rnd/experimentor/RefreshParts()
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
@@ -135,11 +143,11 @@
 			for(var/node_id in listin)
 				var/datum/techweb_node/N = SSresearch.techweb_node_by_id(node_id)
 				var/str = "<b>[N.display_name]</b>: [listin[N]] points.</b>"
-				if(SSresearch.science_tech.researched_nodes[N.id])
+				if(linked_techweb.researched_nodes[N.id])
 					res += str
-				else if(SSresearch.science_tech.boosted_nodes[N.id])
+				else if(linked_techweb.boosted_nodes[N.id])
 					boosted += str
-				if(SSresearch.science_tech.visible_nodes[N.id])	//JOY OF DISCOVERY!
+				if(linked_techweb.visible_nodes[N.id])	//JOY OF DISCOVERY!
 					output += str
 			output += boosted + res
 			dat += output

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -14,6 +14,7 @@
 	var/list/datum/design/matching_designs
 	var/department_tag = "Unidentified"			//used for material distribution among other things.
 	var/datum/techweb/stored_research
+	var/host_id = "SCIENCE"
 	var/datum/techweb/host_research
 
 	var/screen = RESEARCH_FABRICATOR_SCREEN_MAIN
@@ -25,10 +26,15 @@
 	matching_designs = list()
 	cached_designs = list()
 	stored_research = new
-	host_research = SSresearch.science_tech
+	update_techweb()
 	INVOKE_ASYNC(src, .proc/update_research)
 	materials = AddComponent(/datum/component/remote_materials, "lathe", mapload, _after_insert=CALLBACK(src, .proc/AfterMaterialInsert))
 	RefreshParts()
+
+/obj/machinery/rnd/production/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		host_id = new_research_id
+	host_research = SSresearch.get_techweb_by_id(host_id)
 
 /obj/machinery/rnd/production/Destroy()
 	materials = null

--- a/code/modules/research/nanites/nanite_program_hub.dm
+++ b/code/modules/research/nanites/nanite_program_hub.dm
@@ -9,6 +9,7 @@
 	circuit = /obj/item/circuitboard/machine/nanite_program_hub
 
 	var/obj/item/disk/nanite_program/disk
+	var/research_id = "SCIENCE"
 	var/datum/techweb/linked_techweb
 	var/current_category = "Main"
 	var/detail_view = TRUE
@@ -24,7 +25,12 @@
 
 /obj/machinery/nanite_program_hub/Initialize()
 	. = ..()
-	linked_techweb = SSresearch.science_tech
+	update_techweb()
+
+/obj/machinery/nanite_program_hub/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/nanite_program_hub/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/disk/nanite_program))
@@ -125,6 +131,7 @@
 			if(disk.program)
 				qdel(disk.program)
 			disk.program = new downloaded.program_type
+			disk.linked_techweb = linked_techweb
 			disk.name = "[initial(disk.name)] \[[disk.program.name]\]"
 			playsound(src, 'sound/machines/terminal_prompt.ogg', 25, FALSE)
 			. = TRUE

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -54,6 +54,9 @@
 	//Rules that automatically manage if the program's active without requiring separate sensor programs
 	var/list/datum/nanite_rule/rules = list()
 
+	// Handled by the downloader + disk, used for things like generating research for a techweb
+	var/datum/techweb/linked_techweb
+
 /datum/nanite_program/New()
 	. = ..()
 	register_extra_settings()
@@ -68,6 +71,7 @@
 		on_mob_remove()
 	if(nanites)
 		nanites.programs -= src
+	linked_techweb = null
 	return ..()
 
 /datum/nanite_program/proc/copy()

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -161,7 +161,7 @@
 	var/points = 1
 	if(!host_mob.client) //less brainpower
 		points *= 0.25
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+	linked_techweb.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
 
 /datum/nanite_program/researchplus
 	name = "Neural Network"
@@ -194,7 +194,7 @@
 	var/points = round(SSnanites.neural_network_count / 12, 0.1)
 	if(!C.client) //less brainpower
 		points *= 0.25
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
+	linked_techweb.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))
 
 /datum/nanite_program/access
 	name = "Subdermal ID"

--- a/code/modules/research/nanites/program_disks.dm
+++ b/code/modules/research/nanites/program_disks.dm
@@ -6,11 +6,13 @@
 	desc = "A disk capable of storing nanite programs. Can be customized using a Nanite Programming Console."
 	var/program_type
 	var/datum/nanite_program/program
+	var/datum/techweb/linked_techweb // set by downloader
 
 /obj/item/disk/nanite_program/Initialize()
 	. = ..()
 	if(program_type)
 		program = new program_type
+		program.linked_techweb = linked_techweb
 
 /obj/item/disk/nanite_program/aggressive_replication
 	program_type = /datum/nanite_program/aggressive_replication

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -19,7 +19,8 @@ Nothing else in the console has ID requirements.
 	desc = "A console used to interface with R&D tools."
 	icon_screen = "rdcomp"
 	icon_keyboard = "rd_key"
-	var/datum/techweb/stored_research					//Reference to global science techweb.
+	var/research_id = "SCIENCE" // Our techweb's ID var. TODO: Componentize this and the next var.
+	var/datum/techweb/stored_research					//Reference to our specific science techweb.
 	var/obj/item/disk/tech_disk/t_disk	//Stores the technology disk.
 	var/obj/item/disk/design_disk/d_disk	//Stores the design disk.
 	circuit = /obj/item/circuitboard/computer/rdconsole
@@ -90,10 +91,15 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/Initialize()
 	. = ..()
-	stored_research = SSresearch.science_tech
+	update_techweb()
 	stored_research.consoles_accessing[src] = TRUE
 	matching_design_ids = list()
 	SyncRDevices()
+
+/obj/machinery/computer/rdconsole/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	stored_research = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/computer/rdconsole/Destroy()
 	if(stored_research)
@@ -153,8 +159,6 @@ Nothing else in the console has ID requirements.
 	var/list/price = TN.get_price(stored_research)
 	if(stored_research.can_afford(price))
 		investigate_log("[key_name(user)] researched [id]([json_encode(price)]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
-		if(stored_research == SSresearch.science_tech)
-			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "name" = TN.display_name, "price" = "[json_encode(price)]", "time" = SQLtime()))
 		if(stored_research.research_node_id(id))
 			say("Successfully researched [TN.display_name].")
 			var/logname = "Unknown"
@@ -1163,31 +1167,12 @@ Nothing else in the console has ID requirements.
 	circuit = /obj/item/circuitboard/computer/rdconsole/bos
 	req_access = null
 	req_access_txt = "120"
+	research_id = "BOS"
 
 /obj/machinery/computer/rdconsole/core/vault
+	research_id = "VAULT"
 	circuit = /obj/item/circuitboard/computer/rdconsole/vault
 
 /obj/machinery/computer/rdconsole/core/followers
+	research_id = "FOLLOWERS"
 	circuit = /obj/item/circuitboard/computer/rdconsole/followers
-
-//lettern's lazy way of adding more channels
-/obj/machinery/computer/rdconsole/core/bos/Initialize()
-	. = ..()
-	stored_research = SSresearch.bos_tech //lettern, note about this
-	stored_research.consoles_accessing[src] = TRUE
-	matching_design_ids = list()
-	SyncRDevices()
-
-/obj/machinery/computer/rdconsole/core/vault/Initialize()
-	. = ..()
-	stored_research = SSresearch.science_tech //lettern, note about this
-	stored_research.consoles_accessing[src] = TRUE
-	matching_design_ids = list()
-	SyncRDevices()
-
-/obj/machinery/computer/rdconsole/core/followers/Initialize()
-	. = ..()
-	stored_research = SSresearch.followers_tech
-	stored_research.consoles_accessing[src] = TRUE
-	matching_design_ids = list()
-	SyncRDevices()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -3,6 +3,7 @@
 	desc = "A computer system running a deep neural network that processes arbitrary information to produce data useable in the development of new technologies. In layman's terms, it makes research points."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "server"
+	var/research_id = "SCIENCE" // this is all over the place, todo: centralize/componentize
 	var/datum/techweb/stored_research
 	//Code for point mining here.
 	var/working = TRUE			//temperature should break it.
@@ -17,15 +18,36 @@
 	var/temp_penalty_coefficient = 0.5	//1 = -1 points per degree above high tolerance. 0.5 = -0.5 points per degree above high tolerance.
 	req_access = list(ACCESS_RD) //ONLY THE R&D CAN CHANGE SERVER SETTINGS.
 
+/obj/machinery/rnd/server/proc/create_custom_techweb() // admin call only ATM, heavy wip
+	// todo: maybe move this to SSresearch
+	if(SSresearch.technets[research_id])
+		stored_research = SSresearch.technets[research_id] // no overwriting existing servers
+		return
+	stored_research = new /datum/techweb/custom(research_id)
+	SSresearch.technets[research_id] = stored_research
+
+/obj/machinery/rnd/server/proc/init_server() // separate from initialize for admin purposes
+	LAZYADD(SSresearch.servernets[research_id], src)
+	// might do more in the future
+
+/obj/machinery/rnd/server/proc/disconnect_server() // above, but with destroy
+	LAZYREMOVE(SSresearch.servernets[research_id], src)
+	// todo: maybe delete (custom?) techwebs if we remove the last server one has? :thinking:
+
 /obj/machinery/rnd/server/Initialize()
 	. = ..()
-	SSresearch.servers |= src
-	stored_research = SSresearch.science_tech
-	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
-	B.apply_default_parts(src)
+	SSresearch.servers |= src // global rnd server list
+	init_server()
+	update_techweb()
+
+/obj/machinery/rnd/server/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	stored_research = SSresearch.get_techweb_by_id(research_id)
 
 /obj/machinery/rnd/server/Destroy()
 	SSresearch.servers -= src
+	disconnect_server()
 	return ..()
 
 /obj/machinery/rnd/server/RefreshParts()
@@ -152,26 +174,14 @@
 	return TRUE
 
 
-/obj/machinery/rnd/server/bos/Initialize()
-	. = ..()
-	SSresearch.BOSservers |= src
-	stored_research = SSresearch.bos_tech //note this lettern
-	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
-	B.apply_default_parts(src)
+/obj/machinery/rnd/server/bos
+	research_id = "BOS"
 
-/obj/machinery/rnd/server/vault/Initialize()
-	. = ..()
-	SSresearch.VAULTservers |= src
-	stored_research = SSresearch.science_tech //note this lettern
-	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
-	B.apply_default_parts(src)
+/obj/machinery/rnd/server/vault
+	research_id = "VAULT"
 
-/obj/machinery/rnd/server/followers/Initialize()
-	. = ..()
-	SSresearch.VAULTservers |= src
-	stored_research = SSresearch.followers_tech
-	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/rdserver(null)
-	B.apply_default_parts(src)
+/obj/machinery/rnd/server/followers
+	research_id = "FOLLOWERS"
 
 /* so we can link lathes and such to this server's techweb */
 /obj/machinery/rnd/server/multitool_act(mob/living/user, obj/item/I)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -22,6 +22,7 @@
 	var/list/last_bitcoins = list()								//Current per-second production, used for display only.
 	var/list/discovered_mutations = list()                           //Mutations discovered by genetics, this way they are shared and cant be destroyed by destroying a single console
 	var/list/tiers = list()										//Assoc list, id = number, 1 is available, 2 is all reqs are 1, so on
+	var/create_roundstart = TRUE
 
 /datum/techweb/New()
 	hidden_nodes = SSresearch.techweb_nodes_hidden.Copy()
@@ -46,6 +47,7 @@
 /datum/techweb/syndicate
 	id = "SYNDICATE"
 	organization = "Syndicate"
+	create_roundstart = FALSE
 
 /datum/techweb/syndicate/New()
 	var/datum/techweb_node/syndicate_basic/Node = new()
@@ -54,6 +56,7 @@
 /datum/techweb/abductor
 	id = "ABDUCTOR"
 	organization = "Aliens"
+	create_roundstart = FALSE
 
 /datum/techweb/abductor/New()
 	var/datum/techweb_node/alientech/Node = new()
@@ -71,9 +74,9 @@
 	id = "BOS"
 	organization = "Brotherhood of Steel"
 
-/datum/techweb/enclave	//Enclave tech "channel"
-	id = "ENCLAVE"
-	organization = "Enclave"
+/datum/techweb/vault	//vault techweb
+	id = "VAULT"
+	organization = "Vault" // add number when we actually add the vault
 
 /datum/techweb/followers //Followers tech "channel"
 	id = "FOLLOWERS"
@@ -82,6 +85,7 @@
 /datum/techweb/bepis	//Should contain only 1 BEPIS tech selected at random.
 	id = "EXPERIMENTAL"
 	organization = "Nanotrasen R&D"
+	create_roundstart = FALSE
 
 /datum/techweb/bepis/New()
 	. = ..()
@@ -373,6 +377,7 @@
 
 /datum/techweb/specialized
 	var/allowed_buildtypes = ALL
+	create_roundstart = FALSE
 
 /datum/techweb/specialized/add_design(datum/design/D)
 	if(!(D.build_type & allowed_buildtypes))
@@ -434,3 +439,13 @@
 
 /datum/techweb/specialized/autounlocking/autolathe/ammo
 	design_autounlock_buildtypes = AMMOLATHE
+
+/datum/techweb/custom
+	organization = "Research @ Home"
+	create_roundstart = FALSE
+
+/datum/techweb/custom/New(_id, _org = null)
+	id = _id
+	if (istext(_org))
+		organization = _org
+	..()

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -77,7 +77,8 @@
 	display_results(user, target, "<span class='notice'>You dissect [target], and add your [points_earned] point\s worth of discoveries to the research database!</span>",
 	"[user] dissects [target], discovering [points_earned] point\s of data!",
 	"[user] dissects [target]!")
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points_earned))
+	// todo: find some way to identify who to send research to. operating computer? special optable?
+	SSresearch.get_techweb_by_id("SCIENCE").add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points_earned))
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
 	target.apply_damage(80, BRUTE, L, wound_bonus=CANT_WOUND)
 	ADD_TRAIT(target, TRAIT_DISSECTED, "[surgery.name]")
@@ -88,7 +89,8 @@
 	display_results(user, target, "<span class='notice'>You dissect [target], but do not find anything particularly interesting.</span>",
 	"[user] dissects [target], however it seems [user.p_they()] didn't find anything useful.",
 	"[user] dissects [target], but looks a little dissapointed.")
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = (round(check_value(target, surgery) * 0.01))))
+	// todo: find some way to identify who to send research to. operating computer? special optable?
+	SSresearch.get_techweb_by_id("SCIENCE").add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = (round(check_value(target, surgery) * 0.01))))
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
 	target.apply_damage(80, BRUTE, L, wound_bonus=CANT_WOUND)
 	return TRUE

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -357,11 +357,17 @@
 /obj/item/surgical_drapes/advanced
 	name = "smart surgical drapes"
 	desc = "A smart set of drapes with wireless synchronization to the station's research networks, with an integrated display allowing users to execute advanced surgeries without the aid of an operating computer."
+	var/research_id = "SCIENCE"
 	var/datum/techweb/linked_techweb
 
 /obj/item/surgical_drapes/advanced/Initialize(mapload)
 	. = ..()
-	linked_techweb = SSresearch.science_tech
+	update_techweb()
+
+/obj/item/surgical_drapes/advanced/proc/update_techweb(new_research_id = null)
+	if(istext(new_research_id))
+		research_id = new_research_id
+	linked_techweb = SSresearch.get_techweb_by_id(research_id)
 
 /obj/item/surgical_drapes/advanced/proc/get_advanced_surgeries()
 	. = list()


### PR DESCRIPTION
## About The Pull Request
Fixes #300.
Overhauls research to remove hardcoded techwebs and fix the inconsistency with networks generating points. This should allow mappers to add/handle new networks easily.
TODO IN A FUTURE PR: Move all the duplicated `research_id`, `linked_techweb`, and `update_techweb` vars/procs to a `/datum/technology_connection` or promote it to /obj/machinery.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Will hopefully make it easier to add new tech networks for factions, as well as remove ones that aren't used, and link machinery.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->