### PR TITLE
Removes carpal tunnel syndrome from the game

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -587,7 +587,39 @@
 	var/advanced = 0
 	tooadvanced = TRUE //technophobes will still need to be able to make ammo	//not anymore they wont
 /obj/machinery/autolathe/ammo/attackby(obj/item/O, mob/user, params)
-	..()
+	if(istype(O, /obj/item/storage/bag/casings))
+		var/obj/item/storage/bag/casings/casings_bag = O
+		var/datum/component/material_container/mats = GetComponent(/datum/component/material_container)
+		var/count = 0
+		if(INTERACTING_WITH(user, src))
+			return
+		if(!length(casings_bag.contents))
+			to_chat(user, span_warning("There's nothing in \the [casings_bag] to load into \the [src]!"))
+			return
+		to_chat(user, span_notice("You start dumping \the [casings_bag] into \the [src]."))
+		if(!do_after(user, 2 SECONDS, target = src))
+			to_chat(user, span_notice("You stop dumping \the [casings_bag] into \the [src]."))
+			return
+		for(var/obj/item/ammo_casing/casing in casings_bag.contents)
+			var/mat_amount = mats.get_item_material_amount(casing)
+			if(!mat_amount)
+				continue
+			if(!mats.has_space(mat_amount))
+				to_chat(user, span_warning("You can't fit any more in \the [src]!"))
+				return
+			if(!SEND_SIGNAL(casings_bag, COMSIG_TRY_STORAGE_TAKE, casing, src))
+				continue
+			// Forgive me for this.
+			if(mats.after_insert)
+				mats.after_insert.Invoke(casing, mats.last_inserted_id, mats.insert_item(casing))
+			// I blame whoever wrote material containers.
+			qdel(casing)
+			count++
+		if(count > 0)
+			to_chat(user, span_notice("You insert [count] casing\s into \the [src]."))
+		else
+			to_chat(user, span_warning("There aren't any casings in \the [O] to recycle!"))
+		return
 	if(!simple && panel_open)
 		if(istype(O, /obj/item/book/granter/crafting_recipe/gunsmith_one))
 			to_chat(user, "<span class='notice'>You upgrade [src] with simple ammunition schematics.</span>")
@@ -609,8 +641,7 @@
 			advanced = 1
 			qdel(O)
 	else
-		attack_hand(user)
-		return TRUE
+		return ..()
 
 /obj/machinery/autolathe/ammo/can_build(datum/design/D, amount = 1)
 	if("Simple Ammo" in D.category)

--- a/code/modules/farming/farming_structures.dm
+++ b/code/modules/farming/farming_structures.dm
@@ -239,53 +239,64 @@
 	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 
-/obj/structure/legion_extractor/proc/seedify(obj/item/O, t_max, obj/structure/legion_extractor/extractor, mob/living/user)
+/obj/structure/legion_extractor/proc/seedify(obj/item/O, t_max, mob/living/user)
 	var/t_amount = 0
-	var/list/seeds = list()
 	if(t_max == -1)
 		t_max = rand(1,2) //Slightly worse than the actual thing
 
-	var/seedloc = O.loc
-	if(extractor)
-		seedloc = extractor.loc
+	var/atom/seedloc = src.drop_location()
 
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/))
 		var/obj/item/reagent_containers/food/snacks/grown/F = O
 		if(F.seed)
 			if(user && !user.temporarilyRemoveItemFromInventory(O)) //couldn't drop the item
 				return
-			while(t_amount < t_max)
-				var/obj/item/seeds/t_prod = F.seed.Copy()
-				seeds.Add(t_prod)
-				t_prod.forceMove(seedloc)
-				t_amount++
-			qdel(O)
-			return seeds
-
-	else if(istype(O, /obj/item/grown))
-		var/obj/item/grown/F = O
-		if(F.seed)
-			if(user && !user.temporarilyRemoveItemFromInventory(O))
+			if (SEND_SIGNAL(O.loc, COMSIG_CONTAINS_STORAGE) && !SEND_SIGNAL(O.loc, COMSIG_TRY_STORAGE_TAKE, O, null)) // couldn't remove from storage
 				return
 			while(t_amount < t_max)
 				var/obj/item/seeds/t_prod = F.seed.Copy()
 				t_prod.forceMove(seedloc)
 				t_amount++
 			qdel(O)
-		return 1
-
-	return 0
+	else if(istype(O, /obj/item/grown))
+		var/obj/item/grown/F = O
+		if(F.seed)
+			if(user && !user.temporarilyRemoveItemFromInventory(O))
+				return
+			if (SEND_SIGNAL(O.loc, COMSIG_CONTAINS_STORAGE) && !SEND_SIGNAL(O.loc, COMSIG_TRY_STORAGE_TAKE, O, null))
+				return
+			while(t_amount < t_max)
+				var/obj/item/seeds/t_prod = F.seed.Copy()
+				t_prod.forceMove(seedloc)
+				t_amount++
+			qdel(O)
+	return t_amount
 
 /obj/structure/legion_extractor/attackby(obj/item/O, mob/user, params)
-
 	if(default_unfasten_wrench(user, O)) //So we can move them around
 		return
-
-	else if(seedify(O,-1, src, user))
-		to_chat(user, SPAN_NOTICE("You extract some seeds."))
+	else if(istype(O, /obj/item/storage/bag/plants))
+		var/obj/item/storage/bag/plants/PB = O
+		if(!PB.contents.len)
+			to_chat(user, span_warning("There's nothing in \the [PB]!"))
+			return
+		to_chat(user, span_info("You start to empty \the [PB] into \the [src]."))
+		var/count = 0
+		if(!do_after(user, 2 SECONDS, target = src))
+			return
+		for(var/obj/item/G in PB.contents)
+			count += seedify(G, -1, user) // seedify handles removing applicable items from storage
+		if(count > 0)
+			to_chat(user, span_info("You empty \the [PB] into \the [src]."))
+			playsound(loc, 'sound/effects/blobattack.ogg', 25, 1, -1)
+		else
+			to_chat(user, span_warning("You can't extract seeds from anything in \the [PB]!"))
+		return
+	else if(seedify(O, -1, user))
+		to_chat(user, span_notice("You extract some seeds."))
 		return
 	else if(user.a_intent != INTENT_HARM)
-		to_chat(user, SPAN_WARNING("You can't extract any seeds from \the [O.name]!"))
+		to_chat(user, span_warning("You can't extract any seeds from \the [O]!"))
 	else
 		return ..()
 

--- a/code/modules/farming/farming_structures.dm
+++ b/code/modules/farming/farming_structures.dm
@@ -33,39 +33,53 @@
 	. = ..()
 	. += "<span class='notice'>It is currently [open?"open, letting you pour liquids in.":"closed, letting you draw liquids from the tap."]</span>"
 
-/obj/structure/fermenting_barrel/proc/makeWine(obj/item/reagent_containers/food/snacks/grown/fruit)
-	var/amount = fruit.seed.potency / 4
-	if(fruit.distill_reagent)
-		reagents.add_reagent(fruit.distill_reagent, amount)
-	else
-		var/data = list()
-		data["names"] = list("[initial(fruit.name)]" = 1)
-		data["color"] = fruit.filling_color
-		data["boozepwr"] = fruit.wine_power
-		if(fruit.wine_flavor)
-			data["tastes"] = list(fruit.wine_flavor = 1)
+/obj/structure/fermenting_barrel/proc/makeWine(list/obj/item/reagent_containers/food/snacks/grown/fruits)
+	for(var/obj/item/reagent_containers/food/snacks/grown/fruit in fruits)
+		var/amount = fruit.seed.potency / 4
+		if(fruit.distill_reagent)
+			reagents.add_reagent(fruit.distill_reagent, amount)
 		else
-			data["tastes"] = list(fruit.tastes[1] = 1)
-		reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, amount, data)
-	qdel(fruit)
+			var/data = list()
+			data["names"] = list("[initial(fruit.name)]" = 1)
+			data["color"] = fruit.filling_color
+			data["boozepwr"] = fruit.wine_power
+			if(fruit.wine_flavor)
+				data["tastes"] = list(fruit.wine_flavor = 1)
+			else
+				data["tastes"] = list(fruit.tastes[1] = 1)
+			reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, amount, data)
+		qdel(fruit)
 	playsound(src, 'sound/effects/bubbles.ogg', 50, TRUE)
 
 /obj/structure/fermenting_barrel/attackby(obj/item/I, mob/user, params)
 	var/obj/item/reagent_containers/food/snacks/grown/fruit = I
 	if(istype(fruit))
 		if(!fruit.can_distill)
-			to_chat(user, "<span class='warning'>You can't distill this into anything...</span>")
+			to_chat(user, span_warning("You can't ferment this into anything..."))
 			return TRUE
 		else if(!user.transferItemToLoc(I,src))
-			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
+			to_chat(user, span_warning("[I] is stuck to your hand!"))
 			return TRUE
-		to_chat(user, "<span class='notice'>You place [I] into [src] to start the fermentation process.</span>")
-		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * speed_multiplier)
+		to_chat(user, span_notice("You place [I] into [src] to start the fermentation process."))
+		addtimer(CALLBACK(src, .proc/makeWine, list(fruit)), rand(8 SECONDS, 12 SECONDS) * speed_multiplier)
 		return TRUE
-	var/obj/item/W = I
-	if(W)
-		if(W.is_refillable())
-			return FALSE //so we can refill them via their afterattack.
+	else if(SEND_SIGNAL(I, COMSIG_CONTAINS_STORAGE) && do_after(user, 2 SECONDS, target = src))
+		var/list/storage_contents = list()
+		SEND_SIGNAL(I, COMSIG_TRY_STORAGE_RETURN_INVENTORY, storage_contents)
+		var/list/fruits = list()
+		for(var/obj/item in storage_contents)
+			fruit = item
+			if(!istype(fruit) || !fruit.can_distill || !SEND_SIGNAL(I, COMSIG_TRY_STORAGE_TAKE, fruit, src))
+				continue
+			fruits += fruit
+		if (length(fruits))
+			addtimer(CALLBACK(src, .proc/makeWine, fruits), rand(8 SECONDS, 12 SECONDS) * speed_multiplier)
+			to_chat(user, span_notice("You fill \the [src] from \the [I] and start the fermentation process."))
+		else
+			to_chat(user, span_warning("There's nothing in \the [I] that you can ferment!"))
+		return TRUE
+	if(I?.is_refillable())
+		return FALSE //so we can refill them via their afterattack.
 	else
 		return ..()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -97,10 +97,11 @@
 				update_icon()
 			return TRUE
 
-		if(istype(O, /obj/item/storage/bag))
-			var/obj/item/storage/P = O
+		if(SEND_SIGNAL(O, COMSIG_CONTAINS_STORAGE))
+			var/list/storage_contents = list()
+			SEND_SIGNAL(O, COMSIG_TRY_STORAGE_RETURN_INVENTORY, storage_contents) // list mutation, ew
 			var/loaded = 0
-			for(var/obj/G in P.contents)
+			for(var/obj/G in storage_contents)
 				if(contents.len >= max_n_of_items)
 					break
 				if(accept_check(G))
@@ -670,10 +671,9 @@
 	proj_pass_rate = 70
 	pass_flags = LETPASSTHROW
 	pass_flags_self = PASSTABLE | LETPASSTHROW
-	var/climbable = TRUE
 
 /obj/machinery/smartfridge/bottlerack/grownbin/accept_check(obj/item/O)
-	if(istype(O, /obj/item/reagent_containers/food/snacks/grown))
+	if(istype(O, /obj/item/reagent_containers/food/snacks/grown) || istype(O, /obj/item/grown))
 		return TRUE
 	return FALSE
 
@@ -688,7 +688,13 @@
 	max_n_of_items = 100
 
 /obj/machinery/smartfridge/bottlerack/alchemy_rack/accept_check(obj/item/O)
-	if(istype(O, /obj/item/reagent_containers/pill/patch) || istype(O, /obj/item/reagent_containers/glass/bottle/primitive) || istype(O, /obj/item/stack/medical/poultice) || istype(O, /obj/item/smelling_salts))
+	var/static/list/alchemyrack_typecache = typecacheof(list(
+		/obj/item/reagent_containers/pill/patch,
+		/obj/item/reagent_containers/glass/bottle/primitive,
+		/obj/item/stack/medical/poultice,
+		/obj/item/smelling_salts
+	))
+	if(is_type_in_typecache(O, alchemyrack_typecache))
 		return TRUE
 	return FALSE
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -105,8 +105,8 @@
 	l_hand = /obj/item/gun/ballistic/automatic/pistol/n99
 	belt = /obj/item/storage/belt
 	backpack_contents = list(
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/mineral/wood = 50,
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/stack/sheet/mineral/wood/fifty = 1,
 		/obj/item/pickaxe/mini = 1,
 		/obj/item/toy/crayon/spraycan = 1,
 		/obj/item/cultivator = 1,


### PR DESCRIPTION
## About The Pull Request
- Fixes settlers getting 50 single sheets of wood and metal, rather than two stacks of 50 sheets.
- Allow seeds to be extracted in bulk via plant bags.
- Allow plants to be fermented in bulk via plant bags.
- Allow fridges and racks to be loaded automatically from *all* storage, not just bags.

## Why It's Good For The Game
I've been getting terrible wrist pain and developing repetitive stress injuries from all the repeated spam clicking and wrist movements involved in making bitters and poultices while playing Legion slave. Most stuff that requires spamclicking like that should be removed in favor of bulk actions, to save people's wrists.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog

:cl:
add: Added bulk fruit fermentation. By clicking a fermenting barrel with a plant bag, all the suitable plants in it will be fermented.
add: Added bulk seed extraction. By clicking a Legion seed extractor with a plant bag, all the suitable plants in it will have their seeds extracted.
tweak: Smartfridges like bottle racks, alchemy racks, etc. can now be loaded from ALL storage items, not just bags.
/:cl: