### PR TITLE
Add Feng operative kit for pornhublive

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -171,3 +171,30 @@
 
 /obj/item/storage/box/large/custom_kit/sadismbox/PopulateContents()
 	new /obj/item/melee/onehanded/scourge(src)
+
+// to auto-delete when emptied, no free storage
+/obj/item/storage/backpack/duffelbag/equipment/fengoperative/PopulateContents()
+	new /obj/item/clothing/under/f13/chinasuitcosmetic(src)
+	new /obj/item/clothing/head/f13/chinahelmetcosmetic(src)
+	new /obj/item/clothing/suit/armor/f13/combat/chinese(src)
+	new /obj/item/gun/ballistic/automatic/pistol/type17/strelle(src)
+	new /obj/item/gun/ballistic/automatic/smg/p90/worn(src)
+	new /obj/item/storage/box/medicine/stimpaks/stimpaks5(src)
+	for (var/i in 1 to 2)
+		new /obj/item/reagent_containers/hypospray/medipen/medx(src)
+	for (var/i in 1 to 3)
+		new /obj/item/ammo_box/magazine/m10mm_p90(src)
+	for (var/i in 1 to 5)
+		new /obj/item/ammo_box/magazine/m10mm_adv/simple(src)
+	new /obj/item/implanter/stealth(src)
+	new /obj/item/clothing/shoes/combat/sneakboots(src)
+	new /obj/item/clothing/gloves/krav_maga(src)
+	new /obj/item/binoculars(src)
+	new /obj/item/radio/headset/headset_sec(src)
+	new /obj/item/storage/belt/military/assault(src)
+	new /obj/item/clothing/glasses/hud/health(src)
+	
+/datum/gear/donator/kits/fengoperative
+	name = "Operative Kit"
+	path = /obj/item/storage/backpack/duffelbag/equipment/fengoperative
+	ckeywhitelist = list("pornhublive")


### PR DESCRIPTION
Adds a loadout kit with the following items, locked to the ckey `pornhublive`:

- Non-armored Chinese stealth suit and helmet
- Chinese combat armor
- Type 17 Strelle
- Worn P90 SMG
- Box of 5 stimpaks
- Two medx injectors
- 3 p90 magazines
- 5 pistol magazines
- Stealth implanter
- Sneakboots
- Krav Maga gloves
- Binoculars
- Security headset
- Assault belt
- Medical HUD

When the kit is emptied entirely, it will despawn, since the kit doesn't include a free storage item.