### PR TITLE
Port fix for infinite APC power from Citadel

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1355,13 +1355,7 @@
 			charging = APC_NOT_CHARGING
 			chargecount = 0
 			longtermpower = max(-10,longtermpower - 2)
-			if(cell.charge >= cur_used)
-				cell.use(GLOB.CELLRATE * cur_used)
-			else
-				// This turns everything off in the case that there is still a charge left on the battery, just not enough to run the room.
-				equipment = autoset(equipment, 0)
-				lighting = autoset(lighting, 0)
-				environ = autoset(environ, 0)
+			cell.use(min(GLOB.CELLRATE * cur_used, cell.charge))
 
 		// set channels based on remaining charge
 


### PR DESCRIPTION
Ports a fix for APCs having infinite power if one tick tries to consume a number of kilojoules higher than the cell's number of watt-ticks, because of a missing conversion factor.