### PR TITLE
Fix prison map runtimes/missing turfs/smoothing

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -6,6 +6,10 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/wasteland)
+"ar" = (
+/obj/structure/window/fulltile/wood,
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/wasteland)
 "av" = (
 /obj/machinery/computer/camera_advanced{
 	desc = "Used to access the various cameras in the prison.";
@@ -282,6 +286,10 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"cL" = (
+/obj/item/flag/legion,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "cW" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -319,6 +327,11 @@
 	name = "metal plating"
 	},
 /area/f13/building)
+"dj" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_wide,
+/area/f13/wasteland)
 "dm" = (
 /obj/structure/bed,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -395,6 +408,11 @@
 "dL" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"dP" = (
+/turf/open/floor/wood/wood_wide{
+	icon_state = "wide-broken2"
+	},
 /area/f13/wasteland)
 "dR" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -494,6 +512,14 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/wasteland)
+"fg" = (
+/obj/structure/bed/old,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/sign/poster/contraband/pinup_anthro8{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/wasteland)
 "fi" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -581,6 +607,11 @@
 /obj/effect/decal/cleanable/blood/gibs/human/limb,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"gc" = (
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_wide,
+/area/f13/wasteland)
 "ge" = (
 /obj/structure/sign/poster/contraband/pinup_anthro15,
 /turf/closed/wall/f13/tunnel,
@@ -690,6 +721,12 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
+/area/f13/wasteland)
+"gW" = (
+/obj/structure/simple_door/wood{
+	name = "recovery room"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/wasteland)
 "gZ" = (
 /obj/structure/camera_assembly{
@@ -840,6 +877,10 @@
 /area/f13/building)
 "hW" = (
 /turf/open/floor/wood/wood_fancy,
+/area/f13/wasteland)
+"hZ" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood/wood_wide,
 /area/f13/wasteland)
 "ie" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -1275,7 +1316,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/pool/drain,
+/obj/structure/drain,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "lO" = (
@@ -1555,6 +1596,13 @@
 	name = "tile"
 	},
 /area/f13/building)
+"of" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "ov" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1666,6 +1714,10 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"pD" = (
+/obj/structure/junk/small/tv,
+/turf/open/floor/wood/wood_common/wood_common_light,
+/area/f13/wasteland)
 "pE" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1941,6 +1993,13 @@
 	icon_state = "common_light-broken1"
 	},
 /area/f13/wasteland)
+"rB" = (
+/obj/structure/window/fulltile/wood/broken,
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "rD" = (
 /obj/structure/bookcase{
 	icon_state = "book-4"
@@ -1970,6 +2029,13 @@
 /obj/structure/camera_assembly,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"sd" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/wasteland)
 "sg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -2086,7 +2152,7 @@
 	dir = 8;
 	pixel_x = 1
 	},
-/obj/machinery/pool/drain,
+/obj/structure/drain,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "tz" = (
@@ -2120,6 +2186,9 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
+/area/f13/wasteland)
+"tI" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/wasteland)
 "ua" = (
 /obj/structure/sink{
@@ -2273,7 +2342,9 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "vd" = (
-)
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "ve" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -2582,6 +2653,12 @@
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/wasteland)
+"xg" = (
+/obj/structure/fluff/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "xk" = (
 /obj/structure/sign/warning/explosives,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -2626,6 +2703,11 @@
 	},
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"xz" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/wood/wood_wide,
+/area/f13/wasteland)
 "xD" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -2698,6 +2780,16 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_fancy,
+/area/f13/wasteland)
+"yt" = (
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_y = 32
+	},
+/obj/machinery/telecomms/relay/preset/ruskie{
+	name = "renegade telecomms server"
+	},
+/turf/open/floor/wood/wood_wide,
 /area/f13/wasteland)
 "yB" = (
 /obj/effect/decal/cleanable/dirt{
@@ -2911,8 +3003,8 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/pool/drain,
 /obj/item/soap,
+/obj/structure/drain,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "Bm" = (
@@ -3108,6 +3200,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/wasteland)
+"Dd" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Di" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3211,6 +3310,19 @@
 "EV" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
+"FC" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/wood/wood_wide{
+	icon_state = "wide-broken6"
+	},
+/area/f13/wasteland)
+"Hi" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "IE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3283,6 +3395,11 @@
 "JB" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
+	},
+/area/f13/wasteland)
+"JC" = (
+/turf/open/floor/wood/wood_wide{
+	icon_state = "wide-broken6"
 	},
 /area/f13/wasteland)
 "JD" = (
@@ -3380,6 +3497,14 @@
 /area/f13/wasteland)
 "Kv" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"Ky" = (
+/obj/structure/bed/wooden,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/sign/poster/contraband/pinup_anthro14{
+	pixel_y = 32
+	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "KE" = (
@@ -4319,6 +4444,13 @@
 	},
 /turf/open/floor/wood/wood_wide,
 /area/f13/wasteland)
+"Uu" = (
+/obj/structure/curtain{
+	color = "#c40e0e";
+	pixel_x = -32
+	},
+/turf/open/floor/wood/wood_fancy,
+/area/f13/wasteland)
 "Uv" = (
 /obj/item/trash/f13/c_ration_1,
 /obj/item/trash/f13/c_ration_2{
@@ -4508,6 +4640,10 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/wood/wood_wide,
+/area/f13/wasteland)
+"VX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_fancy,
 /area/f13/wasteland)
 "Wa" = (
 /obj/structure/bed/mattress/pregame,
@@ -4819,12 +4955,12 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/pool/drain,
 /mob/living/simple_animal/hostile/vault/security{
 	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
 	faction = list("powder");
 	name = "Powder Ganger Guard"
 	},
+/obj/structure/drain,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "Zt" = (
@@ -5223,8 +5359,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -5480,8 +5616,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -5737,8 +5873,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -5994,8 +6130,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -6251,8 +6387,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -6508,8 +6644,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -6765,8 +6901,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -7022,8 +7158,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -7279,8 +7415,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -7536,8 +7672,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -7793,8 +7929,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -8050,9 +8186,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 DH
 DH
 DH
@@ -8262,9 +8398,9 @@ AI
 AI
 LS
 OC
-vd
-vd
-vd
+tI
+tI
+tI
 uI
 Cr
 OC
@@ -8272,7 +8408,7 @@ LS
 gv
 TD
 gF
-vd
+ar
 lu
 DH
 DH
@@ -8308,9 +8444,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 DH
 DH
 DH
@@ -8524,12 +8660,12 @@ DH
 PR
 Cr
 Cr
-vd
+tI
 ow
 eE
 eA
 Vf
-vd
+ar
 lu
 DH
 DH
@@ -8566,9 +8702,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 DH
 DH
 DH
@@ -8775,13 +8911,13 @@ UL
 DH
 DH
 LS
-vd
+tI
 rQ
 DH
 PR
 Cr
 Cr
-vd
+tI
 LS
 LS
 LS
@@ -8824,9 +8960,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 DH
 DH
 DH
@@ -9036,13 +9172,13 @@ ZN
 hP
 Qv
 gj
-vd
-vd
+tI
+tI
 Cr
 Cr
 sU
 Cr
-vd
+tI
 LS
 DH
 DH
@@ -9082,8 +9218,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -9290,15 +9426,15 @@ DH
 DH
 LS
 NY
-vd
+tI
 LS
-vd
-LS
-LS
-vd
+gW
 LS
 LS
-vd
+gW
+LS
+LS
+gW
 LS
 LS
 DH
@@ -9339,8 +9475,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 AI
@@ -9398,7 +9534,7 @@ wv
 ox
 tn
 BK
-vd
+pD
 wv
 DH
 DH
@@ -9596,8 +9732,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -9853,8 +9989,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -9905,7 +10041,7 @@ DH
 wv
 QQ
 bV
-vd
+sd
 hl
 Jn
 cF
@@ -10060,17 +10196,17 @@ DH
 DH
 DH
 LS
-vd
-vd
+ar
+ar
 LS
-vd
-vd
+ar
+ar
 LS
-vd
-vd
+ar
+ar
 LS
-vd
-vd
+ar
+ar
 LS
 DH
 DH
@@ -10110,8 +10246,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -10154,7 +10290,7 @@ DH
 wv
 iv
 wv
-vd
+Ky
 DV
 wv
 DH
@@ -10167,7 +10303,7 @@ wv
 dt
 wv
 wv
-vd
+rB
 Kr
 wv
 wv
@@ -10317,17 +10453,17 @@ DH
 DH
 DH
 Wf
-vd
-vd
+Hi
+Hi
 ez
-vd
-vd
+Hi
+Hi
 ez
-vd
-vd
+Hi
+Hi
 ez
-vd
-vd
+Hi
+Hi
 Ed
 DH
 DH
@@ -10367,8 +10503,8 @@ DH
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -10624,8 +10760,8 @@ DH
 DH
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -10881,8 +11017,8 @@ DH
 DH
 AI
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -11138,8 +11274,8 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -11395,8 +11531,8 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -11652,8 +11788,8 @@ DH
 DH
 DH
 DH
-vd
-vd
+EV
+EV
 DH
 DH
 DH
@@ -11909,8 +12045,8 @@ DH
 DH
 DH
 eN
-vd
-vd
+EV
+EV
 cn
 DH
 DH
@@ -17562,7 +17698,7 @@ DH
 wJ
 UL
 uF
-vd
+of
 UL
 wJ
 DH
@@ -18317,19 +18453,19 @@ AI
 kx
 LS
 LS
-vd
-vd
+ar
+ar
 LS
 LS
-vd
+Dd
 cn
 DH
 eN
-vd
+Dd
 LS
 LS
-vd
-vd
+ar
+ar
 LS
 LS
 DH
@@ -18574,15 +18710,15 @@ AI
 kx
 LS
 db
-vd
+Uu
 JS
 db
 LS
-vd
+cL
 cy
-vd
+Dd
 wW
-vd
+cL
 LS
 rD
 mR
@@ -18834,7 +18970,7 @@ rl
 Yh
 ph
 hJ
-vd
+ar
 UL
 UL
 UL
@@ -19347,7 +19483,7 @@ LS
 KM
 BS
 ph
-vd
+VX
 Br
 UL
 UL
@@ -19362,8 +19498,8 @@ sP
 LS
 DH
 fi
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -19619,8 +19755,8 @@ LS
 LS
 DH
 DH
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -19862,7 +19998,7 @@ qN
 ph
 ph
 yr
-vd
+ar
 UL
 UL
 UL
@@ -19876,8 +20012,8 @@ DH
 LS
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -20116,7 +20252,7 @@ DH
 DH
 LS
 db
-vd
+VX
 LG
 db
 LS
@@ -20133,8 +20269,8 @@ UL
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -20390,8 +20526,8 @@ LS
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -20630,7 +20766,7 @@ DH
 DH
 LS
 qN
-vd
+VX
 Qc
 qN
 LS
@@ -20647,8 +20783,8 @@ DV
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -20842,7 +20978,7 @@ EV
 EV
 EV
 EV
-vd
+EV
 AI
 AI
 AI
@@ -20890,7 +21026,7 @@ tH
 UI
 UI
 uZ
-vd
+ar
 UL
 UL
 UL
@@ -20904,8 +21040,8 @@ DH
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -21097,10 +21233,10 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -21151,7 +21287,7 @@ LS
 UL
 UQ
 uF
-vd
+of
 UL
 LS
 qM
@@ -21161,8 +21297,8 @@ LS
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -21356,12 +21492,12 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -21418,8 +21554,8 @@ nL
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -21614,12 +21750,12 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -21675,8 +21811,8 @@ zF
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -21875,23 +22011,23 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -21918,7 +22054,7 @@ tH
 fJ
 UI
 mh
-vd
+ar
 UL
 UL
 UL
@@ -21932,8 +22068,8 @@ zF
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -22133,24 +22269,24 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -22176,11 +22312,11 @@ hW
 xf
 un
 LS
-vd
+cL
 AI
 AI
 AI
-vd
+cL
 LS
 rn
 sP
@@ -22189,8 +22325,8 @@ xc
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -22405,10 +22541,10 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -22446,8 +22582,8 @@ LS
 LS
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -22664,8 +22800,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -22703,8 +22839,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -22921,9 +23057,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 AI
@@ -22960,8 +23096,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -23179,8 +23315,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -23216,9 +23352,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23436,14 +23572,14 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23472,10 +23608,10 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23694,13 +23830,13 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23727,10 +23863,10 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23956,9 +24092,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 AI
@@ -23983,10 +24119,10 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -24214,34 +24350,34 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -24473,31 +24609,31 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -25830,14 +25966,14 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -26087,15 +26223,15 @@ DH
 DH
 DH
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 DH
@@ -26345,15 +26481,15 @@ DH
 DH
 DH
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 DH
 DH
@@ -26593,24 +26729,24 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -26850,15 +26986,15 @@ DH
 DH
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -26867,8 +27003,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -27106,17 +27242,15 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-AI
-AI
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 AI
@@ -27125,8 +27259,10 @@ AI
 AI
 AI
 AI
-vd
-vd
+AI
+AI
+EV
+EV
 AI
 AI
 DH
@@ -27363,7 +27499,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 AI
 zU
@@ -27382,9 +27518,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 DH
@@ -27619,8 +27755,8 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 zU
@@ -27641,8 +27777,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -27876,7 +28012,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 AI
 AI
@@ -27898,9 +28034,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 DH
@@ -28132,8 +28268,8 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -28156,8 +28292,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -28389,7 +28525,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 AI
 AI
@@ -28414,8 +28550,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -28646,7 +28782,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 AI
 AI
@@ -28671,9 +28807,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 DH
 DH
@@ -28902,8 +29038,8 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -28929,8 +29065,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -29159,7 +29295,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 AI
 AI
@@ -29186,8 +29322,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -29416,7 +29552,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 AI
 AI
@@ -32755,7 +32891,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 AI
 AI
@@ -32779,8 +32915,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -33012,7 +33148,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 zU
 zU
@@ -33035,8 +33171,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 AI
 DH
@@ -33269,11 +33405,11 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 zU
 Po
-vd
+gc
 zU
 CL
 BY
@@ -33292,7 +33428,7 @@ AI
 AI
 AI
 AI
-vd
+EV
 AI
 AI
 DH
@@ -33526,7 +33662,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 zU
 pS
@@ -33548,8 +33684,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -33783,7 +33919,7 @@ DH
 DH
 AI
 AI
-vd
+EV
 AI
 zU
 jh
@@ -33804,8 +33940,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -34040,28 +34176,28 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 zU
 zU
-vd
+hZ
 zU
-vd
-zU
-zU
+hZ
 zU
 zU
 zU
 zU
 zU
-AI
-AI
+zU
+zU
 AI
 AI
 AI
 AI
 AI
-vd
+AI
+AI
+EV
 AI
 DH
 DH
@@ -34297,7 +34433,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 zU
 hu
@@ -34305,7 +34441,7 @@ ti
 zU
 zX
 VJ
-vd
+FC
 As
 zU
 Wz
@@ -34317,8 +34453,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -34554,13 +34690,13 @@ DH
 DH
 DH
 AI
-vd
-vd
+EV
+EV
 zU
 hU
 aJ
 zU
-vd
+dj
 KL
 dr
 hE
@@ -34574,8 +34710,8 @@ AI
 AI
 AI
 AI
-vd
-vd
+EV
+EV
 AI
 DH
 DH
@@ -34812,7 +34948,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 zU
 zU
 zU
@@ -34831,7 +34967,7 @@ AI
 AI
 AI
 AI
-vd
+EV
 AI
 DH
 DH
@@ -35069,7 +35205,7 @@ DH
 DH
 DH
 AI
-vd
+EV
 AI
 AI
 AI
@@ -35086,9 +35222,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 DH
 DH
@@ -35326,8 +35462,8 @@ DH
 DH
 DH
 DH
-vd
-vd
+EV
+EV
 AI
 AI
 AI
@@ -35341,9 +35477,9 @@ AI
 AI
 AI
 AI
-vd
-vd
-vd
+EV
+EV
+EV
 AI
 AI
 DH
@@ -35584,21 +35720,21 @@ DH
 DH
 DH
 AI
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
+EV
 AI
 AI
 DH
@@ -38980,7 +39116,7 @@ DG
 WV
 PA
 DG
-vd
+xg
 PC
 tF
 DH
@@ -47406,7 +47542,7 @@ UL
 NW
 jJ
 ej
-vd
+xz
 jy
 dL
 UL
@@ -48687,14 +48823,14 @@ DH
 DH
 DH
 Wf
-vd
-vd
-vd
-vd
-vd
-vd
-vd
-vd
+Hi
+Hi
+Hi
+Hi
+Hi
+Hi
+Hi
+Hi
 Ed
 DH
 DH
@@ -53495,7 +53631,7 @@ DH
 DH
 eN
 wv
-vd
+fg
 tz
 uz
 wv
@@ -53754,7 +53890,7 @@ CA
 dL
 fo
 vN
-vd
+VX
 JO
 lL
 DH
@@ -54781,8 +54917,8 @@ DH
 CA
 jO
 bA
-vd
-vd
+VX
+VX
 JO
 DV
 yH
@@ -56838,7 +56974,7 @@ CA
 dL
 VV
 td
-vd
+dP
 wv
 gz
 wv
@@ -57093,7 +57229,7 @@ DH
 DH
 CA
 dL
-vd
+yt
 uj
 td
 fs
@@ -57354,7 +57490,7 @@ qO
 hG
 td
 td
-vd
+JC
 dS
 wv
 DH

--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -3817,7 +3817,7 @@
 "NG" = (
 /obj/machinery/button/door{
 	id = 23001;
-	name = "Pharamcy Shutters"
+	name = "Pharmacy Shutters"
 	},
 /turf/closed/wall/mineral/concrete/blastproof,
 /area/f13/building)

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -752,7 +752,6 @@
 "aYb" = (
 /obj/structure/bed/wooden,
 /obj/item/nullrod/tribal_knife{
-	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn.";
 	name = "shiv"
 	},
 /obj/machinery/light/small{
@@ -4388,10 +4387,6 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/building)
-"flC" = (
-/obj/item/hatchet,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "fmb" = (
 /obj/structure/cross,
 /turf/open/indestructible/ground/outside/dirt/harsh{
@@ -7320,10 +7315,6 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/building)
-"iWx" = (
-/obj/item/trash/f13/dog,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "iWD" = (
 /obj/machinery/light{
 	dir = 4
@@ -7548,13 +7539,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
-"jie" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	desc = "A crumpled, time-worn piece of paper. It looks to be a regretful letter to his wives, dated just prior to the Great War.";
-	name = "Woodsmans Note"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jif" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
@@ -11834,12 +11818,6 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"oDF" = (
-/obj/item/clothing/under/pants/classicjeans,
-/obj/item/clothing/suit/jacket/flannel/brown,
-/obj/item/clothing/head/beanie/stripedred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "oDG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -15044,16 +15022,6 @@
 	icon_state = "wide_light-broken2"
 	},
 /area/f13/wasteland)
-"suw" = (
-/obj/item/twohanded/chainsaw{
-	attack_verb = list("sawed","shredded","felled");
-	desc = "Manufactured by House Industries with a hard-nose solid 32-inch bar and tungsten carbide teeth, it looks like it could probably saw through a tank. The engine housing is pure pre-War alloy, and contains a microvibration antifouler.";
-	name = "Woodsman Special";
-	toolspeed = 0.8;
-	wound_bonus = 20
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "suz" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -83954,9 +83922,9 @@ dmU
 rPW
 eUg
 eUg
-eUg
-eUg
-eUg
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -84211,9 +84179,9 @@ dmU
 rPW
 rPW
 owD
-oDF
-suw
-eUg
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -84468,9 +84436,9 @@ dmU
 rPW
 rPW
 owD
-tvL
-jie
-eUg
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -84725,9 +84693,9 @@ rPW
 rPW
 rPW
 owD
-iWx
-flC
-eUg
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -84982,9 +84950,9 @@ rPW
 rPW
 eUg
 eUg
-eUg
-eUg
-eUg
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -7110,6 +7110,10 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
+"iEG" = (
+/obj/item/trash/f13/dog,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iFW" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "greendirtysolid"
@@ -9549,6 +9553,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
+/area/f13/caves)
+"lUq" = (
+/obj/item/clothing/under/pants/classicjeans,
+/obj/item/clothing/suit/jacket/flannel/brown,
+/obj/item/clothing/head/beanie/stripedred,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lUy" = (
 /obj/structure/car/rubbish3{
@@ -19341,6 +19351,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
+"xKh" = (
+/obj/item/hatchet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xKi" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -19549,6 +19563,16 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood/wood_wide,
 /area/f13/building)
+"xZf" = (
+/obj/item/twohanded/chainsaw{
+	attack_verb = list("sawed","shredded","felled");
+	desc = "Manufactured by House Industries with a hard-nose solid 32-inch bar and tungsten carbide teeth, it looks like it could probably saw through a tank. The engine housing is pure pre-War alloy, and contains a microvibration antifouler.";
+	name = "Woodsman Special";
+	toolspeed = 0.8;
+	wound_bonus = 20
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "yaA" = (
 /obj/item/roller,
 /turf/open/floor/plasteel/f13{
@@ -19676,6 +19700,13 @@
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"yii" = (
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	desc = "A crumpled, time-worn piece of paper. It looks to be a regretful letter to his wives, dated just prior to the Great War.";
+	name = "Woodsmans Note"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "yim" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -83922,9 +83953,9 @@ dmU
 rPW
 eUg
 eUg
-rPW
-rPW
-rPW
+eUg
+eUg
+eUg
 rPW
 rPW
 rPW
@@ -84179,9 +84210,9 @@ dmU
 rPW
 rPW
 owD
-rPW
-rPW
-rPW
+lUq
+xZf
+eUg
 rPW
 rPW
 rPW
@@ -84436,9 +84467,9 @@ dmU
 rPW
 rPW
 owD
-rPW
-rPW
-rPW
+tvL
+yii
+eUg
 rPW
 rPW
 rPW
@@ -84693,9 +84724,9 @@ rPW
 rPW
 rPW
 owD
-rPW
-rPW
-rPW
+iEG
+xKh
+eUg
 rPW
 rPW
 rPW
@@ -84950,9 +84981,9 @@ rPW
 rPW
 eUg
 eUg
-rPW
-rPW
-rPW
+eUg
+eUg
+eUg
 rPW
 rPW
 rPW

--- a/code/game/turfs/f13concrete.dm
+++ b/code/game/turfs/f13concrete.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 
 /turf/closed/wall/mineral/concrete
 	name = "supermart wall"
-	desc = "A pre-War supermart wall made of reinforced concrete. This one looks newly built"
+	desc = "A pre-War supermart wall made of reinforced concrete. This one looks newly-built."
 	icon = 'icons/turf/walls/f13superstore.dmi'
 	icon_state = "supermart"
 	icon_type_smooth = "supermart"
@@ -167,11 +167,11 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 	explosion_block = 2
 	smooth = SMOOTH_TRUE
 	sheet_type = /obj/item/stack/sheet/mineral/concrete
-	canSmoothWith = list(/turf/closed/wall/f13/supermart, /turf/closed/wall/mineral/concrete, /turf/closed/wall,)
+	canSmoothWith = list(/turf/closed/wall/f13/supermart, /turf/closed/wall/mineral/concrete, /turf/closed/wall/mineral/concrete/blastproof, /turf/closed/wall,)
 
 /turf/closed/wall/mineral/concrete/blastproof
-	name = "fortified supermart wall"
-	desc = "A pre-War supermart that has been coated with plastic to reduce cracking from overpressure."
+	name = "fortified concrete wall"
+	desc = "A pre-War concrete that has been coated with plastic to reduce cracking from overpressure."
 	hardness = 80
 	explosion_block = 5
 	slicing_duration = 150 //50% longer than usual

--- a/code/modules/fallout/obj/structures/setpieces.dm
+++ b/code/modules/fallout/obj/structures/setpieces.dm
@@ -1,0 +1,8 @@
+// USE INSTEAD OF /obj/machinery/pool/drain
+/obj/structure/drain
+	name = "drain"
+	icon = 'icons/obj/machines/pool.dmi'
+	icon_state = "drain"
+	desc = "A suction system to remove the contents of the pool, and sometimes small objects. Do not insert fingers."
+	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE

--- a/code/modules/pool/pool_drain.dm
+++ b/code/modules/pool/pool_drain.dm
@@ -1,3 +1,5 @@
+// DO NOT MAP THIS IN WITHOUT A POOL CONTROLLER
+// FOR COSMETIC MAPPING, USE /obj/structure/drain
 /obj/machinery/pool/drain
 	name = "drain"
 	icon_state = "drain"

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -2148,6 +2148,7 @@
 #include "code\modules\fallout\obj\structures\fridge.dm"
 #include "code\modules\fallout\obj\structures\mob_spawners.dm"
 #include "code\modules\fallout\obj\structures\obstacle.dm"
+#include "code\modules\fallout\obj\structures\setpieces.dm"
 #include "code\modules\fallout\obj\structures\simple_door.dm"
 #include "code\modules\fallout\obj\structures\table_frames.dm"
 #include "code\modules\fallout\obj\structures\tables_racks.dm"


### PR DESCRIPTION
This is semi-urgent.
- Drains cause massive runtimes.
- Mapmerge didn't seem to be done correctly, resulting in odd and missing keys.
- Missing turfs were re-added.
This was done by just copying the new changes onto a known good copy, so there's a decent chance I missed something, sorry. Still better than hundreds of runtimes a second.