### PR TITLE
Port Coyote fix for mines being set off by flashlights

### DIFF
--- a/code/modules/fallout/obj/explosives.dm
+++ b/code/modules/fallout/obj/explosives.dm
@@ -154,18 +154,17 @@
 /obj/item/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
 
-/obj/item/mine/proc/on_entered(datum/source)
+/obj/item/mine/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	if(!armed)
 		return
-	if(triggered || !isturf(loc) || !isliving(usr) || isstructure(usr) || isnottriggermine(usr))
+	if(triggered || !isturf(loc) || !isliving(arrived) || isstructure(arrived) || isnottriggermine(arrived))
 		return
 	
-	var/atom/movable/AM = usr
-	if(usr.movement_type & FLYING)
+	if(arrived.movement_type & FLYING)
 		return
 
-	INVOKE_ASYNC(src, .proc/triggermine, AM)
+	INVOKE_ASYNC(src, .proc/triggermine, arrived)
 
 /obj/item/mine/proc/triggermine(mob/victim)
 	if(triggered)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Due to faulty checks, flashlights were set off by mines. Rather than checking the activating atom, it was checking `usr`, which is always either null or a player—meaning it'd sometimes get false positives for mobs stepping on it when something like a light overlay entered its turf.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not setting off mines and plushies with flashlights is a good change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->