### PR TITLE
Make the NCR shorts loadout name match the item

### DIFF
--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -600,7 +600,7 @@
 						)
 
 /datum/gear/uniform/ncr_shorts
-	name = "NCR Rhodesian shorts"
+	name = "NCR fatigue shorts"
 	path = /obj/item/clothing/under/f13/ncr/ncr_shorts
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_FACTIONS
 	restricted_desc = "NCR"


### PR DESCRIPTION
## About The Pull Request
The NCR fatigue shorts, named "NCR fatigue shorts" in game, were changed on The Wasteland to be named "NCR Rhodesian shorts" in the loadout. This is completely lost on people who don't immerse themselves in fascist chan memes, i.e. "normal people."
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rigbe merged code without actually fucking reading it, apparently. Rhodesia shit is a bad meme. Stop drooling over a failed army failing to prop up a failed state. You're not cool for doing it, you just spend too much time on /k/, which is the opposite of cool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->