### PR TITLE
Fix incorrect transition (blue) matrix destinations

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1076,7 +1076,7 @@
 "aed" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
-	destination_y = 56;
+	destination_y = 70;
 	destination_z = 7
 	},
 /area/f13/tunnel/northwest)
@@ -10394,8 +10394,8 @@
 /area/f13/building/hospital)
 "aLa" = (
 /obj/structure/statue_fal{
-	pixel_y = -15;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -15
 	},
 /obj/structure/railing{
 	dir = 9
@@ -25067,7 +25067,7 @@
 "dcd" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 32;
+	destination_y = 40;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -27603,7 +27603,7 @@
 "eUD" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 27;
+	destination_y = 33;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -28461,7 +28461,7 @@
 "fyU" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 30;
+	destination_y = 36;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -30277,7 +30277,7 @@
 "gPa" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 26;
+	destination_y = 32;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -31450,6 +31450,13 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"hOA" = (
+/turf/closed/indestructible/f13/matrix/transition{
+	destination_x = 2;
+	destination_y = 38;
+	destination_z = 9
+	},
+/area/f13/tunnel/southeast)
 "hOC" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -32730,7 +32737,7 @@
 "iHd" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
-	destination_y = 60;
+	destination_y = 74;
 	destination_z = 7
 	},
 /area/f13/tunnel/northwest)
@@ -33737,7 +33744,7 @@
 "jjK" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
-	destination_y = 58;
+	destination_y = 72;
 	destination_z = 7
 	},
 /area/f13/tunnel/northwest)
@@ -36259,7 +36266,7 @@
 "led" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
-	destination_y = 59;
+	destination_y = 73;
 	destination_z = 7
 	},
 /area/f13/tunnel/northwest)
@@ -38015,7 +38022,7 @@
 "mnc" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
-	destination_y = 57;
+	destination_y = 71;
 	destination_z = 7
 	},
 /area/f13/tunnel/northwest)
@@ -43018,7 +43025,7 @@
 "pJM" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 29;
+	destination_y = 35;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -43275,7 +43282,7 @@
 "pVl" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 31;
+	destination_y = 37;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -44818,7 +44825,7 @@
 "rbw" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 3;
+	destination_y = 39;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -46958,7 +46965,7 @@
 "sCp" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
-	destination_y = 28;
+	destination_y = 34;
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
@@ -120669,7 +120676,7 @@ bmi
 atv
 dcd
 rbw
-rbw
+hOA
 pVl
 fyU
 pJM

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -136,9 +136,9 @@
 "akm" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 8;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "akM" = (
@@ -615,9 +615,9 @@
 /area/f13/building)
 "aOF" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
 	dir = 1;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "aPO" = (
@@ -735,16 +735,16 @@
 /area/f13/wasteland)
 "bed" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "garage door";
-	id = "westranchgarage"
+	id = "westranchgarage";
+	name = "garage door"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "ber" = (
 /obj/machinery/door/password/voice{
-	password = "Omnicron";
-	max_integrity = 10000
+	max_integrity = 10000;
+	password = "Omnicron"
 	},
 /turf/open/floor/pod/dark,
 /area/f13/bunker)
@@ -1628,8 +1628,8 @@
 /area/f13/legion)
 "cey" = (
 /obj/structure/fence/wooden{
-	dir = 1;
 	density = 0;
+	dir = 1;
 	name = "wood post"
 	},
 /obj/structure/fluff/railing,
@@ -1687,8 +1687,8 @@
 /area/f13/wasteland)
 "cjq" = (
 /obj/structure/wreck/car/bike{
-	dir = 4;
-	desc = "An old pre-war motorcycle, this ones wheels have been pulled off and it's clear parts are just flat out missing.  It's very ruined."
+	desc = "An old pre-war motorcycle, this ones wheels have been pulled off and it's clear parts are just flat out missing.  It's very ruined.";
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -1834,9 +1834,9 @@
 	},
 /obj/item/renegade_flag,
 /turf/closed/wall/f13/wood/house{
-	name = "salvaged wall";
+	color = "#b09168";
 	desc = "A weathered wall put together using various bits of scrap metal.";
-	color = "#b09168"
+	name = "salvaged wall"
 	},
 /area/f13/wasteland)
 "cvg" = (
@@ -2183,9 +2183,9 @@
 /area/f13/caves)
 "cME" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
 	dir = 9;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "cMV" = (
@@ -2200,9 +2200,9 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 6;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "cNI" = (
@@ -2285,8 +2285,8 @@
 	color = "000000"
 	},
 /mob/living/simple_animal/hostile/gecko{
-	faction = list("neutral");
 	desc = "An absolutely braindead gecko, even by gecko standards.  He seems oddly docile.";
+	faction = list("neutral");
 	name = "Stinky Pete"
 	},
 /obj/machinery/light/small/broken{
@@ -2362,11 +2362,11 @@
 	dir = 1
 	},
 /obj/structure/stairs/north{
+	desc = "That's totally an overpass, and not some kind of stairs.  Promise.";
 	dir = 8;
 	icon = 'icons/turf/f13road.dmi';
 	icon_state = "crossborderroundmid";
-	name = "overpass";
-	desc = "That's totally an overpass, and not some kind of stairs.  Promise."
+	name = "overpass"
 	},
 /obj/structure/railing{
 	dir = 1
@@ -2402,10 +2402,10 @@
 /area/f13/wasteland)
 "cYt" = (
 /obj/machinery/chem_dispenser/drinks/beer{
+	density = 0;
 	dir = 8;
 	pixel_x = 21;
-	pixel_y = -2;
-	density = 0
+	pixel_y = -2
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2660,8 +2660,8 @@
 /area/f13/wasteland)
 "doO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 8
+	dir = 8;
+	icon_state = "outerturn"
 	},
 /area/f13/caves)
 "dpl" = (
@@ -3168,10 +3168,10 @@
 	icon_state = "remains"
 	},
 /obj/item/twohanded/baseball/spiked{
-	pixel_x = -14;
-	pixel_y = 4;
+	desc = "He built it, they came.";
 	name = "Big Billys Smash'n'Masher";
-	desc = "He built it, they came."
+	pixel_x = -14;
+	pixel_y = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -3222,10 +3222,10 @@
 /area/f13/building)
 "efC" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -3394,9 +3394,9 @@
 "ers" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 4;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "erI" = (
@@ -3598,10 +3598,10 @@
 /area/f13/building)
 "eBO" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/structure/obstacle/barbedwire/end,
 /obj/effect/decal/cleanable/dirt,
@@ -3806,8 +3806,8 @@
 /area/f13/wasteland)
 "eOT" = (
 /obj/structure/sign/poster/contraband/free_tonto{
-	pixel_y = 16;
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 16
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -3927,8 +3927,8 @@
 /area/f13/legion)
 "eZk" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -3996,8 +3996,8 @@
 /area/f13/wasteland)
 "fei" = (
 /obj/effect/turf_decal/big/energy{
-	pixel_x = 16;
-	alpha = 200
+	alpha = 200;
+	pixel_x = 16
 	},
 /turf/open/floor/f13{
 	icon_state = "whiteyellowrustychess"
@@ -4097,8 +4097,8 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/river{
-	name = "dirty water";
-	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption."
+	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
+	name = "dirty water"
 	},
 /area/f13/wasteland)
 "flB" = (
@@ -4237,11 +4237,11 @@
 	icon_state = "sheetgrey"
 	},
 /obj/effect/decal/remains{
+	desc = "Looks like he got off the wild ride afterall.";
 	icon_state = "remains";
-	pixel_x = -2;
-	pixel_y = -5;
 	name = "Mr. Bones";
-	desc = "Looks like he got off the wild ride afterall."
+	pixel_x = -2;
+	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4298,8 +4298,8 @@
 	pixel_x = -26
 	},
 /turf/open/indestructible/ground/outside/river{
-	name = "dirty water";
-	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption."
+	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
+	name = "dirty water"
 	},
 /area/f13/wasteland)
 "fBt" = (
@@ -4349,8 +4349,8 @@
 /area/f13/wasteland)
 "fET" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/side/telecomms{
@@ -4692,10 +4692,10 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
@@ -4766,10 +4766,10 @@
 "gft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/building)
@@ -4971,9 +4971,9 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 10;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "gtG" = (
@@ -5032,8 +5032,8 @@
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
 /obj/item/lighter{
-	pixel_y = 4;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -5098,8 +5098,8 @@
 /area/f13/legion)
 "gCx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 1
+	dir = 1;
+	icon_state = "outerturn"
 	},
 /area/f13/caves)
 "gCB" = (
@@ -5168,8 +5168,8 @@
 /area/f13/building)
 "gHm" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -5392,9 +5392,9 @@
 "gWB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 4;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "gXG" = (
@@ -5542,8 +5542,8 @@
 "hhc" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
-	pixel_y = 3;
-	desc = "A RobCo Industries terminal, widely available for commercial and private use before the war. This ones screen seems to have the faint image of some sort of game involving theme parks burned into it."
+	desc = "A RobCo Industries terminal, widely available for commercial and private use before the war. This ones screen seems to have the faint image of some sort of game involving theme parks burned into it.";
+	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5773,9 +5773,9 @@
 /area/f13/wasteland)
 "hsQ" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 9;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "htK" = (
@@ -6264,10 +6264,10 @@
 /area/f13/legion)
 "ibQ" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6350,12 +6350,12 @@
 /area/f13/wasteland)
 "igD" = (
 /obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 15;
 	density = 0;
-	name = "wall mounted terminal";
+	dir = 8;
+	doc_content_1 = "Lockdown override currently in place; standard issue employee IDs will no longer be able to access this facility. Please contact your team supervisor for additional information.";
 	doc_title_1 = "Security Lockdown Active";
-	doc_content_1 = "Lockdown override currently in place; standard issue employee IDs will no longer be able to access this facility. Please contact your team supervisor for additional information."
+	name = "wall mounted terminal";
+	pixel_x = 15
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -6415,11 +6415,11 @@
 "iji" = (
 /obj/effect/decal/marking,
 /mob/living/simple_animal/hostile/gecko{
-	resize = 0.7;
-	name = "Chonklette";
 	color = "#ff0000";
 	desc = "Scrawny looking red gecko, not very chonky.";
-	health = 30
+	health = 30;
+	name = "Chonklette";
+	resize = 0.7
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -6495,8 +6495,8 @@
 	color = "000000"
 	},
 /obj/structure/debris/v1{
-	pixel_x = -16;
-	density = 0
+	density = 0;
+	pixel_x = -16
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -6582,10 +6582,10 @@
 /area/f13/caves)
 "ivP" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = 15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = 15
 	},
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6603,9 +6603,9 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 8;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "iwy" = (
@@ -7392,9 +7392,9 @@
 	pixel_y = -10
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
+	dir = 1;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
-	dir = 1
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "jEL" = (
@@ -7623,17 +7623,17 @@
 /area/f13/wasteland)
 "jXY" = (
 /obj/structure/billboard/ritas{
+	desc = "An old billboard advertising some kind of pre-war product.";
 	icon_state = "advert2";
 	name = "billboard";
-	desc = "An old billboard advertising some kind of pre-war product.";
 	pixel_y = -4
 	},
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "jYh" = (
@@ -7662,8 +7662,8 @@
 "jYw" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
-	pixel_y = 4;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -8230,23 +8230,23 @@
 /area/f13/building)
 "kSK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 8
+	dir = 8;
+	icon_state = "outerturn"
 	},
 /area/f13/wasteland)
 "kSL" = (
 /obj/structure/billboard/ritas{
+	desc = "An old billboard advertising some kind of pre-war product.";
 	icon_state = "advert1";
 	name = "billboard";
-	desc = "An old billboard advertising some kind of pre-war product.";
 	pixel_y = -4
 	},
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "kSQ" = (
@@ -8254,8 +8254,8 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	light_color = "#f4e3b0";
-	pixel_y = 24;
-	light_range = 10
+	light_range = 10;
+	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/legion)
@@ -8315,11 +8315,11 @@
 /area/f13/building)
 "kXY" = (
 /mob/living/simple_animal/hostile/gecko{
-	resize = 1.3;
-	name = "Chonko";
 	color = "#ff0000";
 	desc = "Damn boy, that's a thick ass boy!";
-	health = 80
+	health = 80;
+	name = "Chonko";
+	resize = 1.3
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -8867,12 +8867,12 @@
 /area/f13/legion)
 "lMa" = (
 /obj/machinery/light/sign/kebab{
-	pixel_y = 11;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 11
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 8
+	dir = 8;
+	icon_state = "outerturn"
 	},
 /area/f13/caves)
 "lMr" = (
@@ -8904,8 +8904,8 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "legioneastgatehouse";
 	max_integrity = 600;
-	obj_integrity = 600;
-	name = "reinforced shutters"
+	name = "reinforced shutters";
+	obj_integrity = 600
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
@@ -9023,9 +9023,9 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/fence/wooden{
+	density = 0;
 	dir = 1;
-	pixel_x = 15;
-	density = 0
+	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
@@ -9073,10 +9073,10 @@
 /area/f13/wasteland)
 "mcR" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9364,9 +9364,9 @@
 	obj_integrity = 1200
 	},
 /turf/closed/wall/f13/wood/house{
-	name = "salvaged wall";
+	color = "#b09168";
 	desc = "A weathered wall put together using various bits of scrap metal.";
-	color = "#b09168"
+	name = "salvaged wall"
 	},
 /area/f13/wasteland)
 "mua" = (
@@ -9953,10 +9953,10 @@
 /area/f13/legion)
 "noC" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = 15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -10444,9 +10444,9 @@
 /area/f13/building)
 "nTu" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 10;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "nUC" = (
@@ -10469,8 +10469,8 @@
 /area/f13/building)
 "nUZ" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/darkgreen/side/telecomms,
 /area/f13/bunker)
@@ -10483,9 +10483,9 @@
 /area/f13/bunker)
 "nVB" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 6;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "nVI" = (
@@ -10851,8 +10851,8 @@
 "otd" = (
 /obj/structure/table/wood,
 /obj/item/candle/infinite{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/candle/infinite,
 /obj/item/candle/infinite{
@@ -10973,8 +10973,8 @@
 /area/f13/wasteland)
 "oAf" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "oAz" = (
@@ -11091,9 +11091,9 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/fence/wooden{
 	dir = 1;
+	name = "Satellite Dish Pole";
 	pixel_x = 8;
-	pixel_y = 30;
-	name = "Satellite Dish Pole"
+	pixel_y = 30
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -11315,8 +11315,8 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "oVc" = (
@@ -11605,8 +11605,8 @@
 /obj/structure/table/wood/settler,
 /obj/item/seeds/bamboo,
 /obj/item/seeds/poppy/broc{
-	pixel_y = 2;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 2
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/building)
@@ -11799,9 +11799,9 @@
 /area/f13/caves)
 "pxa" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
+	dir = 5;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
-	dir = 5
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "pyd" = (
@@ -11987,10 +11987,10 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 10;
@@ -12241,11 +12241,11 @@
 /area/f13/building)
 "pWD" = (
 /mob/living/simple_animal/hostile/gecko{
-	resize = 0.7;
-	name = "Chonklette";
 	color = "#ff0000";
 	desc = "Scrawny looking red gecko, not very chonky.";
-	health = 30
+	health = 30;
+	name = "Chonklette";
+	resize = 0.7
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -12363,9 +12363,9 @@
 "qff" = (
 /obj/effect/decal/remains/human,
 /obj/item/tank/internals/emergency_oxygen{
-	volume = 1;
 	pixel_x = -9;
-	pixel_y = 8
+	pixel_y = 8;
+	volume = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -12521,9 +12521,9 @@
 /area/f13/building)
 "qsI" = (
 /obj/item/paper/crumpled{
+	info = "For any late colleague; The facility director instructed us to move to the lower levels are there's an on-going incident. The entire security system is automated and once the countdown reaches zero, the security gate will seal itself. Hopefully this is just a practice drill.. Just in case I lef-";
 	pixel_x = 5;
-	pixel_y = 7;
-	info = "For any late colleague; The facility director instructed us to move to the lower levels are there's an on-going incident. The entire security system is automated and once the countdown reaches zero, the security gate will seal itself. Hopefully this is just a practice drill.. Just in case I lef-"
+	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -12625,9 +12625,9 @@
 	},
 /obj/item/flag/legion,
 /obj/structure/fence/wooden{
+	density = 0;
 	dir = 1;
-	pixel_x = 15;
-	density = 0
+	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
@@ -12720,12 +12720,12 @@
 /area/f13/legion)
 "qLp" = (
 /obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 15;
 	density = 0;
-	name = "wall mounted terminal";
+	dir = 8;
+	doc_content_1 = "Lockdown override currently in place; standard issue employee IDs will no longer be able to access this facility. Please contact your team supervisor for additional information.";
 	doc_title_1 = "Security Lockdown Active";
-	doc_content_1 = "Lockdown override currently in place; standard issue employee IDs will no longer be able to access this facility. Please contact your team supervisor for additional information."
+	name = "wall mounted terminal";
+	pixel_x = 15
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -12768,9 +12768,9 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 9;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "qMZ" = (
@@ -13052,8 +13052,8 @@
 "rir" = (
 /obj/effect/spawner/lootdrop/toolsbasic,
 /obj/structure/sign/warning/fire{
-	pixel_y = -30;
-	name = "\improper DANGER: FUEL STORAGE"
+	name = "\improper DANGER: FUEL STORAGE";
+	pixel_y = -30
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
@@ -13096,8 +13096,8 @@
 "rlg" = (
 /obj/structure/table/booth,
 /obj/item/gun/ballistic/revolver/russian{
-	pixel_y = -4;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = -4
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_x = -10;
@@ -13134,9 +13134,9 @@
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
+	density = 0;
 	dir = 4;
-	pixel_y = 0;
-	density = 0
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
@@ -13360,8 +13360,8 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "legioneastgatehouse";
 	max_integrity = 600;
-	obj_integrity = 600;
-	name = "reinforced shutters"
+	name = "reinforced shutters";
+	obj_integrity = 600
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
@@ -13677,9 +13677,9 @@
 /area/f13/caves)
 "rQi" = (
 /obj/structure/fence/wooden{
+	density = 0;
 	dir = 1;
-	pixel_x = 13;
-	density = 0
+	pixel_x = 13
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -13777,9 +13777,9 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_x = -12;
 	desc = "An oily rag that really could use a good cleaning.";
-	name = "Oily rag"
+	name = "Oily rag";
+	pixel_x = -12
 	},
 /obj/item/chair/stool,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -13966,8 +13966,8 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "rencompoundshed";
 	max_integrity = 1200;
-	obj_integrity = 1200;
-	name = "reinforced shutters"
+	name = "reinforced shutters";
+	obj_integrity = 1200
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -14689,9 +14689,9 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
 	dir = 4;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "tfS" = (
@@ -14922,8 +14922,8 @@
 /area/f13/legion)
 "txY" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -14964,9 +14964,9 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
+	dir = 1;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
-	dir = 1
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "tAD" = (
@@ -15022,8 +15022,8 @@
 /area/f13/bunker)
 "tEy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 1
+	dir = 1;
+	icon_state = "outerturn"
 	},
 /area/f13/wasteland)
 "tEX" = (
@@ -15253,10 +15253,10 @@
 /area/f13/wasteland)
 "tWg" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -15436,9 +15436,9 @@
 /area/f13/building)
 "ulG" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
 	dir = 4;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "ulK" = (
@@ -15450,8 +15450,8 @@
 /area/f13/wasteland)
 "ulT" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	name = "garage door";
-	id = "westranchgarage"
+	id = "westranchgarage";
+	name = "garage door"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -15808,9 +15808,9 @@
 /area/f13/wasteland)
 "uFQ" = (
 /mob/living/simple_animal/hostile/lizard{
-	name = "Licks-The-Transistors";
 	AIStatus = 3;
-	desc = "A very crispy looking lizard."
+	desc = "A very crispy looking lizard.";
+	name = "Licks-The-Transistors"
 	},
 /turf/open/indestructible,
 /area/f13/caves)
@@ -15853,9 +15853,9 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
 	dir = 9;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "uJJ" = (
@@ -16273,8 +16273,8 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/river{
-	name = "dirty water";
-	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption."
+	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
+	name = "dirty water"
 	},
 /area/f13/wasteland)
 "vlA" = (
@@ -16386,10 +16386,10 @@
 /area/f13/wasteland)
 "vtR" = (
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/machinery/button/door{
 	id = "firetowergate";
@@ -16473,12 +16473,12 @@
 /area/f13/wasteland)
 "vDp" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
-	light_color = "#FFFFFF";
+	desc = "The shadows from the building above cast this area in darkness.";
 	icon = null;
 	icon_state = null;
-	desc = "The shadows from the building above cast this area in darkness.";
-	name = "ambient lighting";
-	light_power = 0.2
+	light_color = "#FFFFFF";
+	light_power = 0.2;
+	name = "ambient lighting"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16685,9 +16685,9 @@
 /area/f13/bunker)
 "vQD" = (
 /obj/structure/fermenting_barrel{
+	layer = 10;
 	pixel_x = -6;
-	pixel_y = 12;
-	layer = 10
+	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -16832,9 +16832,9 @@
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
 	dir = 4;
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "vYK" = (
@@ -16847,8 +16847,8 @@
 	pixel_x = -26
 	},
 /turf/open/indestructible/ground/outside/river{
-	name = "dirty water";
-	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption."
+	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
+	name = "dirty water"
 	},
 /area/f13/wasteland)
 "vYV" = (
@@ -17179,10 +17179,10 @@
 /area/f13/building)
 "wxO" = (
 /obj/machinery/chem_dispenser/drinks{
+	density = 0;
 	dir = 8;
 	pixel_x = 21;
-	pixel_y = 2;
-	density = 0
+	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17193,17 +17193,17 @@
 /area/f13/building)
 "wxZ" = (
 /obj/structure/billboard/ritas{
+	desc = "An old billboard advertising some kind of pre-war product.";
 	icon_state = "advert3";
 	name = "billboard";
-	desc = "An old billboard advertising some kind of pre-war product.";
 	pixel_y = -4
 	},
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "wyA" = (
@@ -17319,8 +17319,8 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/remains/human{
-	pixel_x = 10;
-	desc = "Those are definitely the remains of a person, the skull seems to have a small hole in the left temple, and the right side of it is flat out blown out.  You can guess how that happened."
+	desc = "Those are definitely the remains of a person, the skull seems to have a small hole in the left temple, and the right side of it is flat out blown out.  You can guess how that happened.";
+	pixel_x = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -17709,8 +17709,8 @@
 /area/f13/wasteland)
 "xiZ" = (
 /obj/structure/wreck/bus/rusted{
-	name = "razor transport";
-	desc = "A pre-war bus now serving as some kind of raider transport. Looks like it's out of fuel, though."
+	desc = "A pre-war bus now serving as some kind of raider transport. Looks like it's out of fuel, though.";
+	name = "razor transport"
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -17750,8 +17750,8 @@
 /area/f13/wasteland)
 "xmV" = (
 /mob/living/simple_animal/hostile/handy/protectron{
-	name = "protectron guardian";
-	health = 360
+	health = 360;
+	name = "protectron guardian"
 	},
 /obj/machinery/light/broken{
 	dir = 1
@@ -17799,19 +17799,19 @@
 	icon_state = "post_wood"
 	},
 /obj/structure/fence/wooden{
-	dir = 1;
-	pixel_x = -15;
 	density = 0;
-	name = "wood post"
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "xql" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
+	dir = 1;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
-	dir = 1
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "xrw" = (
@@ -17950,8 +17950,8 @@
 	pixel_x = -32
 	},
 /mob/living/simple_animal/pet/cat/kitten{
-	name = "Sprinkles";
-	desc = "That's a tiny little baby kitten with a loose fitting collar made of leather, a nametag saying \"Sprinkles\" is attached. It's maybe a few weeks old at most. The creature is missing large patches of hair and clearly has mange, nevermind that it's clearly underfed and on the edge of starvation. Despite that, its big black eyes practically scream that it loves you."
+	desc = "That's a tiny little baby kitten with a loose fitting collar made of leather, a nametag saying \"Sprinkles\" is attached. It's maybe a few weeks old at most. The creature is missing large patches of hair and clearly has mange, nevermind that it's clearly underfed and on the edge of starvation. Despite that, its big black eyes practically scream that it loves you.";
+	name = "Sprinkles"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -17981,8 +17981,8 @@
 	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerturn";
-	dir = 8
+	dir = 8;
+	icon_state = "outerturn"
 	},
 /area/f13/wasteland)
 "xAL" = (
@@ -18135,8 +18135,8 @@
 "xIf" = (
 /obj/structure/fence/door,
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavement";
-	icon = 'icons/fallout/turfs/f13roadharsh.dmi'
+	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
 "xJd" = (
@@ -18189,9 +18189,9 @@
 /area/f13/caves)
 "xLk" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
-	icon_state = "outerpavementcorner";
+	dir = 8;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
-	dir = 8
+	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland)
 "xLw" = (
@@ -18283,8 +18283,8 @@
 "xTq" = (
 /obj/structure/table,
 /obj/item/clothing/mask/cigarette/rollie{
-	pixel_y = 10;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 10
 	},
 /obj/item/clothing/mask/cigarette/rollie,
 /turf/open/indestructible/ground/outside/dirt/harsh,

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -2727,6 +2727,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
+"cHJ" = (
+/turf/closed/indestructible/f13/matrix/transition{
+	destination_x = 254;
+	destination_y = 72;
+	destination_z = 4
+	},
+/area/f13/wasteland)
 "cIj" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -10345,13 +10352,6 @@
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/raiders)
-"kxN" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 254;
-	destination_y = 64;
-	destination_z = 4
-	},
-/area/f13/wasteland)
 "kyn" = (
 /obj/structure/destructible/tribal_torch/lit{
 	pixel_x = 3
@@ -14138,13 +14138,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/ncr)
-"oaz" = (
-/turf/closed/indestructible/f13/matrix/transition{
-	destination_x = 254;
-	destination_y = 72;
-	destination_z = 4
-	},
-/area/f13/wasteland)
 "oaU" = (
 /obj/machinery/chem_master/primitive{
 	pixel_y = 5
@@ -21774,6 +21767,13 @@
 	dir = 5
 	},
 /area/f13/wasteland)
+"vwv" = (
+/turf/closed/indestructible/f13/matrix/transition{
+	destination_x = 254;
+	destination_y = 64;
+	destination_z = 4
+	},
+/area/f13/wasteland)
 "vwO" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_mosaic,
@@ -24917,7 +24917,7 @@ qZx
 qZx
 qZx
 vol
-oaz
+cHJ
 uzI
 bpP
 oUZ
@@ -24925,7 +24925,7 @@ tnd
 bQJ
 nsn
 krI
-kxN
+vwv
 vol
 qZx
 qZx

--- a/modular_coyote/code/modules/mapping/map_transition_patch.dm
+++ b/modular_coyote/code/modules/mapping/map_transition_patch.dm
@@ -4,6 +4,8 @@
 // To continue my coding standard.
 
 /turf/closed/indestructible/f13/matrix/transition
+	name = "transit matrix"
+	desc = "It looks like walking into this will take you someplace else."
 	icon_state = "matrixblue"
 	var/destination_z
 	var/destination_x
@@ -26,7 +28,7 @@
 		var/itercount = 0
 		while(DT.density || istype(DT.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
 			if (itercount++ >= 100)
-				log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [A] within 100 iterations.")
+				log_game("MATRIX Z-TRANSIT ERROR: Could not find a safe place to land [A] within 100 iterations.")
 				break
 			if (tx < 128)
 				tx++


### PR DESCRIPTION
## About The Pull Request
Some blue matrix tiles had incorrect destinations, usually off by only a few tiles, but one was actually missing an entire digit and would dump people in a closed telecomms compartment forever.
Also, adds a name and description to the blue matrix turfs to differentiate them from green matrix turfs, and explain how to use them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes gay baby jail (winding up in a closed telecomms compartment). Also makes these transit turfs a bit less confusing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->