### PR TITLE
Fix mapmerge and merge hooks

### DIFF
--- a/tools/bootstrap/python37._pth
+++ b/tools/bootstrap/python37._pth
@@ -1,0 +1,6 @@
+python37.zip
+.
+..\..\..
+
+# Uncomment to run site.main() automatically
+import site

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python36._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/mapmerge2/convert.py
+++ b/tools/mapmerge2/convert.py
@@ -4,4 +4,4 @@ from . import frontend, dmm
 if __name__ == '__main__':
     settings = frontend.read_settings()
     for fname in frontend.process(settings, "convert"):
-        dmm.DMM.from_file(fname).to_file(fname, settings.tgm)
+        dmm.DMM.from_file(fname).to_file(fname, tgm = settings.tgm)

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -58,7 +58,7 @@ class DMM:
         self.grid[coord] = self.get_or_generate_key(tile)
 
     def generate_new_key(self):
-        free_keys = self._ensure_free_keys(1)
+        self._ensure_free_keys(1)
         max_key = max_key_for(self.key_length)
         # choose one of the free keys at random
         key = random.randint(0, max_key - 1)

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -96,7 +96,7 @@ def main(repo):
                     converted[path] = merge_map(head_files[path], dmm.DMM.from_bytes(data))
         if len(working_commit.parents) != 1:
             print("A merge commit was encountered before good versions of these maps were found:")
-            print("\n".join(f"    {x}" for x in head_files.keys() - base_files.keys()))
+            print("\n".join(f"    {x}" for x in head_files.keys() - converted.keys()))
             return 1
         working_commit = working_commit.parents[0]
 


### PR DESCRIPTION
## About The Pull Request
The python version in dependencies.sh was updated to 3.7.9, but Bootstrap was still expecting python 3.6. This broke the map and DMI merge hooks, mapmerge, and several of the map tests when running locally.

## Why It's Good For The Game
These are important tools!