### PR TITLE
Runtime fixes, August 13, 2022

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -226,11 +226,12 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		var/throw_dir = get_dir(epicenter,T)
 		for(var/obj/item/I in T)
-			if(!I.anchored)
-				var/throw_range = rand(throw_dist, max_range)
-				var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-				I.throw_speed = EXPLOSION_THROW_SPEED //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
-				I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
+			if(QDELETED(I) || I.anchored)
+				continue
+			var/throw_range = rand(throw_dist, max_range)
+			var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
+			I.throw_speed = EXPLOSION_THROW_SPEED //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
+			I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
 
 		//wait for the lists to repop
 		var/break_condition

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -95,8 +95,8 @@
 //Check if has client or not bruh
 /mob/living/proc/hud_client_check()
 	var/image/onlineholder = hud_list[ONLINE_HUD]
-	var/icon/I = icon(icon, icon_state, dir)
-	onlineholder.pixel_y = I.Height() - world.icon_size
+	if(!onlineholder) // we don't have an SSD hud
+		return
 	if(living_flags & HIDE_OFFLINE_INDICATOR)
 		onlineholder.icon_state = "none"
 		return

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -43,15 +43,17 @@
 	if(!T)
 		return FALSE
 	var/totalitemdamage = target.pre_attacked_by(src, user)
-	target.apply_damage(totalitemdamage * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
 	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
 		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+	target.apply_damage(totalitemdamage * fisto_setting, BRUTE, wound_bonus = -25*fisto_setting**2)
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)
 	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	log_combat(user, target, "power fisted", src)
+	if(QDELETED(target))
+		return
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 	target.throw_at(throw_target, 2 * throw_distance, 0.5 + (throw_distance / 2))
-	log_combat(user, target, "power fisted", src)
 
 // Goliath				Throws targets far. Max damage 50.
 /obj/item/melee/powerfist/f13/goliath

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2429,10 +2429,10 @@ Records disabled until a use for them is found
 						markings[index_up] = first_marking
 
 				if("marking_remove")
-					// move the specified marking up
+					// remove the specified marking
 					var/index = text2num(href_list["marking_index"])
 					var/marking_type = href_list["marking_type"]
-					if(index && marking_type && features[marking_type])
+					if(index > 0 && marking_type && index < length(features[marking_type]))
 						// because linters are just absolutely awful:
 						var/list/L = features[marking_type]
 						L.Cut(index, index + 1)

--- a/code/modules/mob/living/living_active_block.dm
+++ b/code/modules/mob/living/living_active_block.dm
@@ -9,8 +9,9 @@
 	REMOVE_TRAIT(src, TRAIT_MOBILITY_NOUSE, ACTIVE_BLOCK_TRAIT)
 	REMOVE_TRAIT(src, TRAIT_SPRINT_LOCKED, ACTIVE_BLOCK_TRAIT)
 	remove_movespeed_modifier(/datum/movespeed_modifier/active_block)
-	var/datum/block_parry_data/data = I.get_block_parry_data()
-	DelayNextAction(data.block_end_click_cd_add)
+	if(I)
+		var/datum/block_parry_data/data = I.get_block_parry_data()
+		DelayNextAction(data.block_end_click_cd_add)
 	return TRUE
 
 /mob/living/proc/active_block_start(obj/item/I)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,5 +1,5 @@
 
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = "Your armor absorbs the blow!", soften_text = "Your armor softens the blow!", armour_penetration, penetrated_text = "Your armor was penetrated!", silent=FALSE)
+/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = "Your armor absorbs the blow!", soften_text = "Your armor softens the blow!", armour_penetration = null, penetrated_text = "Your armor was penetrated!", silent=FALSE)
 	var/armor = getarmor(def_zone, attack_flag)
 
 	if(silent && armor > 0)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -23,7 +23,7 @@
 	var/designation = ""
 	var/radiomod = "" //Radio character used before state laws/arrivals announce to allow department transmissions, default, or none at all.
 	var/obj/item/camera/siliconcam/aicamera = null //photography
-	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_TRACK_HUD)
+	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_TRACK_HUD, ONLINE_HUD)
 
 	var/obj/item/radio/borg/radio = null //AIs dont use this but this is at the silicon level to advoid copypasta in say()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -355,7 +355,7 @@
 	else
 		result = A.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 
-	if(!result)
+	if(!length(result))
 		return
 	else
 		to_chat(src, result.Join("\n"))

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,14 +8,14 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1571
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.10
+export RUST_G_VERSION=0.5.0
 
 #node version
 export NODE_VERSION=14
 export NODE_VERSION_PRECISE=14.16.1
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.7
+export SPACEMAN_DMM_VERSION=suite-1.7.2
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.7.9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
- Bumps rust-g versions to see if it fixes an error with querying centcomdb.
- Fixes a null reference runtime in stop_active_blocking.
- Fixes the f13 powerfist throwing deleted mobs.
- Fixes explosions throwing deleted items.
- Fixes a broken keyword argument in run_armor_check.
- Fixes silicons runtiming from a missing SSD hud.
- Fixes a runtime from things that returned an empty examine result list.
- Fixes a runtime from spam-clicking on "remove marking".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes bad. The explosions one specifically gave us over 1k in a few seconds. TODO: Port SSexplosions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->