### PR TITLE
Fix caltrops, plushies, etc.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -200,11 +200,6 @@
 #define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"				//from base of turf/New(): (turf/source, direction)
 
 // /atom/movable signals
-#define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)
-#define COMSIG_MOVABLE_UNCROSS "movable_uncross"				//from base of atom/movable/Uncross(): (/atom/movable)
-	#define COMPONENT_MOVABLE_BLOCK_UNCROSS 1
-#define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"            //from base of atom/movable/Uncrossed(): (/atom/movable)
-	#define HEARING_MESSAGE_MODE 7
 #define COMSIG_MOVABLE_CHASM_DROP "movable_chasm_drop"			//from base of /datum/component/chasm/drop() (/datum/component/chasm)
 
 // /mind signals

--- a/code/__DEFINES/dcs/signals/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom_movable.dm
@@ -55,9 +55,9 @@
 	#define HEARING_SPEAKER 2
 	#define HEARING_LANGUAGE 3
 	#define HEARING_RAW_MESSAGE 4
-	/* #define HEARING_RADIO_FREQ 5
-	#define HEARING_SPANS 6
-	#define HEARING_MESSAGE_MODE 7 */
+	// #define HEARING_RADIO_FREQ 5
+	// #define HEARING_SPANS 6
+	#define HEARING_MESSAGE_MODE 7
 
 ///called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -6,15 +6,28 @@
 
 	var/cooldown = 0
 
+	///given to connect_loc to listen for something moving over target
+	var/static/list/crossed_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
+	)
+
 /datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 100,  _flags = NONE)
 	min_damage = _min_damage
 	max_damage = max(_min_damage, _max_damage)
 	probability = _probability
 	flags = _flags
 
-	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED), .proc/Crossed)
+	if(ismovable(parent))
+		AddComponent(/datum/component/connect_loc_behalf, parent, crossed_connections)
+	else
+		RegisterSignal(get_turf(parent), COMSIG_ATOM_ENTERED, .proc/on_entered)
 
-/datum/component/caltrop/proc/Crossed(datum/source, atom/movable/AM)
+/datum/component/caltrop/UnregisterFromParent()
+	..()
+	if(ismovable(parent))
+		qdel(GetComponent(/datum/component/connect_loc_behalf))
+
+/datum/component/caltrop/proc/on_entered(datum/source, atom/movable/AM)
 	var/atom/A = parent
 	if(!A.has_gravity())
 		return

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -24,7 +24,7 @@
 		))
 
 /datum/component/chasm/Initialize(turf/target)
-	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Entered)
+	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/Entered)
 	target_turf = target
 	START_PROCESSING(SSobj, src) // process on create, in case stuff is still there
 

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -4,6 +4,11 @@
 	var/expire_time
 	var/min_clean_strength = CLEAN_WEAK
 
+	///given to connect_loc to listen for something moving over target
+	var/static/list/crossed_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/try_infect_crossed,
+	)
+
 /datum/component/infective/Initialize(list/datum/disease/_diseases, expire_in)
 	if(islist(_diseases))
 		diseases = _diseases
@@ -18,7 +23,7 @@
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/try_infect_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/try_infect_collide)
-	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/try_infect_crossed)
+	AddComponent(/datum/component/connect_loc_behalf, parent, crossed_connections)
 	RegisterSignal(parent, COMSIG_MOVABLE_IMPACT_ZONE, .proc/try_infect_impact_zone)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK_ZONE, .proc/try_infect_attack_zone)
@@ -28,6 +33,10 @@
 			RegisterSignal(parent, COMSIG_FOOD_EATEN, .proc/try_infect_eat)
 	else if(istype(parent, /obj/effect/decal/cleanable/blood/gibs))
 		RegisterSignal(parent, COMSIG_GIBS_STREAK, .proc/try_infect_streak)
+
+/datum/component/squeak/UnregisterFromParent()
+	..()
+	qdel(GetComponent(/datum/component/connect_loc_behalf))
 
 /datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
 	for(var/V in diseases)

--- a/code/datums/components/magnetic_catch.dm
+++ b/code/datums/components/magnetic_catch.dm
@@ -1,10 +1,16 @@
+/datum/component/magnetic_catch
+	///given to connect_loc to listen for something moving onto or off of parent
+	var/static/list/crossed_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/entered_react,
+		COMSIG_ATOM_EXITED = .proc/exited_react,
+	)
+
 /datum/component/magnetic_catch/Initialize()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
 	if(ismovable(parent))
-		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/crossed_react)
-		RegisterSignal(parent, COMSIG_MOVABLE_UNCROSSED, .proc/uncrossed_react)
+		AddComponent(/datum/component/connect_loc_behalf, parent, crossed_connections)
 		for(var/i in get_turf(parent))
 			if(i == parent)
 				continue
@@ -17,12 +23,6 @@
 
 /datum/component/magnetic_catch/proc/examine(datum/source, mob/user, list/examine_list)
 	examine_list += "It has been installed with inertia dampening to prevent coffee spills."
-
-/datum/component/magnetic_catch/proc/crossed_react(datum/source, atom/movable/thing)
-	RegisterSignal(thing, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react, TRUE)
-
-/datum/component/magnetic_catch/proc/uncrossed_react(datum/source, atom/movable/thing)
-	UnregisterSignal(thing, COMSIG_MOVABLE_PRE_THROW)
 
 /datum/component/magnetic_catch/proc/entered_react(datum/source, atom/movable/thing, atom/oldloc)
 	RegisterSignal(thing, COMSIG_MOVABLE_PRE_THROW, .proc/throw_react, TRUE)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -88,7 +88,7 @@
 		RegisterSignal(parent, COMSIG_ITEM_MINE_TRIGGERED, .proc/create_blast_pellets)
 
 /datum/component/pellet_cloud/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_PELLET_CLOUD_INIT, COMSIG_GRENADE_PRIME, COMSIG_GRENADE_ARMED, COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNCROSSED, COMSIG_ITEM_MINE_TRIGGERED, COMSIG_ITEM_DROPPED))
+	UnregisterSignal(parent, list(COMSIG_PARENT_PREQDELETED, COMSIG_PELLET_CLOUD_INIT, COMSIG_GRENADE_PRIME, COMSIG_GRENADE_ARMED, COMSIG_MOVABLE_MOVED, COMSIG_ITEM_MINE_TRIGGERED, COMSIG_ITEM_DROPPED))
 
 /**
  * create_casing_pellets() is for directed pellet clouds for ammo casings that have multiple pellets (buckshot and scatter lasers for instance)
@@ -286,7 +286,10 @@
 	LAZYINITLIST(bodies)
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/grenade_dropped)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/grenade_moved)
-	RegisterSignal(parent, COMSIG_MOVABLE_UNCROSSED, .proc/grenade_uncrossed)
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXITED =.proc/grenade_uncrossed,
+	)
+	AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
 
 /// Someone dropped the grenade, so set them to the shooter in case they're on top of it when it goes off
 /datum/component/pellet_cloud/proc/grenade_dropped(obj/item/nade, mob/living/slick_willy)

--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -3,13 +3,17 @@
 	var/offset_y = 0
 	var/is_swarming = FALSE
 	var/list/swarm_members = list()
+	///given to connect_loc to listen for something moving onto or off of parent
+	var/static/list/crossed_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/join_swarm,
+		COMSIG_ATOM_EXITED = .proc/leave_swarm,
+	)
 
 /datum/component/swarming/Initialize(max_x = 24, max_y = 24)
 	offset_x = rand(-max_x, max_x)
 	offset_y = rand(-max_y, max_y)
 
-	RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/join_swarm)
-	RegisterSignal(parent, COMSIG_MOVABLE_UNCROSSED, .proc/leave_swarm)
+	AddComponent(/datum/component/connect_loc_behalf, parent, crossed_connections)
 
 /datum/component/swarming/Destroy()
 	if(is_swarming)


### PR DESCRIPTION
## About The Pull Request
Refactors all uses of the defunct `MOVABLE_CROSSED`/`MOVABLE_UNCROSSED` signals to use connect_loc/connect_loc_behalf and `ATOM_ENTERED`/`ATOM_EXITED`.

## Why It's Good For The Game
Fixes caltrops, fixes plushies, fixes a few other things no one cares about.