### PR TITLE
Mapping fixes, August 17 2022

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -1022,14 +1022,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/enclave)
 "ady" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/enclave)
 "adz" = (
@@ -13593,12 +13589,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/vault)
-"lJs" = (
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/bunker)
 "lJR" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -19573,14 +19563,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
 "rMX" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Reactor APC";
-	pixel_x = -28
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
 "rMY" = (
@@ -20550,7 +20536,6 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/bunker)
@@ -25430,6 +25415,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"xUK" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "xWe" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/simple_door/room,
@@ -25603,12 +25597,6 @@
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
-	},
-/area/f13/bunker)
-"yjB" = (
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluerustychess"
 	},
 /area/f13/bunker)
 "yjN" = (
@@ -73810,7 +73798,7 @@ mCQ
 loB
 uLV
 oqm
-qAP
+xUK
 hkR
 uLV
 oqm
@@ -79700,7 +79688,7 @@ shC
 shC
 oqm
 xim
-yjB
+mqy
 xim
 bMf
 tpW
@@ -79969,7 +79957,7 @@ oqm
 krr
 nvg
 syS
-lJs
+qgk
 oqm
 fkR
 jbp

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -14916,9 +14916,6 @@
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc/auto_name/east{
-	req_access_txt = "255"
-	},
 /obj/item/clothing/head/helmet/f13/power_armor/midwest,
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -16333,14 +16330,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "tsV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "ttq" = (

--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -5,11 +5,11 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ar" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "av" = (
 /obj/machinery/computer/camera_advanced{
 	desc = "Used to access the various cameras in the prison.";
@@ -34,12 +34,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aB" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -56,19 +56,19 @@
 	pixel_x = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aO" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aY" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -83,14 +83,14 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bp" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bq" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -110,13 +110,13 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "by" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bz" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -129,7 +129,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/f13/armor/combat/mk2,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bF" = (
 /obj/structure/sink{
 	dir = 8;
@@ -148,7 +148,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -162,7 +162,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bV" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -187,14 +187,14 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ce" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -232,26 +232,26 @@
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cn" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "co" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cq" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cs" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -259,7 +259,7 @@
 	name = "wood post"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cw" = (
 /obj/machinery/computer,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -270,32 +270,32 @@
 	dir = 5
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cB" = (
 /obj/structure/bed/wooden{
 	pixel_y = 11
 	},
 /obj/structure/bed/wooden,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cF" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cI" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cL" = (
 /obj/item/flag/legion,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cW" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2";
@@ -312,7 +312,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dh" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/pickaxe,
@@ -331,7 +331,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dm" = (
 /obj/structure/bed,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -340,16 +340,16 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dq" = (
 /obj/effect/landmark/start/f13/centurion,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dr" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dt" = (
 /obj/item/kirbyplants/random,
 /obj/structure/curtain{
@@ -357,11 +357,11 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dv" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dw" = (
 /turf/closed/wall/mineral/concrete/blastproof,
 /area/f13/building)
@@ -392,11 +392,11 @@
 	},
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dF" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dJ" = (
 /obj/structure/frame/machine,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -408,12 +408,12 @@
 "dL" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dP" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dR" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -429,7 +429,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dX" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -440,21 +440,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eh" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ej" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ep" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -463,7 +463,7 @@
 /obj/structure/bed/old,
 /obj/item/bedsheet,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "es" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -480,7 +480,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -489,19 +489,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eN" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eU" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
@@ -511,7 +511,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fg" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -519,14 +519,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fi" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fl" = (
 /obj/vehicle/ridden/wheelchair,
 /obj/machinery/light{
@@ -552,19 +552,19 @@
 /obj/effect/spawner/bundle/f13/armor/combat,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fs" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ft" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fy" = (
 /obj/structure/closet/cabinet,
 /obj/item/pda,
@@ -577,7 +577,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -590,12 +590,12 @@
 /obj/effect/landmark/start/f13/vetlegionary,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fP" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fW" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -611,7 +611,7 @@
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ge" = (
 /obj/structure/sign/poster/contraband/pinup_anthro15,
 /turf/closed/wall/f13/tunnel,
@@ -622,7 +622,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gr" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -642,7 +642,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gy" = (
 /obj/item/kirbyplants/random,
 /obj/structure/railing{
@@ -650,11 +650,11 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gz" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gB" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -663,7 +663,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gD" = (
 /obj/machinery/door/unpowered/celldoor,
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -687,7 +687,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gG" = (
 /obj/machinery/shower{
 	dir = 4
@@ -697,7 +697,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gH" = (
 /obj/machinery/light{
 	dir = 1
@@ -721,13 +721,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gW" = (
 /obj/structure/simple_door/wood{
 	name = "recovery room"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gZ" = (
 /obj/structure/camera_assembly{
 	dir = 5
@@ -737,7 +737,7 @@
 "ha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hf" = (
 /obj/machinery/vending/cigarette,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -750,7 +750,7 @@
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hu" = (
 /obj/structure/sink{
 	dir = 8;
@@ -760,7 +760,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hv" = (
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
@@ -774,7 +774,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hz" = (
 /obj/structure/debris/v3,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -788,20 +788,20 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hD" = (
 /obj/structure/bookcase{
 	icon_state = "book-3"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hF" = (
 /obj/structure/bookcase,
 /turf/open/indestructible/ground/outside/desert,
@@ -815,7 +815,7 @@
 	name = "Renegade Lieutenant"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hH" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2";
@@ -836,7 +836,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hK" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -855,7 +855,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hS" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -868,7 +868,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hV" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -877,11 +877,11 @@
 /area/f13/building)
 "hW" = (
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hZ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ie" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -904,7 +904,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "in" = (
 /obj/machinery/button/door{
 	id = 23555;
@@ -916,7 +916,7 @@
 "ir" = (
 /obj/structure/junk/small,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iu" = (
 /obj/machinery/iv_drip,
 /obj/machinery/iv_drip,
@@ -934,7 +934,7 @@
 "iv" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ix" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -953,7 +953,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iC" = (
 /obj/structure/sign/poster/contraband/pinup_topless,
 /turf/closed/wall/f13/tunnel,
@@ -967,14 +967,14 @@
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iG" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iM" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -996,13 +996,13 @@
 "iU" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iZ" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -1014,13 +1014,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jh" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jx" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
@@ -1040,7 +1040,7 @@
 /obj/structure/table/wood,
 /obj/item/binoculars,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jB" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -1048,7 +1048,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1061,17 +1061,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jN" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jO" = (
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jQ" = (
 /obj/machinery/power/apc,
 /turf/closed/wall/f13/tunnel,
@@ -1080,11 +1080,11 @@
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kc" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kf" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/stairs{
@@ -1108,7 +1108,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "km" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -1122,7 +1122,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ku" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -1136,17 +1136,17 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kx" = (
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ky" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -1185,13 +1185,13 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kX" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1205,11 +1205,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ld" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lh" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -1219,7 +1219,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lm" = (
 /obj/machinery/chem_heater,
 /obj/structure/camera_assembly{
@@ -1265,7 +1265,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lv" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/gun/ballistic/automatic/pistol/mk23,
@@ -1279,7 +1279,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lA" = (
 /mob/living/simple_animal/hostile/vault/security{
 	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
@@ -1293,14 +1293,14 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lH" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lJ" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -1311,7 +1311,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1347,14 +1347,14 @@
 	light_color = "red"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mc" = (
 /obj/structure/chair/wood/dining{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mh" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -1363,21 +1363,21 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mk" = (
 /obj/structure/lattice,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mq" = (
 /obj/item/stack/cable_coil/cyan,
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mv" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "my" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -1387,14 +1387,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mz" = (
 /obj/structure/junk/cabinet,
 /obj/structure/sign/poster/contraband/free_tonto{
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -1415,7 +1415,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mM" = (
 /obj/machinery/button/door{
 	id = 56545;
@@ -1426,14 +1426,14 @@
 "mO" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mR" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "na" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1442,7 +1442,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nc" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/under/rank/prisoner,
@@ -1468,7 +1468,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ng" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1480,7 +1480,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "np" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -1489,7 +1489,7 @@
 /obj/structure/table,
 /obj/item/stack/circuit_stack,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nq" = (
 /obj/structure/chair/wood/dining,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1501,17 +1501,17 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nt" = (
 /obj/effect/landmark/start/f13/decanvet,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nx" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nC" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/head/helmet/f13/ncr/rangercombat/eliteriot,
@@ -1534,7 +1534,7 @@
 /obj/structure/dresser,
 /obj/item/pda,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nO" = (
 /obj/structure/debris/v1,
 /turf/open/floor/plasteel/stairs{
@@ -1547,7 +1547,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nQ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/shoes/ballandchain,
@@ -1564,7 +1564,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1586,7 +1586,7 @@
 	icon_state = "board-1"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "od" = (
 /obj/structure/simple_door/bunker{
 	name = "Medical Storage"
@@ -1602,7 +1602,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ov" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1612,7 +1612,7 @@
 	name = "Washroom"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ox" = (
 /obj/structure/closet/crate/footchest,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -1621,7 +1621,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oB" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -1633,7 +1633,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oI" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -1642,20 +1642,20 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oT" = (
 /obj/structure/junk/arcade,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pa" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pb" = (
 /obj/structure/chair/wood/dining{
 	dir = 4
@@ -1665,7 +1665,7 @@
 "ph" = (
 /obj/effect/landmark/start/f13/venator,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pj" = (
 /obj/structure/table,
 /obj/item/integrated_circuit/logic/binary/and,
@@ -1681,11 +1681,11 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pk" = (
 /obj/effect/landmark/start/f13/orator,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pn" = (
 /obj/structure/junk/drawer{
 	icon_state = "junk_bench"
@@ -1709,7 +1709,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pB" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1717,7 +1717,7 @@
 "pD" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pE" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1727,7 +1727,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pI" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1740,7 +1740,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pN" = (
 /obj/machinery/power/rtg,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1752,13 +1752,13 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken5"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pW" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -1771,7 +1771,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qd" = (
 /obj/structure/simple_door/bunker{
 	name = "Pharmacy"
@@ -1796,11 +1796,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ql" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1827,7 +1827,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qx" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -1837,7 +1837,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -1852,14 +1852,14 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qC" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qD" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -1873,7 +1873,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qG" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/glass,
@@ -1882,7 +1882,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qI" = (
 /obj/structure/table/snooker{
 	dir = 9
@@ -1898,20 +1898,20 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qN" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qO" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qP" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1921,7 +1921,7 @@
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rf" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -1934,7 +1934,7 @@
 	pixel_y = -32
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rl" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -1942,13 +1942,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rn" = (
 /obj/structure/bookcase{
 	icon_state = "book-3"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ro" = (
 /obj/structure/lattice,
 /turf/closed/indestructible/rock{
@@ -1959,12 +1959,12 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rq" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ru" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -1986,44 +1986,44 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rB" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-2"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rD" = (
 /obj/structure/bookcase{
 	icon_state = "book-4"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rQ" = (
 /obj/structure/railing{
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rU" = (
 /obj/structure/closet/crate{
 	anchored = 1;
 	can_be_unanchored = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rX" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sc" = (
 /obj/structure/bed/mattress/pregame,
 /obj/structure/camera_assembly,
@@ -2035,13 +2035,13 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sl" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2050,7 +2050,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sy" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -2074,11 +2074,11 @@
 /area/f13/building)
 "sP" = (
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sT" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sU" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -2086,10 +2086,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sW" = (
 /turf/closed/indestructible/f13/obsidian,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sY" = (
 /obj/machinery/light{
 	dir = 1
@@ -2100,7 +2100,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ta" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -2111,42 +2111,42 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "td" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ti" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tj" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tl" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tn" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tv" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -2161,13 +2161,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tB" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tF" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -2176,7 +2176,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tH" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
@@ -2186,10 +2186,10 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tI" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ua" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2203,7 +2203,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uf" = (
 /obj/machinery/door/poddoor{
 	id = 5654
@@ -2225,23 +2225,23 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ui" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uj" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "un" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "up" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -2253,30 +2253,30 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "us" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uz" = (
 /obj/structure/bed/wooden,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uB" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uF" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uH" = (
 /obj/structure/simple_door/bunker{
 	name = "Service Ladder"
@@ -2293,7 +2293,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uL" = (
 /mob/living/simple_animal/hostile/renegade/engie{
 	desc = "Demolitions and engineering expert.";
@@ -2322,11 +2322,11 @@
 	pixel_x = 15
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uW" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uZ" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2336,7 +2336,7 @@
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "va" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -2344,13 +2344,13 @@
 "vd" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ve" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vg" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/granter/trait/pa_wear,
@@ -2363,12 +2363,12 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken5"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vi" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vj" = (
 /obj/structure/toilet/secret/high_loot{
 	dir = 8
@@ -2378,7 +2378,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vk" = (
 /obj/structure/camera_assembly,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2419,7 +2419,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2438,7 +2438,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2458,7 +2458,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vS" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -2487,7 +2487,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wk" = (
 /obj/structure/simple_door/bunker{
 	name = "Machine Shop & Generator"
@@ -2514,7 +2514,7 @@
 /area/f13/building)
 "wv" = (
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wz" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
@@ -2523,7 +2523,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wH" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt{
@@ -2547,7 +2547,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wJ" = (
 /obj/structure/barricade/bars{
 	max_integrity = 1200;
@@ -2556,7 +2556,7 @@
 	},
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wN" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2565,26 +2565,26 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wO" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wQ" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-2"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wR" = (
 /obj/structure/fluff/railing{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wT" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt{
@@ -2629,14 +2629,14 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wW" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wY" = (
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/wall/f13/tunnel,
@@ -2645,20 +2645,20 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/hos,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xf" = (
 /obj/structure/chair/wood/fancy,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xg" = (
 /obj/structure/fluff/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xk" = (
 /obj/structure/sign/warning/explosives,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -2668,7 +2668,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xo" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -2679,7 +2679,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xt" = (
 /obj/structure/junk/micro,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2696,7 +2696,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xx" = (
 /obj/structure/simple_door/glass{
 	name = "Psychology Office"
@@ -2707,7 +2707,7 @@
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xD" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -2724,7 +2724,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xH" = (
 /obj/structure/camera_assembly{
 	dir = 10
@@ -2740,7 +2740,7 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xN" = (
 /obj/item/ingot/adamantine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2769,7 +2769,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yr" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2780,7 +2780,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yt" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2790,7 +2790,7 @@
 	name = "renegade telecomms server"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2813,7 +2813,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yP" = (
 /obj/item/paper/fluff/jobs/medical/hippocratic,
 /obj/structure/table/glass,
@@ -2822,7 +2822,7 @@
 "yW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yX" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/dice,
@@ -2830,7 +2830,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yY" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -2839,7 +2839,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yZ" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -2847,7 +2847,7 @@
 	},
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "zc" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -2873,7 +2873,7 @@
 "zF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "zH" = (
 /mob/living/simple_animal/hostile/vault/security{
 	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
@@ -2891,14 +2891,14 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "zU" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "zX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "zZ" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2912,7 +2912,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ad" = (
 /obj/machinery/door/unpowered/celldoor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2922,13 +2922,13 @@
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ag" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ai" = (
 /obj/machinery/camera,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2938,7 +2938,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Aw" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -2957,7 +2957,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "AF" = (
 /obj/machinery/light{
 	dir = 4
@@ -2966,7 +2966,7 @@
 /area/f13/building)
 "AI" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "AK" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2977,7 +2977,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "AZ" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -2985,7 +2985,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Be" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -2994,7 +2994,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Bg" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3032,7 +3032,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Bw" = (
 /mob/living/simple_animal/hostile/megafauna/behemoth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3063,24 +3063,24 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BP" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -3094,14 +3094,14 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BR" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BS" = (
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "BY" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -3111,7 +3111,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Cb" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -3121,35 +3121,35 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Cd" = (
 /obj/structure/window/fulltile/house,
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ce" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Cl" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Co" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Cr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "CA" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "CB" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -3166,7 +3166,7 @@
 "CL" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "CQ" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -3181,7 +3181,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "CS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/glass,
@@ -3191,7 +3191,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "CU" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -3199,14 +3199,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Dd" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Di" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3219,7 +3219,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Dt" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -3227,7 +3227,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Dw" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3236,12 +3236,12 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "DF" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "DG" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -3251,10 +3251,10 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "DH" = (
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "DM" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light{
@@ -3265,24 +3265,24 @@
 "DV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ea" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ed" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Eh" = (
 /obj/structure/curtain{
 	color = "#363636";
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "EF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3306,23 +3306,23 @@
 /obj/item/screwdriver,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "EV" = (
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "FC" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Hi" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "IE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3348,28 +3348,28 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Jm" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Jn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Jo" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Js" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Jt" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
@@ -3391,22 +3391,22 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JB" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JC" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JG" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -3414,11 +3414,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JO" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JP" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3431,7 +3431,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JS" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -3439,10 +3439,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JV" = (
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "JX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3467,7 +3467,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Kc" = (
 /obj/structure/railing/handrail/rusty/underlayer{
 	pixel_y = -4
@@ -3484,7 +3484,7 @@
 /area/f13/building)
 "Kl" = (
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Kp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -3494,11 +3494,11 @@
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Kv" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ky" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -3506,17 +3506,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KJ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -3529,7 +3529,7 @@
 /mob/living/simple_animal/hostile/renegade/defender,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KL" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -3539,13 +3539,13 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KM" = (
 /obj/structure/table/wood,
 /obj/item/melee/onehanded/knife/bowie,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KT" = (
 /obj/structure/table/wood,
 /obj/item/radio/tribal{
@@ -3554,14 +3554,14 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "KU" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "La" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3570,7 +3570,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lb" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -3579,7 +3579,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lc" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3596,7 +3596,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lg" = (
 /obj/machinery/button/door{
 	id = 5654;
@@ -3613,13 +3613,13 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lk" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lm" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged{
 	faction = list("powder");
@@ -3630,7 +3630,7 @@
 "Lo" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Lp" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -3670,7 +3670,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "LA" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/unum,
@@ -3681,7 +3681,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "LN" = (
 /obj/machinery/computer/terminal,
 /obj/structure/table/wood,
@@ -3696,10 +3696,10 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "LS" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "LT" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/gun/ballistic/automatic/pistol/m1911,
@@ -3722,7 +3722,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Me" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3730,18 +3730,18 @@
 "Mj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Mm" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Mr" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ms" = (
 /obj/machinery/vending/games,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -3753,7 +3753,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "MC" = (
 /obj/machinery/hypnochair,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -3763,7 +3763,7 @@
 	dir = 9
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "MK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3771,10 +3771,10 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "MT" = (
 /turf/open/floor/carpet/red,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "MX" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 1853;
@@ -3788,7 +3788,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Nj" = (
 /obj/machinery/door/unpowered/celldoor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3798,13 +3798,13 @@
 "No" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Np" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Nu" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -3813,7 +3813,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "NG" = (
 /obj/machinery/button/door{
 	id = 23001;
@@ -3852,7 +3852,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "NS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
@@ -3872,18 +3872,18 @@
 "NW" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "NY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "NZ" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Oc" = (
 /obj/structure/camera_assembly{
 	dir = 8
@@ -3917,13 +3917,13 @@
 "OC" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "OE" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "OU" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3939,7 +3939,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Pf" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3951,20 +3951,20 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Po" = (
 /obj/structure/table/wood/club,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ps" = (
 /obj/structure/table,
 /obj/item/documents{
 	desc = "Documents containing operational intelligence of the Renegades."
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Pu" = (
 /obj/machinery/conveyor{
 	dir = 4
@@ -3981,21 +3981,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PA" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PC" = (
 /obj/structure/fluff/railing{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PH" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -4005,17 +4005,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PI" = (
 /obj/structure/fluff/railing,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PJ" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -4027,12 +4027,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "PY" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -4040,17 +4040,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qd" = (
 /obj/structure/bookcase{
 	icon_state = "book-1"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qf" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qg" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -4071,10 +4071,10 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qp" = (
 /turf/closed/indestructible/riveted,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qs" = (
 /obj/machinery/door/unpowered/celldoor,
 /obj/machinery/door/poddoor/ert{
@@ -4088,7 +4088,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Qx" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -4113,7 +4113,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "QK" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -4122,7 +4122,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "QQ" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -4137,7 +4137,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "QS" = (
 /obj/machinery/computer/terminal,
 /obj/structure/table/reinforced,
@@ -4180,7 +4180,7 @@
 /obj/structure/chair/wood/dining,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Rv" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -4204,16 +4204,16 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "RO" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "RQ" = (
 /obj/structure/punching_bag,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "RS" = (
 /obj/structure/debris/v2,
 /obj/structure/debris/v3,
@@ -4237,11 +4237,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "RY" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "RZ" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -4254,7 +4254,7 @@
 	},
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Sl" = (
 /obj/structure/toilet/secret/low_loot,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4278,7 +4278,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "SI" = (
 /obj/machinery/power/smes,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4294,7 +4294,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ST" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
@@ -4304,7 +4304,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Td" = (
 /obj/structure/holohoop{
 	dir = 4
@@ -4314,7 +4314,7 @@
 "Tf" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "To" = (
 /obj/structure/frame/computer,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4325,13 +4325,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Tv" = (
 /obj/structure/fluff/railing{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ty" = (
 /obj/item/clothing/under/f13/psychologist,
 /obj/structure/closet/cabinet/anchored,
@@ -4343,13 +4343,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "TE" = (
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "TF" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -4378,7 +4378,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "TV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4392,7 +4392,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "TZ" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -4406,14 +4406,14 @@
 	},
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ui" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uk" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -4427,14 +4427,14 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uo" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/cyan,
 /obj/item/electronics/apc,
 /obj/item/assembly/signaler,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uq" = (
 /obj/structure/table,
 /obj/item/electronic_assembly/medium/radio{
@@ -4443,14 +4443,14 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uu" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uv" = (
 /obj/item/trash/f13/c_ration_1,
 /obj/item/trash/f13/c_ration_2{
@@ -4462,7 +4462,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Uw" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4481,7 +4481,7 @@
 	},
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "UG" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/under/rank/medical/chemist,
@@ -4500,7 +4500,7 @@
 "UI" = (
 /obj/effect/landmark/start/f13/vetlegionary,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "UJ" = (
 /obj/machinery/autolathe,
 /obj/machinery/light,
@@ -4510,7 +4510,7 @@
 /area/f13/building)
 "UL" = (
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "UP" = (
 /obj/item/stack/tile/carpet/cyan/ten,
 /obj/item/screwdriver,
@@ -4519,13 +4519,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "UQ" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "UX" = (
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
@@ -4541,7 +4541,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Vg" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -4550,14 +4550,14 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Vk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Vl" = (
 /obj/structure/sign/poster/contraband/pinup_anthro4,
 /turf/closed/wall/f13/tunnel,
@@ -4567,7 +4567,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Vs" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -4577,7 +4577,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Vu" = (
 /obj/machinery/door/poddoor/shutters/radiation,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4587,7 +4587,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "VC" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -4604,7 +4604,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "VJ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/glass/ten,
@@ -4615,7 +4615,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "VQ" = (
 /obj/machinery/door/poddoor{
 	id = 56545
@@ -4640,11 +4640,11 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "VX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Wa" = (
 /obj/structure/bed/mattress/pregame,
 /obj/machinery/light/small{
@@ -4660,31 +4660,31 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Wf" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Wm" = (
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Wx" = (
 /obj/structure/fluff/railing/corner{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Wz" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "WG" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -4718,11 +4718,11 @@
 /area/f13/building)
 "WT" = (
 /turf/open/indestructible,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "WV" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Xe" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -4735,7 +4735,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Xo" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
@@ -4747,7 +4747,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Xt" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -4757,7 +4757,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Xu" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/radiation)
@@ -4776,7 +4776,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "XG" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4808,23 +4808,23 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "XU" = (
 /obj/machinery/msgterminal{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "XW" = (
 /obj/structure/mirror,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "XZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ye" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -4832,7 +4832,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Yg" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/random,
@@ -4847,7 +4847,7 @@
 /obj/effect/landmark/start/f13/venator,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Yl" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/f13/tunnel,
@@ -4865,14 +4865,14 @@
 	icon_state = "board-1"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Ys" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "YD" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -4891,7 +4891,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "YR" = (
 /obj/machinery/defibrillator_mount/loaded,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -4909,7 +4909,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "YZ" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/mask/surgical,
@@ -4935,7 +4935,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Zl" = (
 /mob/living/simple_animal/hostile/ghoul/glowing/strong,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4950,7 +4950,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Zs" = (
 /obj/machinery/shower{
 	dir = 4
@@ -4967,14 +4967,14 @@
 /obj/structure/closet/cabinet/anchored,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "Zx" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ZA" = (
 /obj/structure/anvil/obtainable/table,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4989,7 +4989,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ZL" = (
 /obj/machinery/conveyor_switch/oneway,
 /obj/machinery/light/fo13colored/Red{
@@ -5005,7 +5005,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ZQ" = (
 /obj/item/kirbyplants/random,
 /obj/structure/curtain{
@@ -5013,11 +5013,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ZT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 
 (1,1,1) = {"
 sW

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -15,7 +15,7 @@
 	name = "Overpass Raider"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aac" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/tribal,
@@ -70,12 +70,12 @@
 	},
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aaj" = (
 /obj/effect/decal/riverbank,
 /mob/living/simple_animal/hostile/bloatfly,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aak" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -89,7 +89,7 @@
 	},
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aam" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/protectron{
@@ -112,7 +112,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aap" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -159,13 +159,13 @@
 	name = "Rock Springs NE"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aav" = (
 /obj/effect/landmark/vertibird{
 	name = "Rock Springs SW"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aaD" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -226,13 +226,13 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aeJ" = (
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "afd" = (
 /obj/structure/closet/locker,
 /obj/item/clothing/under/f13/mechanic,
@@ -245,14 +245,14 @@
 /area/f13/building)
 "age" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "agk" = (
 /obj/structure/fence/wooden{
 	dir = 4;
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "agS" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -273,7 +273,7 @@
 "aiX" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ajS" = (
 /obj/structure/flora/grass/wasteland,
 /turf/closed/mineral/random/low_chance,
@@ -292,7 +292,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "akM" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
@@ -301,7 +301,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "amp" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal{
@@ -345,7 +345,7 @@
 "ani" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "anw" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -356,7 +356,7 @@
 /area/f13/building)
 "anP" = (
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "anV" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -366,7 +366,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aon" = (
 /obj/structure/table/glass,
 /obj/item/disk/plantgene,
@@ -376,12 +376,12 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aoJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "apl" = (
 /turf/closed/wall/f13/wood,
 /area/f13/legion)
@@ -404,7 +404,7 @@
 	pixel_y = -12
 	},
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aqb" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -414,7 +414,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aqp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -432,11 +432,11 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aru" = (
 /obj/effect/decal/fakelattice,
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "arx" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/gun/ballistic/shotgun/police,
@@ -453,7 +453,7 @@
 "arE" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "asa" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/poddoor/shutters{
@@ -468,14 +468,14 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "atn" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "atM" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -497,7 +497,7 @@
 /obj/item/crafting/abraxo,
 /obj/item/storage/bag/trash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "avp" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
@@ -505,18 +505,18 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "avz" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "awy" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "awY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -547,21 +547,21 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "azo" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "azr" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
 "azN" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/corner,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "azX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -577,7 +577,7 @@
 "aAf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aBw" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light{
@@ -588,7 +588,7 @@
 "aBy" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aBE" = (
 /mob/living/simple_animal/hostile/raider/baseball{
 	name = "Razor Twins Raider"
@@ -600,37 +600,37 @@
 "aBI" = (
 /obj/structure/closet/crate/miningcar,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aBO" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aCc" = (
 /obj/structure/table/rolling,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aCn" = (
 /obj/effect/turf_decal/huge{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aCD" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aDi" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aDv" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -648,22 +648,22 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aDQ" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aEn" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aEq" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aFa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/side/telecomms,
@@ -685,11 +685,11 @@
 	},
 /mob/living/simple_animal/hostile/handy/gutsy/flamer,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aGI" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aGV" = (
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/building)
@@ -704,7 +704,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aIy" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -715,7 +715,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aJF" = (
 /obj/structure/simple_door/metal,
 /obj/effect/decal/cleanable/dirt,
@@ -759,12 +759,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aMF" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crosswalkvert3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aMH" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt{
@@ -790,7 +790,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aNc" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -813,7 +813,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aPl" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -823,7 +823,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aPO" = (
 /obj/structure/car/rubbish3,
 /obj/effect/turf_decal/trimline/white/line{
@@ -838,7 +838,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aQN" = (
 /obj/item/weldingtool,
 /turf/open/floor/plasteel/f13{
@@ -851,12 +851,12 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aSy" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aSU" = (
 /obj/structure/sink{
 	dir = 4;
@@ -868,14 +868,14 @@
 "aTb" = (
 /obj/item/melee/onehanded/machete/training,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aTA" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aUa" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/gardener,
@@ -901,7 +901,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "aYb" = (
 /obj/structure/bed/wooden,
 /obj/item/nullrod/tribal_knife{
@@ -917,7 +917,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/cig_packs,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "baY" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 1
@@ -928,7 +928,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bbq" = (
 /obj/machinery/door/unpowered/celldoor{
 	name = "Holding"
@@ -937,13 +937,13 @@
 /area/f13/building)
 "bbV" = (
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bcq" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bcB" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -956,7 +956,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bed" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "westranchgarage";
@@ -982,7 +982,7 @@
 "bfd" = (
 /obj/structure/fence/door,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bfj" = (
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -1008,7 +1008,7 @@
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bfT" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -1018,16 +1018,16 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bgs" = (
 /obj/structure/lattice,
 /obj/structure/junk/small/tv,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bgX" = (
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bht" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -1037,7 +1037,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bhF" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -1049,13 +1049,13 @@
 "bie" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "biQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bja" = (
 /obj/structure/camera_assembly{
 	dir = 8
@@ -1120,7 +1120,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_light{
 	icon_state = "worn_light-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "blC" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -1142,7 +1142,7 @@
 	pixel_y = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "blR" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13{
@@ -1188,7 +1188,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "brC" = (
 /obj/item/stack/sheet/mineral/concrete/ten,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1205,7 +1205,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "btu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -1216,7 +1216,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "btP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/corner{
@@ -1230,7 +1230,7 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bub" = (
 /obj/item/storage/pill_bottle/stimulant,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -1274,7 +1274,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bvF" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/f13{
@@ -1292,7 +1292,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bwl" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -1315,7 +1315,7 @@
 "bxi" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "byk" = (
 /obj/machinery/recycler,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -1342,7 +1342,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bAl" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -1359,11 +1359,11 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bBj" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bBW" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1396,7 +1396,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bEl" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -1406,7 +1406,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bER" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -1421,7 +1421,7 @@
 	light_color = "red"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bFd" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -1446,13 +1446,13 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bHt" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bHy" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -1485,7 +1485,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bIv" = (
 /obj/machinery/smartfridge/bottlerack,
 /obj/structure/curtain{
@@ -1501,10 +1501,10 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/debris/v4,
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bIY" = (
 /turf/open/floor/wood/wood_wide/wood_wide_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bJv" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -1518,7 +1518,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bJT" = (
 /obj/structure/simple_door/repaired{
 	name = "Mining Storage"
@@ -1532,7 +1532,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bKZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
@@ -1542,7 +1542,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bLZ" = (
 /obj/machinery/computer/card/legion{
 	dir = 4
@@ -1560,7 +1560,7 @@
 /obj/structure/target_stake,
 /obj/item/target,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bNa" = (
 /obj/effect/overlay/junk/sink{
 	dir = 8;
@@ -1583,7 +1583,7 @@
 "bOc" = (
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/indestructible/ground/outside/dirt/harsh/corner,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bOx" = (
 /obj/machinery/mineral/wasteland_trader/general{
 	icon_state = "trade_idle"
@@ -1609,7 +1609,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bQd" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -1620,13 +1620,13 @@
 "bQf" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bRp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bRJ" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13{
@@ -1645,13 +1645,13 @@
 	pixel_x = -19
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bSp" = (
 /obj/structure/fence{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bSN" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1684,7 +1684,7 @@
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bVj" = (
 /obj/effect/landmark/start/f13/decanrec,
 /obj/effect/decal/cleanable/dirt,
@@ -1716,7 +1716,7 @@
 /obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
 /obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bWo" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -1726,7 +1726,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bWQ" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -1758,7 +1758,7 @@
 	dir = 8;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "bXZ" = (
 /obj/machinery/door/unpowered/secure_legion{
 	name = "Forge"
@@ -1821,7 +1821,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "caa" = (
 /obj/effect/decal/riverbank,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -1853,7 +1853,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cbO" = (
 /obj/structure/toilet{
 	dir = 8
@@ -1893,7 +1893,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cek" = (
 /obj/structure/simple_door/wood{
 	name = "Recruit Dormitories"
@@ -1916,7 +1916,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ceN" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/effect/decal/cleanable/dirt,
@@ -1958,14 +1958,14 @@
 	dir = 10;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cjq" = (
 /obj/structure/wreck/car/bike{
 	desc = "An old pre-war motorcycle, this ones wheels have been pulled off and it's clear parts are just flat out missing.  It's very ruined.";
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ckR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -1982,16 +1982,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/enclave/serviceboots,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cmQ" = (
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "con" = (
 /obj/structure/flora/ausbushes/fullgrass{
 	icon_state = "fullgrass_2"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cos" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -2001,7 +2001,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "coG" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13{
@@ -2013,7 +2013,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "coX" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -2022,7 +2022,7 @@
 	pixel_x = 11
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cqd" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
@@ -2040,7 +2040,7 @@
 "csk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "csD" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2086,7 +2086,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cug" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -2103,7 +2103,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cuN" = (
 /obj/structure/barricade/bars{
 	max_integrity = 1200;
@@ -2116,7 +2116,7 @@
 	desc = "A weathered wall put together using various bits of scrap metal.";
 	name = "salvaged wall"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cvg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/table/wood/junk,
@@ -2134,7 +2134,7 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -2168,17 +2168,17 @@
 "cxv" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cxC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cxK" = (
 /obj/structure/grille,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cxQ" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -2219,12 +2219,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cAF" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cAK" = (
 /obj/structure/lattice,
 /obj/structure/fence{
@@ -2233,7 +2233,7 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cAV" = (
 /obj/structure/wreck/car/bike{
 	pixel_x = -3;
@@ -2246,7 +2246,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cBd" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/legslave,
@@ -2267,7 +2267,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cBX" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
@@ -2323,7 +2323,7 @@
 	pixel_x = -17
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cEn" = (
 /obj/effect/landmark/start/f13/priestess,
 /turf/open/floor/carpet,
@@ -2337,7 +2337,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cFa" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2352,11 +2352,11 @@
 "cFn" = (
 /obj/effect/landmark/poster_spawner/pinup,
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cFw" = (
 /obj/item/chair/folding,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cFI" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/oil,
@@ -2380,7 +2380,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cGA" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged{
 	name = "Razor Twins Raider"
@@ -2404,11 +2404,11 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cHZ" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cJn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -2422,7 +2422,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cJT" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2439,14 +2439,14 @@
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cLm" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cLn" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -2476,7 +2476,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cMV" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -2493,7 +2493,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cNI" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -2504,7 +2504,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cOz" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2513,7 +2513,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cOT" = (
 /obj/structure/debris/v3,
 /turf/closed/indestructible/rock,
@@ -2532,7 +2532,7 @@
 "cPV" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cQh" = (
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 4
@@ -2555,7 +2555,7 @@
 "cRo" = (
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cSb" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -2564,7 +2564,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cSj" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -2577,7 +2577,7 @@
 "cSU" = (
 /mob/living/simple_animal/hostile/renegade/engie,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cTe" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -2597,7 +2597,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cTk" = (
 /obj/structure/junk/drawer,
 /obj/effect/decal/cleanable/dirt,
@@ -2610,7 +2610,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cUF" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/decal/cleanable/dirt{
@@ -2625,7 +2625,7 @@
 	name = "makeshift stairs"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cWp" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/computer/terminal{
@@ -2636,13 +2636,13 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cWO" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cXW" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -2652,7 +2652,7 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cXY" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -2663,7 +2663,7 @@
 "cYe" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cYt" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	density = 0;
@@ -2689,7 +2689,7 @@
 "cYZ" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "cZn" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -2719,7 +2719,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dbp" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -2760,14 +2760,14 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ddN" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
 	},
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ddW" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13{
@@ -2801,7 +2801,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dfw" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 4
@@ -2810,7 +2810,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dfG" = (
 /obj/item/shovel,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -2825,7 +2825,7 @@
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dhl" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -2838,7 +2838,7 @@
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dhW" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -2870,7 +2870,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "djM" = (
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/floor/f13/wood,
@@ -2887,7 +2887,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dkf" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/machinery/light{
@@ -2912,7 +2912,7 @@
 	pixel_x = 5
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dmi" = (
 /obj/structure/table/wood/junk,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -2933,7 +2933,7 @@
 "dnq" = (
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dnA" = (
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/bola,
@@ -2950,7 +2950,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dnY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
@@ -2958,7 +2958,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "doO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -2971,7 +2971,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dqd" = (
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
@@ -2992,31 +2992,31 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dsD" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dsF" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dtm" = (
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "grassa4"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dtD" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dtL" = (
 /mob/living/simple_animal/hostile/raider/tribal{
 	name = "Razor Twins Raider"
@@ -3024,7 +3024,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "duC" = (
 /obj/structure/chair/office/dark,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3037,7 +3037,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dvF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -3070,7 +3070,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dye" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -3091,13 +3091,13 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dyH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dzp" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/table/wood/junk,
@@ -3117,20 +3117,20 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/side{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dBu" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dBw" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dCg" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dCC" = (
 /obj/structure/closet/locker,
 /obj/item/clothing/under/f13/mechanic,
@@ -3146,7 +3146,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dDI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -3160,7 +3160,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dEb" = (
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
@@ -3172,14 +3172,14 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dFm" = (
 /obj/structure/fence/wooden{
 	dir = 4;
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dFB" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -3191,7 +3191,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dHf" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -3207,7 +3207,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dII" = (
 /obj/structure/stairs/west{
 	color = "#624b30"
@@ -3225,7 +3225,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dJz" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -3233,7 +3233,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dKQ" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/smg/greasegun,
@@ -3257,7 +3257,7 @@
 "dLE" = (
 /obj/structure/junk/small/bed,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dLP" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3272,7 +3272,7 @@
 "dOl" = (
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dOp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -3311,7 +3311,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dSy" = (
 /obj/structure/table/reinforced,
 /obj/item/gavelhammer,
@@ -3330,7 +3330,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dTb" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
@@ -3343,24 +3343,24 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dTs" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dTT" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dUk" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dUC" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -3369,7 +3369,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dUD" = (
 /obj/machinery/door/airlock/virology{
 	locked = 1;
@@ -3384,7 +3384,7 @@
 	dir = 8;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dVB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3426,7 +3426,7 @@
 	name = "Overpass Raider"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "dZS" = (
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg{
 	pixel_x = 4;
@@ -3442,7 +3442,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eaf" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/f13/trail,
@@ -3454,7 +3454,7 @@
 "eai" = (
 /obj/structure/cargocrate,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eav" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -3476,7 +3476,7 @@
 /obj/structure/lattice,
 /obj/structure/girder/displaced,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ebn" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/inside/dirt,
@@ -3503,7 +3503,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ebO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -3521,7 +3521,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "edt" = (
 /obj/structure/table/wood,
 /obj/item/seeds/apple,
@@ -3543,11 +3543,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "edy" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "efh" = (
 /obj/item/storage/box,
 /obj/effect/decal/cleanable/dirt,
@@ -3579,7 +3579,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "egd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
@@ -3599,11 +3599,11 @@
 	name = "Powder Ganger baller"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eip" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eja" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -3617,7 +3617,7 @@
 	pixel_x = -18
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ejt" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -3625,16 +3625,16 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ejX" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eke" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eky" = (
 /mob/living/simple_animal/hostile/raider/baseball{
 	name = "Razor Twins Raider"
@@ -3700,14 +3700,14 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eql" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
 	pixel_x = -18
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eqs" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -3727,7 +3727,7 @@
 	name = "Sprinkles"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ers" = (
 /obj/structure/toilet{
 	dir = 8
@@ -3737,7 +3737,7 @@
 	},
 /obj/item/stack/f13Cash/random/med,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "erI" = (
 /obj/structure/fence/wooden,
 /obj/structure/fence/wooden{
@@ -3745,7 +3745,7 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "erL" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/wood/wood_wide{
@@ -3764,7 +3764,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "esI" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3778,7 +3778,7 @@
 	},
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "etk" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -3786,7 +3786,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ett" = (
 /obj/structure/bed/mattress,
 /obj/item/blanket,
@@ -3798,7 +3798,7 @@
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/lead/five,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "etI" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -3806,7 +3806,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "etW" = (
 /obj/machinery/workbench/forge,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3824,13 +3824,13 @@
 "euM" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "evx" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ewv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
@@ -3840,12 +3840,12 @@
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket/plastic,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ewL" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "exl" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/rglass,
@@ -3856,13 +3856,13 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "exU" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "exX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
@@ -3883,7 +3883,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ezi" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
@@ -3892,7 +3892,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ezB" = (
 /obj/effect/spawner/lootdrop/f13/seedspawner,
 /turf/open/floor/plasteel/darkgreen/side,
@@ -3917,7 +3917,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ezS" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3946,7 +3946,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eBo" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Razor Twins Raider"
@@ -3971,13 +3971,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eCK" = (
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eCY" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -3989,11 +3989,11 @@
 	dir = 5
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eEc" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eEG" = (
 /obj/item/storage/backpack/industrial,
 /turf/open/floor/plasteel/f13{
@@ -4014,7 +4014,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eFZ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13{
@@ -4084,7 +4084,7 @@
 "eJJ" = (
 /obj/structure/junk/small,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eKd" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -4104,7 +4104,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eLm" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -4119,7 +4119,7 @@
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eLI" = (
 /obj/item/flashlight/seclite,
 /obj/effect/decal/cleanable/dirt,
@@ -4133,7 +4133,7 @@
 	},
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eMv" = (
 /obj/machinery/power/apc,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -4156,7 +4156,7 @@
 "eNO" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eOr" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -4167,7 +4167,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eOT" = (
 /obj/structure/sign/poster/contraband/free_tonto{
 	pixel_x = 32;
@@ -4206,7 +4206,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eRn" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/carpet/green,
@@ -4247,7 +4247,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eTS" = (
 /obj/item/broken_bottle,
 /obj/effect/decal/cleanable/glass,
@@ -4274,7 +4274,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "eWQ" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -4351,7 +4351,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fcX" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
@@ -4378,7 +4378,7 @@
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fei" = (
 /obj/effect/turf_decal/big/energy{
 	alpha = 200;
@@ -4440,7 +4440,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fjb" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -4452,11 +4452,11 @@
 "fjs" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fjY" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fjZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4464,7 +4464,7 @@
 "fkx" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fkT" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4485,7 +4485,7 @@
 	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
 	name = "dirty water"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "flB" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -4499,7 +4499,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fmA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -4539,11 +4539,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "foH" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fpm" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -4556,7 +4556,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fqn" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4568,7 +4568,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "frN" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -4589,19 +4589,19 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ftT" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fub" = (
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fuj" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -4620,7 +4620,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fvF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -4635,7 +4635,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fvX" = (
 /obj/structure/chair/bench{
 	dir = 8
@@ -4651,15 +4651,15 @@
 	pixel_y = 30
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fyz" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fyJ" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fyP" = (
 /obj/item/stack/ore/iron{
 	pixel_x = 6;
@@ -4678,12 +4678,12 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crosswalkvert3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fzL" = (
 /obj/structure/car/rubbish3,
 /obj/item/newspaper,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fAl" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -4705,13 +4705,13 @@
 	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
 	name = "dirty water"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fBt" = (
 /obj/structure/railing/wood{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fCY" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars{
@@ -4724,7 +4724,7 @@
 "fDX" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fEv" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/wheat,
@@ -4752,11 +4752,11 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fEZ" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fFo" = (
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
 /area/f13/building)
@@ -4806,7 +4806,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fIF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4825,7 +4825,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fIY" = (
 /obj/structure/chair/left,
 /turf/open/floor/f13{
@@ -4839,7 +4839,7 @@
 "fJi" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fJM" = (
 /obj/effect/landmark/start/f13/slave,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4851,11 +4851,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fKY" = (
 /obj/structure/beebox/premade/random,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fLf" = (
 /obj/effect/overlay/junk/sink{
 	dir = 4;
@@ -4874,7 +4874,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fLr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -4903,7 +4903,7 @@
 	color = "#515249"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fLP" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 4
@@ -4912,7 +4912,7 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fLX" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4939,12 +4939,12 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fOJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fOM" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -4976,13 +4976,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fQB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fQF" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/effect/decal/cleanable/dirt,
@@ -4997,13 +4997,13 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fRM" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fRN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -5088,7 +5088,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fVF" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -5105,7 +5105,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "fXg" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/plasteel/f13{
@@ -5141,20 +5141,20 @@
 	pixel_x = -15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gck" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 1
 	},
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gct" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gcI" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -5180,7 +5180,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gdU" = (
 /obj/item/instrument/guitar,
 /turf/open/floor/plasteel/f13{
@@ -5215,7 +5215,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gfI" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -5232,14 +5232,14 @@
 "giH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gjt" = (
 /obj/structure/pondlily_small{
 	pixel_x = -10;
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gjS" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
@@ -5252,14 +5252,14 @@
 "gko" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gks" = (
 /obj/structure/fence/door/opened{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gld" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -5275,14 +5275,14 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "glI" = (
 /obj/structure/fence/wooden{
 	dir = 1;
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "glW" = (
 /obj/structure/pondlily_small,
 /obj/effect/decal/riverbank,
@@ -5311,7 +5311,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gol" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
@@ -5323,7 +5323,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gox" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -5338,7 +5338,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gpN" = (
 /obj/structure/fence/corner/wooden{
 	dir = 4
@@ -5350,7 +5350,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gpO" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -5369,7 +5369,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gqa" = (
 /obj/structure/fence{
 	color = "#515249";
@@ -5379,7 +5379,7 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gqK" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5392,11 +5392,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gsd" = (
 /obj/structure/girder/displaced,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gsA" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/bunker)
@@ -5409,7 +5409,7 @@
 "gsX" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gtE" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -5419,7 +5419,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gtG" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/debris/v3{
@@ -5427,7 +5427,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gtQ" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -5463,7 +5463,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gyp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -5471,7 +5471,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gyL" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
@@ -5485,7 +5485,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gzy" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -5497,7 +5497,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/side{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gAc" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -5531,7 +5531,7 @@
 /area/f13/caves)
 "gBb" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gBX" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -5551,7 +5551,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gCC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -5565,7 +5565,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gDv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -5580,7 +5580,7 @@
 	icon_state = "rock5"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gGn" = (
 /mob/living/simple_animal/hostile/raider/tribal{
 	name = "Razor Twins Raider"
@@ -5629,11 +5629,11 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gJf" = (
 /mob/living/simple_animal/hostile/bloatfly,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gJl" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
@@ -5646,7 +5646,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gLu" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -5684,7 +5684,7 @@
 	name = "compound gate"
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gNb" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road,
@@ -5695,7 +5695,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gNz" = (
 /obj/structure/closet/crate/large,
 /obj/item/twohanded/sledgehammer/simple,
@@ -5718,7 +5718,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gOr" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -5740,12 +5740,12 @@
 	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gPr" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gPu" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks{
@@ -5803,7 +5803,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gRr" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/structure/table/wood,
@@ -5819,7 +5819,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gUl" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/sunset/brick_small_dark,
@@ -5845,7 +5845,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gWB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh{
@@ -5853,7 +5853,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gXG" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/armor_plate/five,
@@ -5887,7 +5887,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "gZI" = (
 /obj/item/chair/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -5899,7 +5899,7 @@
 	pixel_x = 13
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hac" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks{
@@ -5929,7 +5929,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "haZ" = (
 /obj/effect/decal/riverbank,
 /turf/open/water,
@@ -5946,13 +5946,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hcv" = (
 /obj/structure/chair/folding{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "heU" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalbottom"
@@ -5995,14 +5995,14 @@
 /area/f13/building)
 "hgP" = (
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hhc" = (
 /obj/structure/railing/wood{
 	dir = 8;
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hhd" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13{
@@ -6029,12 +6029,12 @@
 /obj/structure/target_stake,
 /obj/item/target/vaultie,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hiG" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hiT" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
@@ -6042,7 +6042,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hjg" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -6059,7 +6059,7 @@
 "hkS" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hlr" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -6097,14 +6097,14 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hlR" = (
 /obj/structure/chair/bench{
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hmo" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -6112,7 +6112,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hmr" = (
 /obj/structure/table,
 /obj/item/reagent_containers/rag/towel,
@@ -6143,7 +6143,7 @@
 "hnj" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hnl" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/decal/cleanable/generic,
@@ -6160,7 +6160,7 @@
 "hnE" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hnP" = (
 /turf/open/floor/wood/wood_common/wood_common_dark,
 /area/f13/building)
@@ -6182,7 +6182,7 @@
 "hpb" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hpn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
@@ -6198,14 +6198,14 @@
 "hqh" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hqn" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hqA" = (
 /obj/structure/junk/small/bed,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6215,7 +6215,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hrG" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -6229,25 +6229,25 @@
 	pixel_x = 11
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hsQ" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
 	dir = 9;
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "htK" = (
 /turf/open/floor/wood/wood_worn/wood_worn_light{
 	icon_state = "worn_light-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hus" = (
 /obj/structure/chair/bench{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "huM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13{
@@ -6259,7 +6259,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hvu" = (
 /obj/structure/table,
 /obj/item/newspaper,
@@ -6288,18 +6288,18 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hwx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hwG" = (
 /obj/structure/nest/protectron{
 	max_mobs = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hwN" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -6313,7 +6313,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hyt" = (
 /turf/open/floor/pod/dark,
 /area/f13/bunker)
@@ -6330,7 +6330,7 @@
 	armed = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hzQ" = (
 /obj/structure/fence/corner{
 	color = "#515249";
@@ -6340,7 +6340,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hAu" = (
 /obj/structure/decoration/vent,
 /obj/machinery/shower{
@@ -6410,7 +6410,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -6455,11 +6455,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hHR" = (
 /obj/item/weldingtool/basic,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hIL" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -6475,7 +6475,7 @@
 	},
 /obj/structure/debris/v3,
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hJH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6487,7 +6487,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hKO" = (
 /obj/structure/table/reinforced,
 /obj/structure/fluff/paper/stack{
@@ -6505,7 +6505,7 @@
 "hNn" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hNq" = (
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/caves)
@@ -6521,7 +6521,7 @@
 	pixel_y = -12
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hNQ" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/road{
@@ -6544,11 +6544,11 @@
 	icon_state = "doublehorizontal"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hQj" = (
 /obj/structure/flora/wasteplant/wild_feracactus,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hQn" = (
 /obj/machinery/mineral/wasteland_vendor/crafting{
 	icon_state = "parts_idle"
@@ -6578,7 +6578,7 @@
 	dir = 6;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hRU" = (
 /obj/structure/junk/drawer,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6633,7 +6633,7 @@
 "hVL" = (
 /obj/structure/closet/crate/grave,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hVV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -6658,12 +6658,12 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hWh" = (
 /obj/effect/turf_decal/huge,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hWw" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -6683,10 +6683,10 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hXy" = (
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hXT" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -6698,12 +6698,12 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hYI" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hYP" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -6711,7 +6711,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "hZD" = (
 /mob/living/simple_animal/hostile/renegade/doc,
 /turf/open/floor/f13{
@@ -6747,7 +6747,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "icp" = (
 /obj/structure/sink{
 	dir = 4;
@@ -6800,7 +6800,7 @@
 	icon_state = "enclave_armored"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ifk" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -6824,7 +6824,7 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "igD" = (
 /obj/machinery/computer/terminal{
 	density = 0;
@@ -6843,7 +6843,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "igW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -6867,24 +6867,24 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iis" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "iiz" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iiC" = (
 /obj/structure/chair/bench{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iiO" = (
 /obj/item/trash/f13/mre,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ijh" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -6905,7 +6905,7 @@
 "ikF" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ikY" = (
 /obj/machinery/shower{
 	pixel_y = 17
@@ -6918,11 +6918,11 @@
 "ilD" = (
 /obj/structure/pondlily_big,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ima" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "imb" = (
 /obj/item/wirecutters,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -6946,7 +6946,7 @@
 	name = "Forge"
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "imt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6966,7 +6966,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "inn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -6995,7 +6995,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iqc" = (
 /obj/structure/junk/small/tv,
 /obj/effect/decal/cleanable/glass,
@@ -7013,7 +7013,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iqV" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/decal/cleanable/dirt,
@@ -7042,7 +7042,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iuQ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
 /turf/open/floor/plasteel/f13{
@@ -7074,7 +7074,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iww" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 1
@@ -7084,12 +7084,12 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iwy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iwH" = (
 /obj/structure/stairs/west{
 	color = "#624b30"
@@ -7124,7 +7124,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iyD" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -7147,17 +7147,17 @@
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iAH" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iAK" = (
 /mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7174,7 +7174,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7182,7 +7182,7 @@
 "iCt" = (
 /obj/structure/junk/micro,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iDc" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -7228,7 +7228,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iHa" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -7255,7 +7255,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iJY" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/effect/decal/cleanable/oil{
@@ -7266,7 +7266,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iKW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -7304,12 +7304,12 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iPD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iPM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -7321,7 +7321,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_light{
 	icon_state = "worn_light-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iQi" = (
 /obj/structure/stairs/west{
 	color = "#A47449"
@@ -7333,7 +7333,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iQq" = (
 /turf/open/floor/plasteel/darkgreen/corner{
 	dir = 1
@@ -7350,7 +7350,7 @@
 "iRx" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iUa" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -7368,7 +7368,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7378,7 +7378,7 @@
 "iVa" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iVe" = (
 /mob/living/simple_animal/hostile/raider/firefighter{
 	name = "Razor Twins Raider"
@@ -7415,14 +7415,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iXe" = (
 /obj/structure/fence{
 	color = "#515249";
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iXk" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -7457,14 +7457,14 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iYE" = (
 /obj/structure/fence{
 	color = "#515249";
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "iYW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7509,7 +7509,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jaO" = (
 /obj/structure/simple_door/glass{
 	name = "Federal Penetentiary"
@@ -7584,13 +7584,13 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jeY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jgq" = (
 /turf/open/floor/plasteel/darkgreen/side/telecomms{
 	dir = 1
@@ -7599,7 +7599,7 @@
 "jgP" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jgT" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
@@ -7610,11 +7610,11 @@
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jhl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jif" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/decal/cleanable/dirt,
@@ -7654,7 +7654,7 @@
 "jkl" = (
 /obj/structure/flora/wasteplant/wild_datura,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jku" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7685,7 +7685,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jlM" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -7714,7 +7714,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "joq" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
@@ -7728,7 +7728,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "joC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -7757,18 +7757,18 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jrH" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "juG" = (
 /obj/item/candle/tribal_torch{
 	pixel_x = -12;
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "juQ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -7779,7 +7779,7 @@
 "jvI" = (
 /obj/structure/fence/door/opened,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jwL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7802,11 +7802,11 @@
 	armed = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jyU" = (
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jzh" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -7820,7 +7820,7 @@
 	pixel_x = 5
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jAv" = (
 /mob/living/simple_animal/hostile/raider{
 	name = "Razor Twins Raider"
@@ -7840,7 +7840,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jBP" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -7852,7 +7852,7 @@
 	pixel_y = -4
 	},
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jCY" = (
 /obj/structure/table,
 /obj/item/bedsheet/black,
@@ -7879,7 +7879,7 @@
 	dir = 1;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jDQ" = (
 /obj/structure/wreck/trash/two_tire,
 /obj/structure/wreck/trash/one_tire,
@@ -7892,16 +7892,16 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jEL" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jFJ" = (
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jFU" = (
 /obj/structure/barricade/bars{
 	max_integrity = 1200;
@@ -7914,14 +7914,14 @@
 "jGv" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jGG" = (
 /obj/structure/flora/grass/wasteland,
 /obj/item/mine/explosive/random{
 	armed = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jHb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/spacecash/random,
@@ -7941,11 +7941,11 @@
 "jIp" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jIy" = (
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jIz" = (
 /turf/open/floor/carpet,
 /area/f13/building)
@@ -7961,7 +7961,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jLa" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/legion)
@@ -7976,7 +7976,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jLP" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -8025,7 +8025,7 @@
 	pixel_y = 20
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jNt" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -8035,7 +8035,7 @@
 "jNP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jPu" = (
 /obj/item/stack/sheet/mineral/concrete/ten,
 /obj/effect/decal/cleanable/dirt,
@@ -8066,7 +8066,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jSa" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -8087,29 +8087,29 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jSP" = (
 /obj/item/stack/sheet/bone,
 /obj/effect/gibspawner,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jSW" = (
 /obj/structure/lamp_post,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jTc" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jUL" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jWa" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -8135,7 +8135,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jXT" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -8157,7 +8157,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jYh" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plasteel/f13{
@@ -8180,11 +8180,11 @@
 "jYu" = (
 /obj/effect/decal/riverbank,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jYw" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "jYy" = (
 /obj/item/flashlight/flare/torch,
 /obj/structure/table/wood,
@@ -8210,13 +8210,13 @@
 "kaA" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kcs" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kde" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -8229,7 +8229,7 @@
 	name = "Crops"
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kdH" = (
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 5
@@ -8242,7 +8242,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kdZ" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/decoration/rag,
@@ -8257,7 +8257,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "keD" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
@@ -8279,7 +8279,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kgq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -8293,14 +8293,14 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "khT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kih" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -8320,7 +8320,7 @@
 	},
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kjp" = (
 /obj/structure/furnace,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -8342,7 +8342,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kkR" = (
 /turf/open/floor/carpet/black,
 /area/f13/legion)
@@ -8364,20 +8364,20 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kmq" = (
 /obj/structure/flora/grass/jungle/b{
 	icon_state = "busha"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kmO" = (
 /obj/structure/lattice,
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "knb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/darkgreen/side{
@@ -8407,14 +8407,14 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "koK" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "koO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -8454,14 +8454,14 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "krl" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ksx" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
@@ -8471,19 +8471,19 @@
 	},
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ksD" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kta" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ktf" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v3,
@@ -8506,7 +8506,7 @@
 "kvF" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8519,7 +8519,7 @@
 	pixel_x = -9
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kwD" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8527,7 +8527,7 @@
 "kwH" = (
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kwK" = (
 /obj/effect/landmark/start/f13/campfollower,
 /obj/effect/decal/cleanable/dirt,
@@ -8545,7 +8545,7 @@
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kxT" = (
 /obj/item/stack/sheet/bone,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -8554,11 +8554,11 @@
 /obj/effect/decal/riverbank,
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kAg" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kAE" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -8567,7 +8567,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kCc" = (
 /obj/machinery/microwave/stove,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -8587,7 +8587,7 @@
 "kEb" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kEf" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -8608,7 +8608,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kEG" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -8673,7 +8673,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kJO" = (
 /obj/structure/nest/radroach,
 /obj/effect/decal/cleanable/dirt,
@@ -8686,7 +8686,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kLN" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -8701,7 +8701,7 @@
 "kLZ" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kMW" = (
 /obj/item/sign/bee_warning{
 	pixel_y = -6
@@ -8713,7 +8713,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kNa" = (
 /obj/structure/closet/locker/oldstyle,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -8726,7 +8726,7 @@
 /area/f13/legion)
 "kNY" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kOi" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2";
@@ -8736,7 +8736,7 @@
 	dir = 4;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kOr" = (
 /obj/structure/sign/poster/contraband/red_rum{
 	pixel_x = -32
@@ -8749,12 +8749,12 @@
 "kOI" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kOU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kPa" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/legion)
@@ -8768,7 +8768,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kQA" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -8801,13 +8801,13 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kSK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kSL" = (
 /obj/structure/billboard/ritas{
 	desc = "An old billboard advertising some kind of pre-war product.";
@@ -8822,7 +8822,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kSQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -8875,7 +8875,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "kWT" = (
 /obj/machinery/workbench,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -8908,25 +8908,25 @@
 	pixel_x = -17
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "laI" = (
 /turf/open/indestructible/ground/outside/desert/harsh{
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "laS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lbD" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lbN" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -8939,25 +8939,25 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lcJ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lcU" = (
 /obj/structure/holohoop{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ldg" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lek" = (
 /obj/machinery/shower{
 	dir = 8
@@ -8999,7 +8999,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lie" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -9036,7 +9036,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lle" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -9050,7 +9050,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "llq" = (
 /obj/structure/destructible/tribal_torch,
 /obj/effect/decal/cleanable/dirt,
@@ -9074,7 +9074,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lmB" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	light_color = "#f4e3b0"
@@ -9104,7 +9104,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lnJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9115,7 +9115,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lom" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/curtain{
@@ -9131,7 +9131,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lpp" = (
 /obj/structure/simple_door/repaired{
 	name = "Penalty Chamber"
@@ -9154,7 +9154,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9177,7 +9177,7 @@
 "lqX" = (
 /mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lrN" = (
 /obj/structure/fence{
 	color = "#515249";
@@ -9186,7 +9186,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lrY" = (
 /obj/structure/pondlily_small{
 	pixel_x = -12;
@@ -9194,7 +9194,7 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lsa" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/apple,
@@ -9213,7 +9213,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ltA" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -9282,14 +9282,14 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lxE" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 8;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lxK" = (
 /obj/structure/junk/small/tv,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -9317,7 +9317,7 @@
 "lzs" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lAz" = (
 /obj/structure/stairs/north{
 	color = "#A47449"
@@ -9327,7 +9327,7 @@
 "lAF" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lBl" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -9342,20 +9342,20 @@
 "lBG" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lCe" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh/corner,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lCK" = (
 /obj/structure/lattice,
 /obj/structure/obstacle/barbedwire{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lCQ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -9364,7 +9364,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lDg" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -9387,7 +9387,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lEQ" = (
 /obj/machinery/vending/nukacolavendfull,
 /obj/effect/decal/cleanable/blood/drip,
@@ -9416,7 +9416,7 @@
 "lGe" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lGf" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9426,7 +9426,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lHl" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -9436,7 +9436,7 @@
 	pixel_y = -14
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lIc" = (
 /turf/open/floor/wood/wood_wide/wood_wide_light,
 /area/f13/legion)
@@ -9464,7 +9464,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lJT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -9486,7 +9486,7 @@
 "lKG" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lKP" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -9494,7 +9494,7 @@
 "lKV" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lLi" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meatsalted,
@@ -9589,7 +9589,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lRH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkgreen/side/telecomms{
@@ -9616,7 +9616,7 @@
 "lTf" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lUg" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/indestructible/ground/outside/road,
@@ -9640,7 +9640,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lVc" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9652,7 +9652,7 @@
 	},
 /mob/living/simple_animal/hostile/handy/gutsy/flamer,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lVw" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -9678,7 +9678,7 @@
 	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lXa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -9699,7 +9699,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "lYn" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -9720,16 +9720,16 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mbi" = (
 /obj/structure/flora/wasteplant/wild_mutfruit,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mbM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mcR" = (
 /obj/structure/fence/corner{
 	dir = 1;
@@ -9737,7 +9737,7 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mdj" = (
 /obj/structure/table,
 /obj/machinery/light/small/broken{
@@ -9786,7 +9786,7 @@
 "mfm" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mfx" = (
 /obj/effect/landmark/start/f13/slave,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -9808,7 +9808,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mgB" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/druggie_pill,
@@ -9825,7 +9825,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mhA" = (
 /obj/structure/filingcabinet{
 	pixel_x = 7
@@ -9843,7 +9843,7 @@
 "miH" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "miO" = (
 /obj/effect/turf_decal/huge{
 	dir = 1
@@ -9852,7 +9852,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "miQ" = (
 /obj/machinery/light/broken,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9869,7 +9869,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mkD" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -9884,7 +9884,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mlj" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9896,7 +9896,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mmo" = (
 /turf/open/floor/plasteel/bar,
 /area/f13/building)
@@ -9920,7 +9920,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mni" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9967,7 +9967,7 @@
 /area/f13/legion)
 "mrw" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/side,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mrK" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9984,7 +9984,7 @@
 /obj/item/clothing/under/f13/enclave/peacekeeper,
 /obj/item/clothing/accessory/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "msr" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -10000,13 +10000,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "msX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mtj" = (
 /obj/effect/decal/fakelattice,
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg{
@@ -10019,19 +10019,19 @@
 	},
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mtp" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mtB" = (
 /obj/effect/decal/riverbank,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mtR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland,
@@ -10049,7 +10049,7 @@
 	desc = "A weathered wall put together using various bits of scrap metal.";
 	name = "salvaged wall"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mua" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -10096,7 +10096,7 @@
 	icon_state = "car_rubish2"
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mwo" = (
 /obj/structure/junk/small/tv,
 /obj/effect/decal/cleanable/dirt,
@@ -10134,7 +10134,7 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier3,
 /obj/item/clothing/head/f13/enclave/peacekeeper,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "myw" = (
 /obj/structure/bed/old,
 /obj/item/blanket,
@@ -10200,7 +10200,7 @@
 	pixel_x = -18
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mCC" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -10217,7 +10217,7 @@
 "mEe" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mEA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10235,7 +10235,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mFE" = (
 /obj/structure/chair/wood/dining{
 	dir = 1
@@ -10258,7 +10258,7 @@
 "mHg" = (
 /obj/item/sign/bee_warning,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mHX" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/decal/cleanable/dirt,
@@ -10283,7 +10283,7 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mIR" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
@@ -10323,7 +10323,7 @@
 	pixel_y = -12
 	},
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mJW" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -10342,7 +10342,7 @@
 "mKP" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mLb" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -10365,11 +10365,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mNB" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mOA" = (
 /obj/machinery/light,
 /obj/machinery/msgterminal,
@@ -10380,7 +10380,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mQs" = (
 /obj/structure/fence/corner/wooden{
 	dir = 4
@@ -10393,13 +10393,13 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mQM" = (
 /obj/item/stack/sheet/mineral/wood/five,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mSi" = (
 /obj/machinery/light{
 	dir = 4
@@ -10419,7 +10419,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mTt" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/legion)
@@ -10447,18 +10447,18 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mUV" = (
 /obj/structure/reagent_dispensers/barrel/explosive{
 	pixel_x = -9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mVe" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mVX" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10475,13 +10475,13 @@
 "mWW" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mXr" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalright"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mXD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10515,7 +10515,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "mZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10555,7 +10555,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nbE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -10579,7 +10579,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_light{
 	icon_state = "worn_light-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nfN" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/legion)
@@ -10592,7 +10592,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nhi" = (
 /obj/item/chair/folding,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10607,7 +10607,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "njp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10629,7 +10629,7 @@
 /obj/structure/flora/grass/wasteland,
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nke" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -10650,7 +10650,7 @@
 "nli" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nlm" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadhard,
@@ -10668,7 +10668,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/enclave/serviceboots,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "noA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -10694,7 +10694,7 @@
 "npz" = (
 /obj/effect/turf_decal/huge,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "npP" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -10716,7 +10716,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nrj" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -10751,22 +10751,22 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nsc" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nsp" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nsw" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nsT" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -10798,7 +10798,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nuj" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -10819,7 +10819,7 @@
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/cloth/ten,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nuK" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13{
@@ -10834,7 +10834,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nuX" = (
 /obj/structure/simple_door/metal/store{
 	name = "Visitation"
@@ -10910,11 +10910,11 @@
 "nzH" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nBh" = (
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nBU" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -11022,7 +11022,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nHC" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -11088,17 +11088,17 @@
 "nLa" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nLj" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nLy" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/low_tools,
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nLI" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/hos,
@@ -11115,7 +11115,7 @@
 "nNg" = (
 /obj/structure/wreck/bus/orange/alt,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nNh" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11168,12 +11168,12 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nPn" = (
 /obj/structure/chair/folding,
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nPv" = (
 /obj/structure/car/rubbish3{
 	icon_state = "car_rubish2"
@@ -11205,7 +11205,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nRc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -11242,7 +11242,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nUC" = (
 /obj/item/storage/trash_stack{
 	pixel_x = 5;
@@ -11253,12 +11253,12 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nUF" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nUX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/cannabis,
@@ -11284,13 +11284,13 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nVI" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nWm" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -11322,13 +11322,13 @@
 	pixel_y = 15
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nXQ" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nXV" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11344,14 +11344,14 @@
 "nYu" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nYC" = (
 /obj/structure/pondlily_small{
 	pixel_x = -12;
 	pixel_y = -10
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "nZC" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -11359,14 +11359,14 @@
 /obj/effect/gibspawner,
 /obj/effect/decal/remains,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oag" = (
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oao" = (
 /obj/machinery/processor,
 /obj/effect/decal/cleanable/dirt,
@@ -11383,7 +11383,7 @@
 "oaR" = (
 /obj/item/shard,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "obf" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -11395,7 +11395,7 @@
 "obp" = (
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "obt" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
@@ -11404,7 +11404,7 @@
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "obT" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -11425,7 +11425,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ocU" = (
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -13
@@ -11439,12 +11439,12 @@
 	pixel_x = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "odw" = (
 /turf/open/floor/wood/wood_worn/wood_worn_light{
 	icon_state = "worn_light-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oeb" = (
 /obj/structure/chair/office,
 /obj/item/paper/crumpled,
@@ -11454,7 +11454,7 @@
 "oeo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oet" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -11472,7 +11472,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ofp" = (
 /obj/machinery/door/unpowered/celldoor,
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -11487,7 +11487,7 @@
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ohg" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -11509,7 +11509,7 @@
 "oil" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ojj" = (
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11557,7 +11557,7 @@
 "omH" = (
 /obj/structure/spacevine,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "onb" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -11587,14 +11587,14 @@
 "onR" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "onW" = (
 /obj/structure/lattice,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ool" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11629,7 +11629,7 @@
 	pixel_y = -34
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oru" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11739,7 +11739,7 @@
 	dir = 4;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "owD" = (
 /obj/structure/barricade/wooden/planks,
 /obj/structure/barricade/wooden/strong,
@@ -11752,7 +11752,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crosswalkvert3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oxf" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife/butcher,
@@ -11770,7 +11770,7 @@
 "oxq" = (
 /obj/structure/cross,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oxu" = (
 /obj/structure/fence{
 	color = "#515249";
@@ -11779,11 +11779,11 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oxM" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oyt" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -11791,21 +11791,21 @@
 	},
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ozw" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oAf" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oAz" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oAV" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -11815,7 +11815,7 @@
 	pixel_x = -32
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oBl" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalleft"
@@ -11823,7 +11823,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oBq" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/belt/utility/gardener,
@@ -11845,7 +11845,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oCn" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -11864,7 +11864,7 @@
 "oCA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oCK" = (
 /obj/structure/toilet{
 	dir = 8
@@ -11957,19 +11957,19 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oGa" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oGc" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oGL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -11978,7 +11978,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oHH" = (
 /mob/living/simple_animal/hostile/renegade/guardian,
 /turf/open/floor/f13/wood,
@@ -11986,7 +11986,7 @@
 "oHJ" = (
 /obj/structure/junk/small/bed2,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oHM" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -11998,21 +11998,21 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oJC" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
 	},
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oJN" = (
 /obj/structure/fence{
 	color = "#515249";
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oKk" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag,
@@ -12056,11 +12056,11 @@
 /obj/structure/lattice,
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oPh" = (
 /obj/item/mine/shrapnel/random,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oPk" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -12073,15 +12073,15 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oRM" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oRW" = (
 /obj/structure/billboard/cola/pristine,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oSw" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -12131,7 +12131,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oUk" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door{
@@ -12157,7 +12157,7 @@
 	},
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oUB" = (
 /obj/structure/fence{
 	dir = 8
@@ -12166,7 +12166,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oVc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12184,7 +12184,7 @@
 "oVs" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oVU" = (
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12205,7 +12205,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oWx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/shovel/spade,
@@ -12233,7 +12233,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oWG" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks,
@@ -12242,7 +12242,7 @@
 "oWN" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oWZ" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -12259,14 +12259,14 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oXV" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "oYd" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oYe" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -12274,7 +12274,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oYi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plasteel/f13{
@@ -12301,7 +12301,7 @@
 "oZn" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oZB" = (
 /obj/structure/debris/v3{
 	pixel_x = -11;
@@ -12309,11 +12309,11 @@
 	},
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oZH" = (
 /obj/structure/debris/v3,
 /turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "oZZ" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -12327,7 +12327,7 @@
 /area/f13/building)
 "paT" = (
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pcw" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
@@ -12353,7 +12353,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pdW" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /obj/effect/decal/cleanable/dirt,
@@ -12363,7 +12363,7 @@
 /area/f13/building)
 "peo" = (
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "peC" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/curtain{
@@ -12378,13 +12378,13 @@
 "pfn" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pfq" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pfU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -12396,11 +12396,11 @@
 "pgy" = (
 /obj/structure/junk/small/bed2,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pgT" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pij" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
@@ -12409,7 +12409,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "piU" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -12427,7 +12427,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pkD" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -12437,7 +12437,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pkO" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -12469,7 +12469,7 @@
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pnd" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -12505,19 +12505,19 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ppF" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ppY" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pqk" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -12525,17 +12525,17 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pqR" = (
 /turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "prR" = (
 /obj/structure/table/wood/junk,
 /obj/item/toy/cards/deck{
 	pixel_y = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "psc" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks,
@@ -12550,13 +12550,13 @@
 "psq" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "psz" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "psD" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul,
@@ -12611,7 +12611,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "puR" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12652,7 +12652,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pwP" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/f13{
@@ -12665,7 +12665,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pxO" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/traitbooks/low,
@@ -12682,7 +12682,7 @@
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pyA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -12701,7 +12701,7 @@
 	dir = 9;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pzx" = (
 /obj/machinery/workbench,
 /obj/item/flashlight/seclite,
@@ -12713,7 +12713,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pAY" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -12749,7 +12749,7 @@
 "pDu" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pEq" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plasteel/darkgreen/side/telecomms,
@@ -12782,7 +12782,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pGQ" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/darkgreen/side,
@@ -12803,7 +12803,7 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pHF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -12813,13 +12813,13 @@
 /obj/item/stack/sheet/mineral/wood/twenty,
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pIm" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pIH" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks{
@@ -12832,7 +12832,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pJM" = (
 /obj/structure/car/rubbish3{
 	icon_state = "car_rubish2"
@@ -12859,7 +12859,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pKc" = (
 /obj/structure/closet/secure_closet/goodies{
 	anchorable = 0;
@@ -12884,19 +12884,19 @@
 	icon_state = "small"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pLr" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pMj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pMp" = (
 /obj/structure/fence/corner{
 	color = "#515249"
@@ -12906,7 +12906,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pMI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12925,12 +12925,12 @@
 "pMV" = (
 /obj/structure/junk/arcade,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pNc" = (
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pNR" = (
 /turf/open/floor/plasteel/darkgreen/side/telecomms{
 	dir = 8
@@ -12944,7 +12944,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pOq" = (
 /obj/item/vending_refill/boozeomat,
 /turf/open/floor/plasteel/f13{
@@ -12959,7 +12959,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pPh" = (
 /obj/item/storage/box/cups,
 /obj/effect/decal/cleanable/dirt,
@@ -12972,7 +12972,7 @@
 	dir = 5;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pRe" = (
 /obj/effect/landmark/start/f13/recleg,
 /obj/effect/decal/cleanable/dirt,
@@ -12999,7 +12999,7 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pSi" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -13012,7 +13012,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pTn" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/dice,
@@ -13046,7 +13046,7 @@
 	icon_state = "doubleverticalbottom"
 	},
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pUt" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/glass/fifty,
@@ -13060,7 +13060,7 @@
 /obj/item/storage/backpack/enclave,
 /obj/item/book/granter/trait/pa_wear,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pUK" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -13085,7 +13085,7 @@
 	},
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pWa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -13111,11 +13111,11 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pXL" = (
 /obj/structure/bookcase,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pZt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5";
@@ -13124,7 +13124,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "pZx" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/eyepatch,
@@ -13136,7 +13136,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qaI" = (
 /obj/structure/debris/v4{
 	pixel_x = -10;
@@ -13148,7 +13148,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qbs" = (
 /obj/machinery/door/airlock/research,
 /obj/machinery/door/poddoor/shutters{
@@ -13196,13 +13196,13 @@
 	dir = 8;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qdP" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qew" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13242,14 +13242,14 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qfm" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qfS" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -13268,7 +13268,7 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks/low,
 /obj/structure/bookcase,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qib" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy/silver_cup{
@@ -13346,7 +13346,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qpC" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol{
 	pixel_x = 32
@@ -13365,11 +13365,11 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qqq" = (
 /obj/item/cultivator/rake,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qqw" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
@@ -13411,11 +13411,11 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qvK" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qwi" = (
 /obj/structure/bed/mattress,
 /obj/item/blanket,
@@ -13441,7 +13441,7 @@
 	dir = 8;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qyY" = (
 /obj/item/defibrillator/primitive,
 /obj/effect/decal/cleanable/dirt,
@@ -13510,12 +13510,12 @@
 	pixel_x = 15
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qEd" = (
 /obj/structure/debris/v2,
 /obj/structure/debris/v3,
 /turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qEQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -13526,7 +13526,7 @@
 	pixel_y = 20
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qFJ" = (
 /obj/structure/sign/warning/securearea{
 	name = "Restricted Area"
@@ -13588,7 +13588,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qLh" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/orange,
@@ -13618,7 +13618,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qLI" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -13655,7 +13655,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qMZ" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -13664,7 +13664,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qNI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
@@ -13683,13 +13683,13 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qOR" = (
 /obj/structure/wreck/car{
 	desc = "An old pre-war car rusted and destroyed with age and weathering.  This one seems to have been used for quite a bit of target practice, with an uncountable number of bullet holes in it."
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qPa" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1
@@ -13706,7 +13706,7 @@
 	pixel_y = 1
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qPV" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
@@ -13723,7 +13723,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qQY" = (
 /mob/living/simple_animal/hostile/raider/ranged/biker{
 	name = "Razor Twins Raider"
@@ -13736,7 +13736,7 @@
 /obj/structure/barricade/sandbags,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qRn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -13756,19 +13756,19 @@
 "qRX" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qSL" = (
 /obj/structure/fence/corner,
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qSU" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qTg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13784,7 +13784,7 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qUb" = (
 /mob/living/simple_animal/hostile/bear/yaoguai,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13803,7 +13803,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qVT" = (
 /obj/structure/sign/poster/contraband/have_a_puff{
 	pixel_x = 32
@@ -13815,13 +13815,13 @@
 "qWC" = (
 /obj/structure/flora/tree/joshua,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qWV" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qXa" = (
 /obj/item/reagent_containers/glass/bottle/nutrient/rh,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -13833,7 +13833,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "qYK" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -13855,7 +13855,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rcx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13864,7 +13864,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rdJ" = (
 /obj/structure/car/rubbish3{
 	icon_state = "car_rubish2";
@@ -13872,7 +13872,7 @@
 	pixel_y = -20
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "reh" = (
 /obj/effect/landmark/start/f13/auxilia,
 /obj/effect/decal/cleanable/dirt,
@@ -13884,7 +13884,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rfl" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 8
@@ -13893,7 +13893,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rfs" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -13901,7 +13901,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rfA" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -13916,7 +13916,7 @@
 	name = "Powder Ganger baller"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rgn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13932,7 +13932,7 @@
 "rhf" = (
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rhC" = (
 /turf/open/floor/wood/wood_common{
 	icon_state = "common-broken1"
@@ -13943,7 +13943,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rir" = (
 /obj/effect/spawner/lootdrop/toolsbasic,
 /obj/structure/sign/warning/fire{
@@ -13961,18 +13961,18 @@
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "riG" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rjf" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rjl" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -14031,7 +14031,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rmu" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -14048,17 +14048,17 @@
 "rmS" = (
 /obj/item/lighter,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rmZ" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rnh" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rnt" = (
 /mob/living/simple_animal/hostile/vault/security{
 	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
@@ -14096,7 +14096,7 @@
 	name = "car battery"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rpD" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt{
@@ -14129,7 +14129,7 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rqJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -14142,7 +14142,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rsc" = (
 /obj/machinery/button/door{
 	id = 271;
@@ -14209,7 +14209,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rvd" = (
 /obj/structure/closet/crate/secure/hydroponics,
 /obj/item/plant_analyzer,
@@ -14255,7 +14255,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/bed,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ryf" = (
 /obj/structure/curtain{
 	color = "#c40e0e"
@@ -14273,7 +14273,7 @@
 "ryA" = (
 /obj/structure/stacklifter,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ryC" = (
 /obj/structure/barricade/bars{
 	max_integrity = 1200;
@@ -14304,11 +14304,11 @@
 /obj/structure/bed/old,
 /obj/item/bedsheet/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rzS" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rAE" = (
 /obj/item/paper{
 	pixel_x = -11;
@@ -14329,7 +14329,7 @@
 "rAF" = (
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rBb" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -14350,7 +14350,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rBh" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/f13{
@@ -14367,7 +14367,7 @@
 "rBn" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rCt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -14407,7 +14407,7 @@
 	icon_state = "trash_2"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rDq" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 1853;
@@ -14449,7 +14449,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rHf" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -14485,7 +14485,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rJb" = (
 /obj/structure/chair/bench,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -14516,7 +14516,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rKy" = (
 /obj/item/paper/fluff/ruins/deepstorage/water_concern{
 	info = "A reminder that regular monthly maintenace must be done on the experimental underground irrigation system to keep the system functional. Contact the below number to organize a scheduled upkeep regime from our technicians; As the system is still in it's experimental phase you will receive a 50% discount on any additional maintenance fees not covered by the contract.";
@@ -14554,13 +14554,13 @@
 "rMj" = (
 /obj/item/stack/sheet/metal/five,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rMl" = (
 /obj/structure/fence/corner/wooden{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rML" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/f13{
@@ -14572,14 +14572,14 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rNm" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rOx" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -14598,7 +14598,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rPW" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -14653,7 +14653,7 @@
 "rRH" = (
 /obj/item/shovel/trench,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rSn" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
@@ -14661,7 +14661,7 @@
 "rTl" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rTN" = (
 /obj/structure/flora/rock/jungle{
 	icon_state = "rock5";
@@ -14719,7 +14719,7 @@
 	},
 /obj/item/chair/stool,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rXd" = (
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14747,7 +14747,7 @@
 "rXY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rYd" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -14781,7 +14781,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "rZN" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -14805,7 +14805,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sbR" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -14831,11 +14831,11 @@
 /obj/item/clothing/glasses/night/f13/enclave,
 /obj/effect/spawner/lootdrop/f13/schoolgirl,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sdB" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sdR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
@@ -14874,7 +14874,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "siC" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -14924,7 +14924,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sny" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -15025,7 +15025,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /obj/machinery/light/small/broken,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "srk" = (
 /obj/structure/chair/sofa,
 /obj/structure/curtain{
@@ -15076,17 +15076,17 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "suj" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "suu" = (
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "suz" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -15101,7 +15101,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "suW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15114,14 +15114,14 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "svu" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "svG" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "swx" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -15174,7 +15174,7 @@
 	pixel_x = -9
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sCb" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -15200,7 +15200,7 @@
 "sDj" = (
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sDB" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -10;
@@ -15213,7 +15213,7 @@
 	color = "#515249"
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sDD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15272,7 +15272,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sIV" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks{
@@ -15305,7 +15305,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sJS" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -15317,7 +15317,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sKJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -15338,7 +15338,7 @@
 "sMy" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sMF" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -15359,7 +15359,7 @@
 	pixel_y = 22
 	},
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sOn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15436,7 +15436,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sSc" = (
 /turf/open/floor/carpet/green,
 /area/f13/building)
@@ -15452,7 +15452,7 @@
 	id = "firetowergate"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sSK" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt/harsh{
@@ -15466,7 +15466,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sSP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -15479,7 +15479,7 @@
 	icon_state = "car_rubish2"
 	},
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sUb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15504,7 +15504,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sVn" = (
 /obj/machinery/light{
 	dir = 8
@@ -15518,7 +15518,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sWs" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13{
@@ -15543,7 +15543,7 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sYV" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -15558,7 +15558,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "sZx" = (
 /obj/structure/ladder/unbreakable{
 	id = "PrisonService";
@@ -15589,7 +15589,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "taW" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -15608,7 +15608,7 @@
 /area/f13/legion)
 "tbm" = (
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tbz" = (
 /obj/structure/rack,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
@@ -15670,7 +15670,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tfS" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -15716,7 +15716,7 @@
 /area/f13/caves)
 "tiX" = (
 /turf/open/floor/wood/wood_worn/wood_worn_light,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tiY" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
@@ -15746,13 +15746,13 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tkm" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tkB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15772,7 +15772,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tlW" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
@@ -15784,7 +15784,7 @@
 	},
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tmN" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/debris/v3{
@@ -15793,12 +15793,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tnt" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/corner{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tnx" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15811,18 +15811,18 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "toe" = (
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tpO" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tqX" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -15835,7 +15835,7 @@
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "trP" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -15887,18 +15887,18 @@
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tvT" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "twx" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "txe" = (
 /obj/structure/table/wood,
 /obj/item/candle/infinite{
@@ -15930,7 +15930,7 @@
 "tzw" = (
 /mob/living/simple_animal/radstag,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tzH" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_common{
@@ -15950,7 +15950,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tAh" = (
 /obj/structure/fence{
 	dir = 8
@@ -15960,11 +15960,11 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tAD" = (
 /obj/structure/debris/v4,
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tAO" = (
 /obj/structure/toilet{
 	dir = 8
@@ -15977,7 +15977,7 @@
 "tAX" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tBs" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -16017,7 +16017,7 @@
 	dir = 1;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tEX" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
@@ -16074,7 +16074,7 @@
 "tIs" = (
 /obj/structure/junk/cabinet,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tII" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /obj/structure/table,
@@ -16098,7 +16098,7 @@
 	},
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tKX" = (
 /obj/structure/junk/small/bed,
 /turf/open/floor/f13/wood{
@@ -16112,7 +16112,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tLe" = (
 /turf/open/floor/carpet/orange,
 /area/f13/building)
@@ -16127,7 +16127,7 @@
 "tMV" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tNa" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/f13{
@@ -16140,14 +16140,14 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tNW" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tOl" = (
 /obj/structure/debris/v3,
 /obj/structure/debris/v3,
@@ -16164,7 +16164,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tPU" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -16219,7 +16219,7 @@
 "tTl" = (
 /obj/structure/reagent_dispensers/barrel,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tTU" = (
 /obj/structure/sink{
 	dir = 1;
@@ -16248,7 +16248,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "tWg" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -16306,7 +16306,7 @@
 "tZA" = (
 /obj/structure/junk/drawer,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uaw" = (
 /obj/structure/stairs/east{
 	color = "#A47449"
@@ -16318,17 +16318,17 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uaY" = (
 /obj/item/wrench/basic,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ubb" = (
 /obj/effect/overlay/turfs/sidewalk{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ubo" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -16350,7 +16350,7 @@
 "ubP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ucY" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
@@ -16393,22 +16393,22 @@
 /obj/structure/bed/old,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uhw" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uhI" = (
 /obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uhL" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uhS" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/reinforced,
@@ -16420,11 +16420,11 @@
 	pixel_y = -5
 	},
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uiC" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uiM" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16437,7 +16437,7 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ujC" = (
 /obj/structure/junk/small,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -16451,14 +16451,14 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ulK" = (
 /obj/structure/junk/small/table,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ulT" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "westranchgarage";
@@ -16479,7 +16479,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "unJ" = (
 /obj/effect/decal/riverbank,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -16498,7 +16498,7 @@
 "uod" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "upz" = (
 /obj/structure/simple_door/wood{
 	name = "Washroom"
@@ -16508,7 +16508,7 @@
 "upH" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "upT" = (
 /obj/structure/nest/gecko,
 /turf/open/indestructible/ground/outside/road{
@@ -16546,12 +16546,12 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "usc" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "usl" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -16607,12 +16607,12 @@
 	max_mobs = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "utH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uve" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
@@ -16627,7 +16627,7 @@
 "uvm" = (
 /obj/structure/flora/tree/cactus,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uvp" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks,
@@ -16645,7 +16645,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uvX" = (
 /obj/machinery/shower{
 	dir = 4
@@ -16662,7 +16662,7 @@
 	dir = 5;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uwI" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/applejack,
@@ -16682,19 +16682,19 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uxF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uyG" = (
 /obj/machinery/light/small/broken,
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uyJ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13{
@@ -16707,7 +16707,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uyU" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -16728,7 +16728,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uzE" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -16747,7 +16747,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uAn" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -16759,7 +16759,7 @@
 	pixel_y = 15
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uCz" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -16772,7 +16772,7 @@
 "uDi" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uDW" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/mechanical,
@@ -16788,7 +16788,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uFg" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -16823,7 +16823,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uFQ" = (
 /mob/living/simple_animal/hostile/lizard{
 	AIStatus = 3;
@@ -16838,7 +16838,7 @@
 /area/f13/legion)
 "uGk" = (
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uGn" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -16851,7 +16851,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uGS" = (
 /obj/structure/table/rolling,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -16876,7 +16876,7 @@
 "uJg" = (
 /obj/item/trash/f13/dog,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uJw" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -16886,13 +16886,13 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uJJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/coin,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uJU" = (
 /obj/structure/table/wood,
 /obj/item/pickaxe,
@@ -16930,7 +16930,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uLI" = (
 /obj/machinery/light{
 	dir = 8
@@ -16951,7 +16951,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uNc" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16983,7 +16983,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uOb" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -17018,20 +17018,20 @@
 "uQf" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uRL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/enclave,
 /obj/item/clothing/suit/armor/f13/power_armor/t51green,
 /obj/item/clothing/head/helmet/f13/power_armor/t51b,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uSd" = (
 /obj/structure/debris/v2,
 /obj/structure/debris/v2,
 /obj/structure/debris/v3,
 /turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uSn" = (
 /turf/closed/indestructible/riveted,
 /area/f13/caves)
@@ -17041,7 +17041,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uSJ" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -17069,13 +17069,13 @@
 /obj/effect/decal/cleanable/glass,
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uUn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uUK" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/wood_wide/wood_wide_light,
@@ -17111,7 +17111,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uWY" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -17126,7 +17126,7 @@
 "uXK" = (
 /obj/effect/decal/riverbank,
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "uXQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -17155,18 +17155,18 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vaW" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vbn" = (
 /obj/structure/flora/rock/jungle{
 	icon_state = "rock5"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vci" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/f13/legion/recruit,
@@ -17232,7 +17232,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vgf" = (
 /obj/item/cultivator,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -17247,13 +17247,13 @@
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vht" = (
 /obj/structure/debris/v3{
 	pixel_x = -12
 	},
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vhU" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17263,7 +17263,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -17288,7 +17288,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vjy" = (
 /obj/item/mop,
 /turf/open/floor/plasteel/darkgreen/side/telecomms,
@@ -17317,7 +17317,7 @@
 	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
 	name = "dirty water"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vld" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/vault/security{
@@ -17335,7 +17335,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vlD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -17361,11 +17361,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vnw" = (
 /obj/structure/junk/small,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "voE" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -17377,7 +17377,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vpo" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -17431,7 +17431,7 @@
 "vsw" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vsV" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/shield/riot,
@@ -17473,13 +17473,13 @@
 "vvA" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vvH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vvZ" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17488,7 +17488,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vwy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17500,7 +17500,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vwV" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17525,7 +17525,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vAn" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag{
@@ -17540,7 +17540,7 @@
 "vCg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vCT" = (
 /obj/machinery/door/airlock/highsecurity{
 	armor = list("melee" = 70, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
@@ -17577,25 +17577,25 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vEa" = (
 /obj/structure/fence/corner{
 	color = "#515249"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vEe" = (
 /obj/structure/bed/old,
 /obj/item/card/id/rusted/brokenholodog/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vEt" = (
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#ff4747"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vEv" = (
 /obj/structure/simple_door/metal/store,
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -17640,15 +17640,15 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vGf" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vGk" = (
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vGm" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
@@ -17664,7 +17664,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vGX" = (
 /mob/living/simple_animal/hostile/raider/baseball{
 	name = "Razor Twins Raider"
@@ -17696,7 +17696,7 @@
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vLp" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -17709,13 +17709,13 @@
 /area/f13/building)
 "vNb" = (
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vNk" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vNF" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v3,
@@ -17750,7 +17750,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vQb" = (
 /obj/structure/car/rubbish3{
 	icon_state = "car_rubish2"
@@ -17758,7 +17758,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vQh" = (
 /obj/machinery/light{
 	dir = 1
@@ -17775,12 +17775,12 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vRd" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/overlay/turfs/sidewalk,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vRw" = (
 /obj/structure/closet/fridge/standard,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -17816,7 +17816,7 @@
 /area/f13/building)
 "vSa" = (
 /turf/closed/mineral/random/high_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vTh" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -17843,7 +17843,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vTG" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -17851,7 +17851,7 @@
 "vTK" = (
 /obj/structure/reagent_dispensers/rainwater_tank,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vUC" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v4,
@@ -17861,7 +17861,7 @@
 "vVk" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vVK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17873,7 +17873,7 @@
 "vVN" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vWl" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v2,
@@ -17884,12 +17884,12 @@
 	name = "Razor Twins Raider"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vWq" = (
 /obj/structure/flora/grass/wasteland,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vWT" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -17903,11 +17903,11 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vXA" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vXF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17928,7 +17928,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vYK" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -17942,7 +17942,7 @@
 	desc = "Water that has been sitting for a long time, doesn't look very healthy for consumption.";
 	name = "dirty water"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "vYV" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
@@ -17987,7 +17987,7 @@
 /area/f13/building)
 "wdI" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wei" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -18009,7 +18009,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wey" = (
 /obj/machinery/processor/chopping_block,
 /obj/structure/table/reinforced,
@@ -18077,7 +18077,7 @@
 "whv" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "whC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18108,7 +18108,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wkl" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -18129,18 +18129,18 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wli" = (
 /obj/structure/fence{
 	color = "#515249";
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wlX" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wmy" = (
 /obj/structure/wreck/bus/blue{
 	name = "Prison Bus"
@@ -18148,7 +18148,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wmN" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/indestructible/ground/outside/road,
@@ -18156,7 +18156,7 @@
 "wnb" = (
 /obj/structure/fluff/railing,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wne" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -18171,7 +18171,7 @@
 "wns" = (
 /mob/living/simple_animal/hostile/bloatfly,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wnQ" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrusty"
@@ -18211,11 +18211,11 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wqX" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wrc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -18247,7 +18247,7 @@
 	pixel_y = 22
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wsR" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/shield/riot,
@@ -18262,7 +18262,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wth" = (
 /obj/item/melee/classic_baton,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -18289,7 +18289,7 @@
 	dir = 4;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wwd" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
@@ -18348,7 +18348,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wyA" = (
 /obj/item/seeds/cannabis,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -18357,7 +18357,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wzK" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -18370,7 +18370,7 @@
 "wAr" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wAt" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/toolsbasic,
@@ -18411,14 +18411,14 @@
 "wCL" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wDW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wEj" = (
 /obj/structure/closet,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -18426,7 +18426,7 @@
 "wEo" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wEX" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/f13/wood,
@@ -18434,7 +18434,7 @@
 "wFb" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wFd" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -18458,7 +18458,7 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wHC" = (
 /obj/item/chair/wood{
 	pixel_y = -6
@@ -18530,7 +18530,7 @@
 	dir = 4;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wKz" = (
 /obj/item/storage/backpack/genetics,
 /turf/open/floor/plasteel/f13{
@@ -18559,7 +18559,7 @@
 /turf/open/floor/wood/wood_wide/wood_wide_light{
 	icon_state = "wide_light-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wND" = (
 /obj/structure/stairs{
 	dir = 4
@@ -18581,7 +18581,7 @@
 "wPA" = (
 /obj/item/cultivator,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wSv" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -18605,7 +18605,7 @@
 	dir = 10;
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wVp" = (
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
@@ -18616,15 +18616,15 @@
 "wVM" = (
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wVT" = (
 /turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wWC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wWD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -18640,7 +18640,7 @@
 /obj/effect/spawner/bundle/f13/m1911,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wWZ" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt{
@@ -18659,7 +18659,7 @@
 "wXQ" = (
 /obj/structure/debris/v3,
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wYf" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged{
@@ -18682,7 +18682,7 @@
 	dir = 6
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "wYK" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -18724,7 +18724,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xaZ" = (
 /obj/structure/closet/crate/freezer{
 	storage_capacity = 30
@@ -18779,7 +18779,7 @@
 "xbG" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xbQ" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -18799,7 +18799,7 @@
 "xcS" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xdl" = (
 /obj/effect/overlay/junk/shower{
 	dir = 4
@@ -18822,7 +18822,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xeY" = (
 /obj/item/storage/trash_stack,
 /obj/machinery/light/broken{
@@ -18832,7 +18832,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xfq" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/oil{
@@ -18852,11 +18852,11 @@
 	},
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xfy" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xfM" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -18873,31 +18873,31 @@
 	pixel_y = -13
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xgV" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xhn" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xhD" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xiM" = (
 /obj/structure/lattice,
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xiZ" = (
 /obj/structure/wreck/bus/rusted{
 	desc = "A pre-war bus now serving as some kind of raider transport. Looks like it's out of fuel, though.";
 	name = "razor transport"
 	},
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xjr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18916,7 +18916,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xlj" = (
 /obj/item/storage/backpack/botany,
 /obj/effect/decal/cleanable/dirt,
@@ -18926,7 +18926,7 @@
 /area/f13/building)
 "xlq" = (
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xly" = (
 /obj/machinery/door/unpowered/celldoor{
 	name = "General Population"
@@ -18940,14 +18940,14 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xni" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xnX" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -18968,7 +18968,7 @@
 "xoP" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xpn" = (
 /obj/item/caution{
 	desc = "A sign denoting the presence of a likely very moist molerat.";
@@ -18996,19 +18996,19 @@
 	},
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xql" = (
 /obj/item/nullrod/tribal_knife{
 	name = "shiv"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xrw" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xsk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -19021,12 +19021,12 @@
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xsC" = (
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xth" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 1
@@ -19034,7 +19034,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xtx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
@@ -19043,22 +19043,22 @@
 "xui" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xuo" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /obj/structure/bookcase,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xuA" = (
 /obj/item/stack/sheet/bone,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xva" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xvC" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -19078,7 +19078,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xwV" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/drip,
@@ -19092,12 +19092,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xxH" = (
 /turf/open/indestructible/ground/outside/dirt/harsh/side{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xyQ" = (
 /obj/structure/barricade/wooden/planks,
 /obj/structure/decoration/rag,
@@ -19157,7 +19157,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xAH" = (
 /obj/effect/decal/cleanable/oil{
 	pixel_x = 15
@@ -19166,13 +19166,13 @@
 	dir = 8;
 	icon_state = "outerturn"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xAL" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xAV" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13{
@@ -19193,7 +19193,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xCd" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/glass,
@@ -19209,14 +19209,14 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	icon_state = "graveldirtedge"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xCV" = (
 /obj/item/storage/toolbox{
 	pixel_x = 5;
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xDn" = (
 /obj/item/kirbyplants/random,
 /obj/structure/curtain{
@@ -19238,7 +19238,7 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xEx" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -19249,19 +19249,19 @@
 "xEK" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xFo" = (
 /obj/effect/overlay/turfs/sidewalk{
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xFs" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/soap,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xFB" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -19284,7 +19284,7 @@
 /obj/effect/spawner/bundle/f13/plasmarifle,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xFG" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -19320,14 +19320,14 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavement"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xJd" = (
 /obj/structure/lattice,
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xJt" = (
 /obj/structure/lamp_post{
 	dir = 8;
@@ -19339,7 +19339,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xJx" = (
 /obj/structure/anvil/obtainable/table,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -19379,16 +19379,16 @@
 	icon = 'icons/fallout/turfs/f13roadharsh.dmi';
 	icon_state = "outerpavementcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xLw" = (
 /obj/effect/decal/riverbank,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xLP" = (
 /obj/structure/lattice,
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xMd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/darkgreen/side/telecomms{
@@ -19398,7 +19398,7 @@
 "xMi" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xMk" = (
 /obj/item/mine/shrapnel/random{
 	armed = 1
@@ -19424,10 +19424,10 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xOf" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xOs" = (
 /obj/machinery/msgterminal/legion,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -19447,7 +19447,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xQU" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh,
@@ -19501,7 +19501,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xUD" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -19515,7 +19515,7 @@
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xWh" = (
 /obj/effect/turf_decal/huge,
 /obj/effect/turf_decal/huge{
@@ -19523,7 +19523,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xWj" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -19533,14 +19533,14 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xXa" = (
 /mob/living/simple_animal/hostile/deathclaw/power_armor{
 	desc = "Ride's over, Mutie. Time to die.";
 	name = "Frank Clawigan"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xXe" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -19553,7 +19553,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "hole"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "xXU" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -19582,14 +19582,14 @@
 "ybp" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ybB" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/dirt/harsh{
 	dir = 10;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ycs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -19635,7 +19635,7 @@
 "ydz" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ydO" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/closet/cabinet,
@@ -19672,7 +19672,7 @@
 "yeK" = (
 /obj/item/trash/f13/crisps,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yfL" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -19694,7 +19694,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "yie" = (
 /obj/structure/debris/v3,
 /obj/structure/debris/v2,
@@ -19741,13 +19741,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ylu" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ylF" = (
 /obj/item/storage/trash_stack{
 	pixel_x = 8;
@@ -19756,7 +19756,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/rocksprings)
 "ymd" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{

--- a/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
@@ -91,7 +91,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -622,7 +622,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hY" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -731,7 +731,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jx" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt,
@@ -739,7 +739,7 @@
 /area/f13/ncr)
 "jB" = (
 /turf/open/indestructible,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -778,7 +778,7 @@
 "jU" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -830,7 +830,7 @@
 /area/f13/ncr)
 "ky" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kz" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood/wood_common,
@@ -905,7 +905,7 @@
 /area/f13/ncr)
 "ll" = (
 /turf/closed/indestructible/riveted,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1225,7 +1225,7 @@
 /area/f13/ncr)
 "oV" = (
 /turf/closed/wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oY" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_fancy,
@@ -1251,7 +1251,7 @@
 /turf/closed/wall/f13/vault{
 	name = "regulation wall"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pn" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -1294,7 +1294,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pT" = (
 /obj/structure/simple_door/room{
 	name = "Lieutenant"
@@ -1793,7 +1793,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vO" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -1927,7 +1927,7 @@
 	layer = 4.1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wH" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
@@ -2251,7 +2251,7 @@
 /area/f13/ncr)
 "zE" = (
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "zH" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -2303,7 +2303,7 @@
 /area/f13/city)
 "Az" = (
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "AC" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -2664,7 +2664,7 @@
 /area/f13/ncr)
 "EO" = (
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "EP" = (
 /obj/structure/railing{
 	dir = 4
@@ -2817,7 +2817,7 @@
 /area/f13/ncr)
 "Gv" = (
 /turf/closed/wall/f13/tentwall,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "Gx" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
@@ -2887,7 +2887,7 @@
 /area/f13/city)
 "Hd" = (
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "He" = (
 /obj/item/paper{
 	pixel_x = -7;
@@ -2934,7 +2934,7 @@
 /area/f13/ncr)
 "HW" = (
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "Ia" = (
 /obj/item/kirbyplants,
 /turf/open/floor/f13{
@@ -3080,7 +3080,7 @@
 /area/f13/ncr)
 "JU" = (
 /turf/closed/wall/f13/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3260,7 +3260,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "Mp" = (
 /obj/structure/curtain{
 	color = "#1e549c";
@@ -3583,7 +3583,7 @@
 "Pr" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "Pu" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -3907,7 +3907,7 @@
 	pixel_x = 6
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "TE" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -98,7 +98,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aal" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/f13{
@@ -138,7 +138,7 @@
 	},
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "abG" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -159,7 +159,7 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "acj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -241,7 +241,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ahM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -261,7 +261,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aiD" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -283,7 +283,7 @@
 "ajz" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ajL" = (
 /obj/structure/table,
 /obj/item/paper/fluff{
@@ -297,7 +297,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ajP" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -311,7 +311,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "akI" = (
 /obj/item/newspaper,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -360,7 +360,7 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "anv" = (
 /obj/effect/landmark/start/f13/ncrmedofficer,
 /obj/effect/decal/cleanable/dirt,
@@ -376,7 +376,7 @@
 "anW" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "api" = (
 /obj/structure/chair/stool/retro/backed,
 /turf/open/floor/f13/wood,
@@ -455,7 +455,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "asU" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/indestructible/ground/outside/road{
@@ -499,7 +499,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "awh" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -544,7 +544,7 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ayu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -575,7 +575,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ayC" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -16
@@ -585,7 +585,7 @@
 	pixel_y = -28
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ayJ" = (
 /obj/structure/sign/poster/official/report_crimes,
 /turf/closed/wall/r_wall/rust,
@@ -595,13 +595,13 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "azg" = (
 /obj/structure/fence{
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "azC" = (
 /obj/structure/fence{
 	dir = 4
@@ -612,7 +612,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "azM" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -625,13 +625,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aAe" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aAj" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/rock,
@@ -673,7 +673,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aEg" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -735,7 +735,7 @@
 "aHo" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aHW" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -772,7 +772,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aLd" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/f13{
@@ -829,7 +829,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aNm" = (
 /obj/structure/decoration/rag{
 	desc = "Writing in your own blood seems like a bad idea.";
@@ -844,7 +844,7 @@
 "aNo" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aNA" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/decal/remains/human,
@@ -852,7 +852,7 @@
 	icon_state = "floor6-old"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aNO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -865,7 +865,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aOT" = (
 /obj/effect/decal/waste,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -890,7 +890,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aQW" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/ncr)
@@ -993,14 +993,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aTS" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aTY" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/savannah,
@@ -1100,13 +1100,13 @@
 	dir = 8;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aXI" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aXN" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -1119,7 +1119,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aYy" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -1127,7 +1127,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "aZv" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1171,7 +1171,7 @@
 	pixel_y = -16
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bam" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -1207,7 +1207,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bcb" = (
 /obj/structure/closet/fridge,
 /obj/machinery/light/small{
@@ -1226,7 +1226,7 @@
 "bch" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bcH" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1250,7 +1250,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "beY" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1262,7 +1262,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bfd" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -1281,7 +1281,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bfB" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
@@ -1299,7 +1299,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bgV" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -1317,7 +1317,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bhk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
@@ -1335,7 +1335,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bhv" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -1349,7 +1349,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bjp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/wrench,
@@ -1406,13 +1406,13 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "blT" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bmg" = (
 /obj/structure/sign/poster/ncr/irradiated_food{
 	pixel_x = 32
@@ -1457,7 +1457,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bpm" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1476,7 +1476,7 @@
 	destination_y = 70;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bqb" = (
 /obj/structure/table/reinforced,
 /obj/item/pda/medical,
@@ -1573,11 +1573,11 @@
 /area/f13/city)
 "btE" = (
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "btZ" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "buT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
@@ -1595,7 +1595,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bwj" = (
 /obj/machinery/ticket_machine{
 	pixel_y = 32
@@ -1604,13 +1604,13 @@
 /area/f13/ncr)
 "bwo" = (
 /turf/closed/indestructible/f13/matrix,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bwN" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bxo" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -1667,7 +1667,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bBQ" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1681,7 +1681,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bDs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder,
@@ -1694,7 +1694,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bEI" = (
 /obj/structure/fence{
 	dir = 4
@@ -1707,7 +1707,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bEN" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -1722,7 +1722,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bFt" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -1751,11 +1751,11 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bGc" = (
 /mob/living/simple_animal/hostile/wolf/playable,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bGY" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -1763,11 +1763,11 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bHg" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bHK" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -1777,7 +1777,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bIC" = (
 /obj/structure/railing{
 	dir = 6
@@ -1822,12 +1822,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bKS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bKX" = (
 /obj/structure/obstacle/old_locked_door,
 /obj/structure/barricade/wooden/planks,
@@ -1881,7 +1881,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bPl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -1948,7 +1948,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bQy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -1961,7 +1961,7 @@
 	destination_y = 67;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bQZ" = (
 /obj/structure/junk/locker,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -1992,7 +1992,7 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bSZ" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -2030,7 +2030,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bVl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -2064,7 +2064,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bVD" = (
 /obj/structure/junk/cabinet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -2124,11 +2124,11 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bZb" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "bZj" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13{
@@ -2149,7 +2149,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cab" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -2178,7 +2178,7 @@
 	pixel_x = 22
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "caQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2200,7 +2200,7 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ccp" = (
 /obj/structure/simple_door/room{
 	name = "Unknown"
@@ -2224,7 +2224,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cdm" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13,
@@ -2238,7 +2238,7 @@
 /area/f13/city)
 "ceg" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ceu" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2263,7 +2263,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cfa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/computer/terminal{
@@ -2289,7 +2289,7 @@
 "cfM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cfZ" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2297,7 +2297,7 @@
 "cgr" = (
 /obj/item/shovel,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cgz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common{
@@ -2349,13 +2349,13 @@
 "ciQ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/bottomright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cjz" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cjG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2370,7 +2370,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cjN" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -2382,7 +2382,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ckn" = (
 /obj/structure/toilet{
 	dir = 4
@@ -2415,7 +2415,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "clF" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -10
@@ -2430,7 +2430,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cmB" = (
 /obj/effect/overlay/junk/toilet,
 /turf/open/floor/plasteel/f13{
@@ -2459,7 +2459,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cnL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/light/broken{
@@ -2487,7 +2487,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cph" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -2524,7 +2524,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cqO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -2566,12 +2566,12 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cuH" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cvf" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
@@ -2590,7 +2590,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cwX" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -2598,7 +2598,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cxk" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2623,7 +2623,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cxt" = (
 /obj/structure/table/wood/settler,
 /obj/item/ammo_box/magazine/m556/rifle,
@@ -2638,7 +2638,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "czd" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -2666,7 +2666,7 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cAB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -2698,7 +2698,7 @@
 /area/f13/city)
 "cBv" = (
 /turf/closed/wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cBy" = (
 /obj/structure/curtain,
 /turf/open/floor/f13,
@@ -2709,7 +2709,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cEe" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/f13{
@@ -2724,7 +2724,7 @@
 "cEB" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cEK" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
@@ -2778,7 +2778,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cHl" = (
 /obj/structure/campfire/stove,
 /turf/open/floor/wood/wood_common,
@@ -2796,7 +2796,7 @@
 	destination_y = 72;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cIj" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -2827,7 +2827,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cJd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/corp/corner{
@@ -2858,7 +2858,7 @@
 	pixel_y = 27
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cJB" = (
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
@@ -2896,12 +2896,12 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cMx" = (
 /obj/structure/debris/v3,
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cMJ" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
@@ -2926,7 +2926,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cNZ" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel{
@@ -2948,7 +2948,7 @@
 	icon_state = "board-1"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cOx" = (
 /obj/structure/fence{
 	dir = 4
@@ -2958,7 +2958,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cOB" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -2978,7 +2978,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cPJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3053,7 +3053,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cSh" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -3102,18 +3102,18 @@
 /area/f13/city)
 "cVa" = (
 /turf/closed/wall/mineral/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cVk" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cVr" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cVP" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_north"
@@ -3138,7 +3138,7 @@
 	pixel_y = 25
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cZg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3167,7 +3167,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "cZO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -3194,7 +3194,7 @@
 "daO" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dbu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
@@ -3207,7 +3207,7 @@
 /area/f13/city)
 "dbY" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dcj" = (
 /obj/structure/decoration/vent/rusty,
 /obj/effect/overlay/turfs/cliff{
@@ -3218,7 +3218,7 @@
 "dcB" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dda" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel{
@@ -3235,7 +3235,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "deh" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -3256,7 +3256,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "deK" = (
 /obj/structure/simple_door/house{
 	name = "North River Apartments"
@@ -3290,12 +3290,12 @@
 "dgz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dgH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dhf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -3370,7 +3370,7 @@
 /area/f13/ncr)
 "dlr" = (
 /turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dlv" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/f13/wood,
@@ -3383,7 +3383,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dmf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname{
@@ -3396,7 +3396,7 @@
 "dmA" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dmL" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -3464,7 +3464,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dpW" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -3534,7 +3534,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dsU" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -3563,11 +3563,11 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dtW" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "due" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -3585,7 +3585,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dux" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3625,7 +3625,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dwb" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3650,7 +3650,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dwA" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
@@ -3661,14 +3661,14 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dwY" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dxk" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -3677,7 +3677,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dxy" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -3716,7 +3716,7 @@
 "dzP" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dAn" = (
 /obj/structure/fence{
 	dir = 4
@@ -3805,7 +3805,7 @@
 	name = "corpse cart"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dGv" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/grass/jungle,
@@ -3824,7 +3824,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dIr" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3832,7 +3832,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dIQ" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/broken,
@@ -3854,7 +3854,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dKp" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/structure/barricade/wooden/strong,
@@ -3867,7 +3867,7 @@
 	dir = 4;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dKQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -3880,7 +3880,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dLF" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -3912,7 +3912,7 @@
 	pixel_x = 7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dNl" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks{
@@ -3921,13 +3921,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dNs" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dNK" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3959,7 +3959,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dPo" = (
 /obj/effect/overlay/junk/mirror{
 	pixel_x = -26;
@@ -3983,7 +3983,7 @@
 	dir = 1;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dQJ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -3998,7 +3998,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dRl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5";
@@ -4006,7 +4006,7 @@
 	pixel_y = -10
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dRs" = (
 /obj/structure/fence{
 	dir = 1
@@ -4015,7 +4015,7 @@
 	dir = 4;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dSH" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
@@ -4025,7 +4025,7 @@
 	pixel_y = -28
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4036,7 +4036,7 @@
 "dTw" = (
 /obj/item/newspaper,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dUo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/screwdriver,
@@ -4046,7 +4046,7 @@
 /area/f13/city)
 "dUq" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "dUC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -4119,7 +4119,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eax" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -4132,13 +4132,13 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eaW" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ebQ" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
@@ -4160,7 +4160,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ecZ" = (
 /obj/structure/table/wood,
 /obj/structure/railing/handrail/end{
@@ -4251,18 +4251,18 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eiv" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ejl" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ejR" = (
 /turf/open/floor/carpet/blue,
 /area/f13/ncr)
@@ -4294,13 +4294,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "elG" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "emM" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4312,7 +4312,7 @@
 	icon_state = "floor1-old"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "emS" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -4320,7 +4320,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ena" = (
 /obj/structure/sign/poster/prewar/poster72,
 /turf/closed/wall/f13/vault{
@@ -4356,7 +4356,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "epz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/spider/stickyweb,
@@ -4387,7 +4387,7 @@
 "erf" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "erv" = (
 /obj/effect/landmark/start/f13/ncrsergeant,
 /turf/open/floor/plasteel/vault,
@@ -4434,7 +4434,7 @@
 	icon_state = "floor6-old"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "esQ" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -4442,7 +4442,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eug" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -4492,13 +4492,13 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "exk" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eym" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/small/bed2,
@@ -4527,7 +4527,7 @@
 /area/f13/city)
 "ezi" = (
 /turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ezn" = (
 /obj/structure/fence{
 	dir = 8;
@@ -4539,7 +4539,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ezr" = (
 /obj/structure/junk/small/table,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -4608,7 +4608,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eFw" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -4706,7 +4706,7 @@
 "eJr" = (
 /obj/item/crafting/coffee_pot,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eJy" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -4727,7 +4727,7 @@
 	pixel_y = -8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eJU" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/item/chair,
@@ -4750,7 +4750,7 @@
 "eKG" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eLv" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -4883,7 +4883,7 @@
 "eRw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eSV" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/boxing/green,
@@ -4921,7 +4921,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eVg" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -4983,7 +4983,7 @@
 	pixel_x = -1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eYw" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 9;
@@ -4995,11 +4995,11 @@
 	},
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eYB" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eYO" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -5013,7 +5013,7 @@
 "eZL" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "eZX" = (
 /obj/structure/chair/office/light,
 /obj/structure/safe/floor,
@@ -5063,7 +5063,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fca" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/wasteland/ncr)
@@ -5076,7 +5076,7 @@
 "fda" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fds" = (
 /obj/machinery/light/small/broken{
 	dir = 1;
@@ -5141,7 +5141,7 @@
 "fhl" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fhz" = (
 /obj/structure/weightlifter,
 /turf/open/floor/f13{
@@ -5187,7 +5187,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verylittleshadowleft"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fiv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/room{
@@ -5203,7 +5203,7 @@
 "fjy" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fjz" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/f13/supermart,
@@ -5229,7 +5229,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fln" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/oil{
@@ -5270,7 +5270,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fnv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common{
@@ -5282,7 +5282,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fnB" = (
 /obj/structure/lattice{
 	pixel_x = 19
@@ -5290,7 +5290,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "foo" = (
 /turf/closed/wall/f13/wood,
 /area/f13/city)
@@ -5366,7 +5366,7 @@
 "fqq" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fqE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/armylootbasic,
@@ -5389,7 +5389,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "frL" = (
 /obj/machinery/vending/nukacolavend,
 /obj/effect/decal/cleanable/dirt,
@@ -5436,7 +5436,7 @@
 "ful" = (
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fup" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -5450,11 +5450,11 @@
 	icon_state = "tall_grass_5"
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fuD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fuF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -5477,7 +5477,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fvc" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -5498,7 +5498,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fvI" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
@@ -5506,14 +5506,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fvJ" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fvY" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fxD" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -5522,7 +5522,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fxI" = (
 /obj/structure/chair/sofa{
 	dir = 4
@@ -5587,18 +5587,18 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fyG" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fyZ" = (
 /obj/structure/railing/wood/underlayer{
 	dir = 1;
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fBy" = (
 /obj/structure/car/rubbish3{
 	pixel_x = -5
@@ -5606,7 +5606,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fCs" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -5618,7 +5618,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fCI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster81{
@@ -5685,7 +5685,7 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fFm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/corner{
@@ -5719,7 +5719,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fGM" = (
 /obj/machinery/light/small,
 /obj/structure/toilet{
@@ -5748,7 +5748,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fHR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -5773,7 +5773,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fIs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5787,13 +5787,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fJh" = (
 /obj/structure/railing/corner,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fJq" = (
 /obj/structure/window/fulltile/store,
 /turf/open/floor/plasteel/dark,
@@ -5829,14 +5829,14 @@
 "fKP" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fKY" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -14
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fLG" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -5872,7 +5872,7 @@
 "fQm" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fQt" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -5907,12 +5907,12 @@
 /area/f13/city)
 "fTN" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fTO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fUr" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -5947,7 +5947,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fWj" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -5970,13 +5970,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fWL" = (
 /obj/structure/railing/wood{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "fXy" = (
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -6065,7 +6065,7 @@
 	pixel_y = -12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gcy" = (
 /obj/machinery/door/unpowered/securedoor{
 	req_one_access_txt = "121"
@@ -6092,13 +6092,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ged" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gei" = (
 /obj/structure/railing/wood{
 	pixel_x = -2;
@@ -6112,14 +6112,14 @@
 /obj/item/hatchet,
 /obj/item/cultivator,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ges" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "geG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -6141,7 +6141,7 @@
 	},
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gfE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light,
@@ -6218,7 +6218,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gjQ" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13{
@@ -6228,7 +6228,7 @@
 "gke" = (
 /obj/structure/railing/wood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gkt" = (
 /obj/structure/table,
 /obj/item/export/bottle/rum{
@@ -6248,7 +6248,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gkx" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -6280,7 +6280,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gmv" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -6345,7 +6345,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gpO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -6357,7 +6357,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gqb" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/drinks/britcup{
@@ -6381,7 +6381,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "grE" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks{
@@ -6399,7 +6399,7 @@
 "gsp" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gsz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6419,18 +6419,18 @@
 	},
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gsT" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gtg" = (
 /obj/item/newspaper,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gto" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6565,7 +6565,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gxm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6617,7 +6617,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gyW" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel/f13{
@@ -6662,7 +6662,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gAI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -6700,7 +6700,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gBW" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -6743,16 +6743,16 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gFf" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gFr" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gFv" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6809,7 +6809,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gIo" = (
 /obj/structure/cargocrate,
 /obj/structure/cargocrate{
@@ -6819,7 +6819,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gIp" = (
 /obj/structure/stairs/east,
 /turf/open/floor/f13{
@@ -6855,7 +6855,7 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gLA" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/plantbgone,
@@ -6919,7 +6919,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gOS" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/wood_common,
@@ -6934,7 +6934,7 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gPD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6958,13 +6958,13 @@
 "gQo" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gRk" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gRt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/corner{
@@ -6980,7 +6980,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gSM" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 5;
@@ -6994,13 +6994,13 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gSO" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gTe" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland/ncr)
@@ -7022,13 +7022,13 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gVp" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gVr" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -7038,7 +7038,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gVI" = (
 /obj/machinery/microwave/stove,
 /obj/machinery/light/small{
@@ -7079,7 +7079,7 @@
 	},
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gYv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/shower{
@@ -7095,7 +7095,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "gYP" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7134,7 +7134,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "haK" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/glass,
@@ -7188,7 +7188,7 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hdM" = (
 /obj/structure/simple_door/tentflap_cloth{
 	pixel_y = -3
@@ -7226,7 +7226,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hen" = (
 /obj/item/gun/ballistic/revolver/hobo/knifegun,
 /obj/effect/decal/cleanable/dirt,
@@ -7249,7 +7249,7 @@
 "hfY" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hgd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -7260,7 +7260,7 @@
 	icon_state = "floor6-old"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hhq" = (
 /obj/machinery/door/unpowered/secure_steeldoor{
 	req_one_access_txt = "121"
@@ -7319,7 +7319,7 @@
 "hkJ" = (
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hle" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -7333,7 +7333,7 @@
 /obj/effect/decal/remains/deadeyebot,
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hmd" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/wood_common,
@@ -7353,7 +7353,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hoy" = (
 /obj/structure/mirelurkegg,
 /mob/living/simple_animal/hostile/mirelurk/baby,
@@ -7438,13 +7438,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hsZ" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "htr" = (
 /obj/effect/overlay/turfs/cliff/corner{
 	dir = 8;
@@ -7455,7 +7455,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "htK" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -7483,7 +7483,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hvh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/shower{
@@ -7513,7 +7513,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopborderbottom1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hwv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/sunset/brick_small_dark,
@@ -7548,7 +7548,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hwQ" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6";
@@ -7567,12 +7567,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hxc" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "worn_dark-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hxk" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/concrete/ten,
@@ -7629,7 +7629,7 @@
 "hBj" = (
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hBv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -7658,7 +7658,7 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hCu" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/f13{
@@ -7676,13 +7676,13 @@
 /area/f13/wasteland/ncr)
 "hDr" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hDx" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hDG" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall,
@@ -7695,7 +7695,7 @@
 "hDV" = (
 /obj/structure/flora/grass/jungle,
 /turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hEc" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet{
@@ -7711,7 +7711,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hFa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -7726,7 +7726,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hFs" = (
 /obj/structure/reagent_dispensers,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
@@ -7762,7 +7762,7 @@
 "hGU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hHb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/footlocker,
@@ -7806,7 +7806,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hJD" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_wide,
@@ -7820,7 +7820,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hJU" = (
 /obj/structure/simple_door/interior,
 /obj/machinery/door/poddoor/shutters{
@@ -7834,7 +7834,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hKf" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -7860,10 +7860,10 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hLa" = (
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hLl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -7886,7 +7886,7 @@
 	pixel_y = -28
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hNd" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -7903,7 +7903,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hNU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/room,
@@ -7916,7 +7916,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hPg" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -7931,7 +7931,7 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hPK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -8014,7 +8014,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hTx" = (
 /obj/structure/table/rolling,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -8031,11 +8031,11 @@
 	pixel_x = -10
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hUu" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hUX" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -8072,7 +8072,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "hYD" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8137,7 +8137,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ibM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8148,7 +8148,7 @@
 "ibY" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "icS" = (
 /obj/structure/sign/poster/ncr/keep_to_myself{
 	pixel_y = -32
@@ -8179,14 +8179,14 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "igs" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "igV" = (
 /obj/structure/simple_door/interior{
 	name = "Novely News"
@@ -8198,12 +8198,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ihj" = (
 /obj/structure/closet/crate/grave,
 /mob/living/simple_animal/butterfly,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ihs" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -8274,7 +8274,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ijK" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -8308,7 +8308,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ilv" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -8325,7 +8325,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ilG" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -8352,7 +8352,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "imp" = (
 /obj/item/chair,
 /turf/open/floor/f13{
@@ -8397,7 +8397,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iob" = (
 /obj/machinery/shower{
 	dir = 8
@@ -8438,12 +8438,12 @@
 "ioY" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ipp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ipU" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/bars,
@@ -8453,7 +8453,7 @@
 /area/f13/city)
 "iqb" = (
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iqc" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/freezer{
@@ -8481,7 +8481,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iqT" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland/ncr)
@@ -8505,13 +8505,13 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "isn" = (
 /obj/structure/chair/stool/retro,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "isq" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 9;
@@ -8553,7 +8553,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "itR" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/empty,
@@ -8588,17 +8588,17 @@
 	dir = 4;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ivS" = (
 /obj/structure/closet/crate/large,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iwj" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iwD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -8617,7 +8617,7 @@
 	pixel_y = 1
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ixi" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/iv_drip{
@@ -8694,11 +8694,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iBp" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iBy" = (
 /obj/structure/fence{
 	max_integrity = 500;
@@ -8707,12 +8707,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iBG" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iBM" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8722,7 +8722,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "innermiddle"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iBY" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -8797,7 +8797,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iEN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -8828,7 +8828,7 @@
 	},
 /obj/effect/spawner/lootdrop/druggie_pill,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iHg" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket,
@@ -8902,11 +8902,11 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iLu" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/bottomright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iMi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/missing_gloves{
@@ -8942,7 +8942,7 @@
 /obj/structure/flora/grass/wasteland,
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iOd" = (
 /obj/structure/fence/corner,
 /obj/structure/destructible/tribal_torch/lit{
@@ -9034,7 +9034,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iTK" = (
 /obj/structure/kitchenspike,
 /obj/item/kitchen/knife/butcher,
@@ -9049,7 +9049,7 @@
 "iUx" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iVn" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_common,
@@ -9077,7 +9077,7 @@
 	dir = 4;
 	icon_state = "crossborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "iYn" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -9174,7 +9174,7 @@
 "jcl" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jdl" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/geiger_counter,
@@ -9187,7 +9187,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jdx" = (
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
@@ -9196,7 +9196,7 @@
 "jdJ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jdS" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -9216,7 +9216,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jeZ" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/shower{
@@ -9235,7 +9235,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jgf" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -9243,7 +9243,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jgp" = (
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
@@ -9265,7 +9265,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jiq" = (
 /obj/machinery/sleeper,
 /turf/open/floor/f13{
@@ -9301,7 +9301,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jkR" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9318,7 +9318,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jlS" = (
 /obj/effect/decal/waste,
 /turf/open/floor/plating/rust,
@@ -9361,7 +9361,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "joT" = (
 /obj/structure/decoration/vent/rusty,
 /obj/effect/decal/cleanable/dirt,
@@ -9432,7 +9432,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jtZ" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9446,7 +9446,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "juF" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/city)
@@ -9494,7 +9494,7 @@
 "jwv" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jwO" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -9505,7 +9505,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jyh" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
@@ -9528,7 +9528,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jAt" = (
 /obj/structure/car/rubbish3{
 	pixel_x = -5
@@ -9536,7 +9536,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jAx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9576,7 +9576,7 @@
 "jAL" = (
 /obj/structure/closet/crate/large,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jAX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -9592,7 +9592,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jDt" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -9651,7 +9651,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jGc" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -9710,7 +9710,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jIy" = (
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/dark,
@@ -9760,7 +9760,7 @@
 "jKz" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jKL" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/dark,
@@ -9793,7 +9793,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jNT" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 9;
@@ -9804,7 +9804,7 @@
 	pixel_x = 22
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jOe" = (
 /obj/effect/decal/waste{
 	pixel_x = 20;
@@ -9837,7 +9837,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jPg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
@@ -9916,7 +9916,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jSz" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -9930,7 +9930,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jSI" = (
 /obj/structure/simple_door/metal/store{
 	name = "Representative"
@@ -9971,7 +9971,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jTO" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -10037,12 +10037,12 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jWt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jWH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
@@ -10075,7 +10075,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "jZr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -10094,7 +10094,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kbf" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -10122,7 +10122,7 @@
 "kcm" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kdO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10169,7 +10169,7 @@
 	pixel_y = -5
 	},
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kha" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/neutral/side{
@@ -10223,14 +10223,14 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kkm" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kkC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/missing_gloves{
@@ -10261,20 +10261,20 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "klV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/water,
 /area/f13/wasteland/ncr)
 "kmn" = (
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "knK" = (
 /obj/structure/fence,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "knT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10283,7 +10283,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "koX" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -10310,19 +10310,19 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "krC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "krI" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
 	destination_y = 65;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ksu" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -10332,7 +10332,7 @@
 "ksA" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kti" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
@@ -10368,7 +10368,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kvn" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -10377,7 +10377,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kwt" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
@@ -10403,7 +10403,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kyM" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -10417,7 +10417,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kzC" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -10449,7 +10449,7 @@
 /obj/structure/debris/v3,
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kAI" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood/wood_common,
@@ -10460,7 +10460,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kBK" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -10486,7 +10486,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kDb" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -10509,19 +10509,19 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kDZ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kEq" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city)
 "kEs" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kEw" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -10533,13 +10533,13 @@
 "kEA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kEF" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kEO" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -10548,7 +10548,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kET" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -10567,7 +10567,7 @@
 	icon_state = "tall_grass_5"
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kGh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10604,7 +10604,7 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kHI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/renegade/grunt,
@@ -10667,7 +10667,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kJq" = (
 /obj/item/defibrillator/primitive{
 	pixel_y = 6
@@ -10810,19 +10810,19 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kQH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kQI" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kQJ" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/darkbrown/side{
@@ -10836,7 +10836,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kRx" = (
 /obj/structure/junk/cabinet,
 /turf/open/floor/wood/wood_common,
@@ -10896,7 +10896,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kVy" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -10919,7 +10919,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kWk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants{
@@ -10961,7 +10961,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kYD" = (
 /obj/effect/decal/waste,
 /turf/open/floor/f13,
@@ -10993,7 +10993,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "kZn" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -11023,7 +11023,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "laj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -11035,7 +11035,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "laC" = (
 /obj/structure/decoration/rag{
 	desc = "Writing in your own blood seems like a bad idea.";
@@ -11048,7 +11048,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "laH" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11164,10 +11164,10 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lez" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "leW" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/chair/greyscale{
@@ -11209,7 +11209,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lgQ" = (
 /obj/structure/fence{
 	dir = 4
@@ -11228,7 +11228,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lhG" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -11259,7 +11259,7 @@
 /area/f13/city)
 "liU" = (
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ljq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/syringe/stimulants,
@@ -11296,7 +11296,7 @@
 "lll" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "llV" = (
 /turf/open/indestructible,
 /area/f13/caves)
@@ -11330,13 +11330,13 @@
 	pixel_y = -11
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lpH" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lpT" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -11399,7 +11399,7 @@
 /area/f13/city)
 "lsq" = (
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lsr" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -11425,7 +11425,7 @@
 	dir = 8;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ltn" = (
 /obj/item/clothing/suit/radiation,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11436,7 +11436,7 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ltC" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/indestructible/rock,
@@ -11446,7 +11446,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ltS" = (
 /obj/structure/chair/pew{
 	dir = 4
@@ -11466,7 +11466,7 @@
 	dir = 1
 	},
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "luW" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4;
@@ -11482,7 +11482,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lvj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
@@ -11490,7 +11490,7 @@
 "lvp" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lvu" = (
 /obj/machinery/door/airlock/vault,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11514,13 +11514,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lxQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lyA" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -11567,7 +11567,7 @@
 	},
 /obj/structure/closet/crate/grave,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lAJ" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -11604,7 +11604,7 @@
 "lBD" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lCk" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -11612,7 +11612,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lDI" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -11625,7 +11625,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken6"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lEf" = (
 /obj/structure/flora/junglebush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11664,7 +11664,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lHx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -11680,7 +11680,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lIB" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -11763,7 +11763,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lMq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -11778,12 +11778,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lMO" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lMX" = (
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 8
@@ -11896,7 +11896,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lQS" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -11992,13 +11992,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lUw" = (
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lUN" = (
 /obj/structure/fence{
 	dir = 4
@@ -12007,7 +12007,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lVx" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 8;
@@ -12032,7 +12032,7 @@
 /area/f13/ncr)
 "lVT" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "lWi" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall/f13/supermart,
@@ -12141,7 +12141,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mcn" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate"
@@ -12166,7 +12166,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mdv" = (
 /obj/structure/plasticflaps,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12192,11 +12192,11 @@
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mfw" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mfC" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
@@ -12211,7 +12211,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mgu" = (
 /obj/structure/junk/small/table,
 /obj/item/stack/sheet/mineral/wood,
@@ -12295,7 +12295,7 @@
 /area/f13/city)
 "mjQ" = (
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mkf" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/blood/old{
@@ -12350,11 +12350,11 @@
 "mmB" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mna" = (
 /obj/structure/closet/crate/large,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mnt" = (
 /obj/machinery/light{
 	dir = 1;
@@ -12397,7 +12397,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mrA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
@@ -12412,7 +12412,7 @@
 "msz" = (
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "msT" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12424,7 +12424,7 @@
 "mtU" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "muj" = (
 /obj/structure/safe,
 /obj/effect/decal/cleanable/dirt,
@@ -12480,7 +12480,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mwR" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -12508,7 +12508,7 @@
 	pixel_y = -12
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mys" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/f13,
@@ -12520,24 +12520,24 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mzh" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 9;
 	pixel_y = -17
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mzv" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mzI" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mAm" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -12556,7 +12556,7 @@
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mCe" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/wood/wood_common,
@@ -12602,7 +12602,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mDz" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/city)
@@ -12651,7 +12651,7 @@
 "mEQ" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mES" = (
 /obj/structure/table,
 /obj/item/export/bottle/whiskey,
@@ -12694,7 +12694,7 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mGc" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/wood/wood_common,
@@ -12720,7 +12720,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mGL" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -12738,7 +12738,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mHM" = (
 /obj/item/reagent_containers/food/urinalcake{
 	pixel_x = -6;
@@ -12755,7 +12755,7 @@
 "mIf" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mIm" = (
 /obj/item/chair,
 /turf/open/floor/wood/wood_common,
@@ -12765,7 +12765,7 @@
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mJK" = (
 /obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -12787,7 +12787,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mKL" = (
 /obj/structure/closet/crate/secure/gear{
 	anchored = 1;
@@ -12804,17 +12804,17 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mKY" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mLl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mLp" = (
 /obj/structure/easel,
 /turf/open/floor/f13{
@@ -12828,14 +12828,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mMA" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mOt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -12847,7 +12847,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mOY" = (
 /obj/structure/railing{
 	dir = 8
@@ -12855,7 +12855,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mPL" = (
 /obj/structure/fence/cut/medium{
 	dir = 4
@@ -12879,13 +12879,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mQU" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mRu" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -12903,7 +12903,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mRR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13016,7 +13016,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mVa" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -13025,7 +13025,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "mVp" = (
 /obj/structure/lamp_post{
 	dir = 1
@@ -13161,7 +13161,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "naH" = (
 /obj/structure/junk/small/table,
 /obj/item/stack/sheet/mineral/wood,
@@ -13171,7 +13171,7 @@
 /obj/structure/chair/stool/f13stool,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "naZ" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -13179,7 +13179,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/bed,
@@ -13193,7 +13193,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nbw" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -13222,7 +13222,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nbX" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -13236,17 +13236,17 @@
 "ndk" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ndt" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-1"
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ndz" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ndR" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -13287,7 +13287,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nfw" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
@@ -13330,7 +13330,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nhA" = (
 /obj/structure/rack,
 /obj/item/twohanded/baseball/spiked,
@@ -13371,7 +13371,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "njY" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -13427,7 +13427,7 @@
 "nlV" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nmG" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13445,7 +13445,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nmP" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
@@ -13458,7 +13458,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nmW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13483,7 +13483,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nnp" = (
 /obj/structure/chair/folding{
 	dir = 1
@@ -13497,7 +13497,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "noj" = (
 /obj/machinery/light{
 	dir = 1;
@@ -13520,14 +13520,14 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "noU" = (
 /obj/structure/fence{
 	max_integrity = 500;
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nqk" = (
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
 /area/f13/wasteland/ncr)
@@ -13536,7 +13536,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nqZ" = (
 /turf/open/floor/f13{
 	icon_state = "redchess"
@@ -13548,7 +13548,7 @@
 	destination_y = 66;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nsK" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13574,7 +13574,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ntL" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -13635,7 +13635,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nwc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -13674,7 +13674,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nxZ" = (
 /obj/item/stack/sheet/mineral/uranium{
 	amount = 3
@@ -13733,7 +13733,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nCY" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -13748,7 +13748,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nEK" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	icon_state = "blood2"
@@ -13767,7 +13767,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nFt" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -13823,13 +13823,13 @@
 /area/f13/caves)
 "nHP" = (
 /turf/open/indestructible/ground/outside/savannah/topleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nIf" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nJo" = (
 /obj/structure/flora/grass/jungle,
 /obj/machinery/light/small/broken{
@@ -13842,7 +13842,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nJZ" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -13875,7 +13875,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nMu" = (
 /obj/structure/grille,
 /obj/structure/barricade/bars{
@@ -13907,7 +13907,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nNH" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -13920,7 +13920,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nQB" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -13976,7 +13976,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nSV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/ncr/keep_to_myself{
@@ -14014,7 +14014,7 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nVj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
@@ -14040,7 +14040,7 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nWu" = (
 /obj/structure/sign/poster/contraband/tools,
 /turf/closed/wall/f13/store,
@@ -14060,7 +14060,7 @@
 	pixel_y = -24
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nXF" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -14125,13 +14125,13 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nZm" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "nZR" = (
 /obj/structure/table,
 /obj/item/key,
@@ -14188,7 +14188,7 @@
 "obo" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "obC" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pestspray,
@@ -14223,7 +14223,7 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "odK" = (
 /obj/structure/wreck/trash/brokenvendor,
 /obj/effect/decal/cleanable/dirt,
@@ -14243,7 +14243,7 @@
 /obj/structure/chair/bench,
 /obj/machinery/light,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oeV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -14256,12 +14256,12 @@
 "ofL" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ogp" = (
 /obj/structure/car/rubbish3,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ogP" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14299,7 +14299,7 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ojo" = (
 /obj/structure/barricade/tentclothcorner{
 	pixel_y = 3
@@ -14307,7 +14307,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ojM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14334,7 +14334,7 @@
 	pixel_y = -2
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "okw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14361,7 +14361,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "onr" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -14385,7 +14385,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ooE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -14443,11 +14443,11 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oth" = (
 /obj/structure/chair/stool/f13stool,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oum" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -14469,7 +14469,7 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ovx" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -14550,7 +14550,7 @@
 	name = "Restricted Area"
 	},
 /turf/closed/wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oxQ" = (
 /obj/structure/sign/warning/nosmoking/circle,
 /turf/closed/wall/f13/store,
@@ -14567,7 +14567,7 @@
 	},
 /obj/structure/railing/wood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oAx" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -12
@@ -14578,11 +14578,11 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oAB" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oBi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -14611,7 +14611,7 @@
 	pixel_x = 22
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oCj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -14627,7 +14627,7 @@
 "oCX" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oEu" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /obj/effect/decal/remains/human,
@@ -14637,7 +14637,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oED" = (
 /turf/closed/wall/r_wall,
 /area/f13/wasteland/ncr)
@@ -14660,7 +14660,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oHQ" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -14681,7 +14681,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oIy" = (
 /obj/structure/sign/poster/ncr/keep_to_myself{
 	pixel_y = -32
@@ -14709,13 +14709,13 @@
 "oKt" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oKA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oKE" = (
 /obj/structure/railing{
 	dir = 4
@@ -14724,7 +14724,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oKF" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks{
@@ -14772,13 +14772,13 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oNt" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oNz" = (
 /obj/structure/table/booth,
 /obj/item/flashlight/lamp/green{
@@ -14796,7 +14796,7 @@
 "oOn" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oOo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -14860,13 +14860,13 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oSE" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oSQ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -14916,7 +14916,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oTX" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/road,
@@ -14927,7 +14927,7 @@
 	pixel_x = 7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oUW" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
@@ -14942,7 +14942,7 @@
 	destination_y = 69;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oVi" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -14999,7 +14999,7 @@
 	pixel_x = 4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oXF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction{
 	dir = 1
@@ -15031,7 +15031,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oZg" = (
 /obj/structure/sign/poster/ncr/democracy{
 	pixel_x = 32
@@ -15048,7 +15048,7 @@
 	pixel_y = -11
 	},
 /turf/open/indestructible/ground/outside/savannah/topleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "oZw" = (
 /obj/structure/toilet/secret/high_loot{
 	dir = 1
@@ -15066,7 +15066,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pau" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/road{
@@ -15083,11 +15083,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pbt" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pbC" = (
 /obj/structure/railing/wood/underlayer{
 	dir = 1;
@@ -15102,7 +15102,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pbY" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/wood/wood_common,
@@ -15126,7 +15126,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pdR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15171,7 +15171,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pgh" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15203,7 +15203,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "phL" = (
 /obj/structure/fence{
 	dir = 4
@@ -15245,13 +15245,13 @@
 	pixel_x = -18
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pkQ" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontaltopborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pkU" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/structure/spider/stickyweb,
@@ -15272,7 +15272,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "plR" = (
 /obj/structure/sign/poster/official/cohiba_robusto_ad,
 /turf/closed/wall/rust,
@@ -15283,11 +15283,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pmr" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pmA" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/venus_human_trap,
@@ -15304,7 +15304,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "poQ" = (
 /obj/structure/obstacle/jammed_door,
 /turf/open/floor/plasteel/dark,
@@ -15406,7 +15406,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pxX" = (
 /obj/structure/closet/cardboard,
 /obj/machinery/light/broken,
@@ -15445,7 +15445,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pAE" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -15453,7 +15453,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pAJ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -15473,7 +15473,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pCQ" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -15485,12 +15485,12 @@
 "pDB" = (
 /obj/structure/closet/crate/grave,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pDT" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pDX" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -15504,7 +15504,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pFw" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -15514,14 +15514,14 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pFz" = (
 /obj/machinery/smartfridge/bottlerack/grownbin{
 	pixel_x = 2;
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pFA" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -15539,7 +15539,7 @@
 "pFU" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pFV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/druggie_pill,
@@ -15592,7 +15592,7 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pIh" = (
 /obj/machinery/light{
 	dir = 8
@@ -15633,7 +15633,7 @@
 	pixel_y = 7
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pIS" = (
 /obj/structure/closet,
 /obj/item/radio{
@@ -15674,7 +15674,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pKD" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner,
@@ -15699,7 +15699,7 @@
 "pKV" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pLb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -15779,7 +15779,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pOR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -15805,7 +15805,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pPZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
@@ -15826,7 +15826,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pQO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
@@ -15844,7 +15844,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pRN" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -15853,7 +15853,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pSl" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15871,7 +15871,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pSQ" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
@@ -15902,7 +15902,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pTk" = (
 /obj/structure/disposalpipe/broken,
 /obj/effect/decal/cleanable/oil{
@@ -15924,7 +15924,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pTJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -15936,7 +15936,7 @@
 "pVt" = (
 /obj/structure/wreck/car/bike,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pVF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -15993,13 +15993,13 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pXp" = (
 /obj/structure/car/rubbish4,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "pXz" = (
 /obj/item/stack/ore/lead,
 /turf/open/water,
@@ -16046,7 +16046,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qaI" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -16112,7 +16112,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qeU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16151,7 +16151,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qhp" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13{
@@ -16162,7 +16162,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopborderbottom1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qib" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -16216,12 +16216,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qkd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qkf" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/armylootbasic,
@@ -16239,11 +16239,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qkJ" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qkS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/indestructible/ground/outside/road,
@@ -16258,11 +16258,11 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qnc" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qno" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner,
@@ -16275,13 +16275,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qnN" = (
 /obj/structure/wreck/trash/one_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qnY" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -16294,7 +16294,7 @@
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qon" = (
 /obj/structure/railing{
 	dir = 4
@@ -16348,7 +16348,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qqp" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -16378,7 +16378,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qrv" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
@@ -16406,7 +16406,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qsM" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gatehouse";
@@ -16428,7 +16428,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qta" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/hemostat,
@@ -16452,7 +16452,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qud" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16502,7 +16502,7 @@
 "qxm" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qxo" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
@@ -16566,7 +16566,7 @@
 "qzt" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qzv" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/city)
@@ -16595,11 +16595,11 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qzO" = (
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qAm" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/f13{
@@ -16611,14 +16611,14 @@
 	dir = 8;
 	icon_state = "crossborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qBd" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qBn" = (
 /obj/structure/sink/well{
 	pixel_x = -20;
@@ -16650,7 +16650,7 @@
 	pixel_y = -24
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qDb" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -16659,7 +16659,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qDx" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16719,7 +16719,7 @@
 	dir = 1;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qFe" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -16742,12 +16742,12 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qFR" = (
 /obj/structure/car/rubbish2,
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qGx" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -16768,7 +16768,7 @@
 /area/f13/city)
 "qHk" = (
 /turf/closed/wall/f13/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qHr" = (
 /obj/item/bedsheet/cmo,
 /obj/structure/bed,
@@ -16789,19 +16789,19 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qHH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qIF" = (
 /obj/structure/fence{
 	max_integrity = 500;
 	name = "reinforced fence"
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qJp" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -16854,7 +16854,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qLD" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16878,7 +16878,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qMY" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag,
@@ -16891,7 +16891,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qNJ" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -16901,13 +16901,13 @@
 "qNO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qOa" = (
 /obj/structure/chair/stool/bar,
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qOd" = (
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/city)
@@ -16925,13 +16925,13 @@
 "qOq" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qOD" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qPP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16950,7 +16950,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qQi" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -16962,7 +16962,7 @@
 	},
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qQr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/glass/bottle/sacid{
@@ -17022,7 +17022,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qRN" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 8;
@@ -17036,7 +17036,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qSE" = (
 /obj/machinery/light{
 	dir = 4
@@ -17048,7 +17048,7 @@
 "qSX" = (
 /obj/structure/wreck/car/bike,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qTs" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/water,
@@ -17082,7 +17082,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qUj" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
 /turf/closed/wall/rust,
@@ -17114,11 +17114,11 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qXa" = (
 /obj/structure/wreck/bus/rusted,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qYt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/junk/toilet{
@@ -17151,7 +17151,7 @@
 "qZp" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "qZx" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -17173,18 +17173,18 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "raJ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "raM" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rbo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -17219,20 +17219,20 @@
 "rdo" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rdq" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rdr" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rdF" = (
 /obj/structure/simple_door/metal/iron{
 	req_access_txt = "87"
@@ -17246,7 +17246,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "reo" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -17275,7 +17275,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rgb" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 5;
@@ -17290,7 +17290,7 @@
 	pixel_x = -18
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rge" = (
 /obj/effect/overlay/turfs/sidewalk,
 /obj/machinery/light/small{
@@ -17307,7 +17307,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rhs" = (
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
@@ -17425,14 +17425,14 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rmV" = (
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rna" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13{
@@ -17452,7 +17452,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rom" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood/wood_wide,
@@ -17479,13 +17479,13 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rqx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rqU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -17505,11 +17505,11 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rrl" = (
 /obj/item/storage/box/matches,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rse" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/sandbags,
@@ -17540,11 +17540,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rsO" = (
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rsT" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_x = 3;
@@ -17553,7 +17553,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rsY" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -17565,7 +17565,7 @@
 "rto" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rtJ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -17587,11 +17587,11 @@
 	dir = 4;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ruW" = (
 /obj/structure/billboard/cola,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rvf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_fancy,
@@ -17624,7 +17624,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rvy" = (
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -17664,7 +17664,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rxJ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -17676,7 +17676,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ryb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/broken{
@@ -17717,13 +17717,13 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ryO" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ryT" = (
 /obj/structure/decoration/rag{
 	layer = 4.3;
@@ -17733,13 +17733,13 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ryV" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rzr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -17759,7 +17759,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rzZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/broken{
@@ -17779,14 +17779,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rAj" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rAm" = (
 /obj/structure/barricade/tentclothcorner{
 	pixel_y = 3
@@ -17794,7 +17794,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rAA" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -17851,7 +17851,7 @@
 "rDb" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rDx" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -17940,7 +17940,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rIg" = (
 /obj/machinery/door/airlock/medical{
 	name = "Laboratory";
@@ -17961,7 +17961,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rJI" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -17998,7 +17998,7 @@
 	icon_state = "tall_grass_8"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rLd" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -18010,7 +18010,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rNK" = (
 /obj/structure/legion_extractor,
 /obj/machinery/light/small{
@@ -18061,7 +18061,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rQJ" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = 12
@@ -18069,7 +18069,7 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rRl" = (
 /obj/item/broken_bottle{
 	pixel_x = -8;
@@ -18134,7 +18134,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rUX" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
@@ -18182,7 +18182,7 @@
 	pixel_y = -18
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rXe" = (
 /obj/effect/decal/remains/human,
 /obj/machinery/light/small{
@@ -18225,7 +18225,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rZh" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowleft"
@@ -18240,7 +18240,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "rZT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -18253,7 +18253,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "saj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18265,7 +18265,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sbp" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 5;
@@ -18277,7 +18277,7 @@
 	pixel_y = -7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sby" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing{
@@ -18293,7 +18293,7 @@
 	pixel_y = -12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "scq" = (
 /obj/item/clothing/glasses/legiongoggles{
 	pixel_y = -6
@@ -18310,13 +18310,13 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "scx" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sdi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -18356,7 +18356,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sfv" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -18371,18 +18371,18 @@
 "sfz" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sfE" = (
 /obj/structure/fence{
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sgb" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sgn" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -18390,7 +18390,7 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sgu" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -18405,7 +18405,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sik" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18420,14 +18420,14 @@
 	dir = 6;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "skg" = (
 /obj/structure/campfire/barrel,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "skT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -18444,7 +18444,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sls" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -18500,7 +18500,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "snN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
@@ -18514,7 +18514,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "spo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18540,7 +18540,7 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sqI" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -18579,7 +18579,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "stm" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 8
@@ -18609,7 +18609,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "suv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/mattress{
@@ -18626,7 +18626,7 @@
 "suC" = (
 /obj/structure/beebox/premade/random,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "suF" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -18636,7 +18636,7 @@
 "suK" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "suN" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -38;
@@ -18645,7 +18645,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "suS" = (
 /obj/structure/mirror{
 	pixel_x = -24;
@@ -18658,7 +18658,7 @@
 "suT" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "svf" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood/wood_common,
@@ -18704,7 +18704,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sxK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/bone,
@@ -18714,14 +18714,14 @@
 /area/f13/city)
 "sxM" = (
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sxO" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "syO" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18734,7 +18734,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "szn" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -18745,7 +18745,7 @@
 /obj/structure/debris/v3,
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "szO" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
@@ -18764,7 +18764,7 @@
 	pixel_y = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sAr" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/wood/wood_common,
@@ -18789,13 +18789,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sAT" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sBv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18811,7 +18811,7 @@
 	name = "Billy the Goat"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sBE" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/f13/wood,
@@ -18828,7 +18828,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sDQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -18849,7 +18849,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sEw" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 8
@@ -18949,13 +18949,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sKf" = (
 /obj/structure/junk/locker,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sKm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18982,7 +18982,7 @@
 	pixel_y = 1
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sMf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19002,10 +19002,10 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sOd" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sOp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19015,7 +19015,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sOV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/f13/bubblegum_large,
@@ -19031,11 +19031,11 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sPD" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sPH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
@@ -19078,7 +19078,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sSb" = (
 /obj/structure/car/rubbish3{
 	pixel_x = -5
@@ -19101,7 +19101,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sSH" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -19159,7 +19159,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sUD" = (
 /obj/structure/fence{
 	pixel_x = 1
@@ -19245,7 +19245,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "sZg" = (
 /obj/structure/stairs/south,
 /turf/open/floor/wood/wood_common,
@@ -19254,7 +19254,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "taf" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -19265,14 +19265,14 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tbl" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tbq" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19305,7 +19305,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tep" = (
 /obj/item/lighter/gold,
 /obj/item/clothing/neck/necklace/dope,
@@ -19320,7 +19320,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tfS" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -19336,13 +19336,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tgL" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tgX" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/cleanable/dirt,
@@ -19355,7 +19355,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "thC" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -19363,7 +19363,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tix" = (
 /obj/structure/junk/micro,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
@@ -19384,7 +19384,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tiQ" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
@@ -19404,7 +19404,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tkl" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -19413,7 +19413,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tkn" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -19424,7 +19424,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tkK" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -19445,14 +19445,14 @@
 	destination_y = 68;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tnj" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4;
 	pixel_x = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "toc" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -19468,7 +19468,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tqw" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -19522,7 +19522,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ttA" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19531,7 +19531,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tuI" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -19542,7 +19542,7 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "twj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -19577,7 +19577,7 @@
 "tyk" = (
 /obj/structure/stairs/south,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tyI" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/raiders)
@@ -19604,7 +19604,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tAH" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -19627,7 +19627,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tCd" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -19635,7 +19635,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tCN" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/f13{
@@ -19659,7 +19659,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tDL" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/f13/wood,
@@ -19682,7 +19682,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tEK" = (
 /turf/open/floor/carpet/red,
 /area/f13/city)
@@ -19713,7 +19713,7 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tFT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -19726,7 +19726,7 @@
 	pixel_y = -16
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tGj" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -19775,7 +19775,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tHM" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13{
@@ -19789,7 +19789,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tIj" = (
 /obj/structure/obstacle/barbedwire/end,
 /obj/item/flag/ncr{
@@ -19798,7 +19798,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tIx" = (
 /obj/structure/simple_door/dirtyglass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19841,13 +19841,13 @@
 	dir = 8;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tKj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tKp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -19858,7 +19858,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tLN" = (
 /obj/structure/reagent_dispensers/barrel/explosive{
 	pixel_x = -7
@@ -19898,7 +19898,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tMR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/lattice/catwalk,
@@ -19933,7 +19933,7 @@
 	pixel_y = -12
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tNS" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4;
@@ -19954,17 +19954,17 @@
 	pixel_y = -10
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tOS" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirthole,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tOT" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tPA" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -20017,7 +20017,7 @@
 	pixel_x = -19
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tRl" = (
 /obj/structure/fence{
 	dir = 4
@@ -20025,7 +20025,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tRp" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibleg"
@@ -20107,7 +20107,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tUU" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -20115,11 +20115,11 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tVn" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tVo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/metal/barred,
@@ -20209,14 +20209,14 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "tZM" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ubq" = (
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/f13{
@@ -20227,19 +20227,19 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "topshadowright"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ubK" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	pixel_y = -16
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ubM" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ubN" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -20247,19 +20247,19 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ubO" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uca" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 1;
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uce" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
@@ -20268,11 +20268,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ucA" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ucE" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 5;
@@ -20284,10 +20284,10 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ucF" = (
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "udq" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/f13/tunnel,
@@ -20297,7 +20297,7 @@
 	dir = 9;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uem" = (
 /obj/structure/decoration/vent/rusty,
 /obj/machinery/shower{
@@ -20317,7 +20317,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ufN" = (
 /obj/structure/fence{
 	dir = 4;
@@ -20327,7 +20327,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ugg" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore";
@@ -20347,13 +20347,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ugw" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ugG" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -20375,7 +20375,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uhE" = (
 /obj/structure/bed/mattress,
 /obj/item/bedsheet/pirate,
@@ -20392,7 +20392,7 @@
 	pixel_y = -21
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uik" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/blueprintLowMid,
@@ -20420,7 +20420,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ujx" = (
 /obj/structure/stairs/north,
 /turf/open/floor/f13{
@@ -20438,7 +20438,7 @@
 	},
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ujI" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -20481,7 +20481,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ulK" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -20530,7 +20530,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "umX" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -20548,7 +20548,7 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "unF" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
@@ -20568,7 +20568,7 @@
 	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uoV" = (
 /obj/structure/simple_door/tentflap_cloth{
 	pixel_y = 3
@@ -20591,7 +20591,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "upJ" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/road{
@@ -20611,7 +20611,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ura" = (
 /obj/structure/chair/bench,
 /turf/open/floor/f13{
@@ -20668,12 +20668,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uuN" = (
 /obj/structure/chair/bench,
 /obj/machinery/light/broken,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uvL" = (
 /obj/structure/sign/plaques/long/northriver2{
 	pixel_y = 32
@@ -20681,7 +20681,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uwB" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 5;
@@ -20694,7 +20694,7 @@
 	pixel_y = 27
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uxv" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -20727,7 +20727,7 @@
 	icon_state = "tree_3"
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uyM" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -20762,20 +20762,20 @@
 	destination_y = 71;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uzZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5"
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uAd" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uAm" = (
 /turf/closed/wall,
 /area/f13/ncr)
@@ -20784,7 +20784,7 @@
 	pixel_x = -18
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uBq" = (
 /obj/structure/tires/five{
 	pixel_x = -19;
@@ -20822,7 +20822,7 @@
 "uCV" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uDl" = (
 /obj/structure/sign/poster/contraband/pinup_couch{
 	layer = 4.3
@@ -20874,7 +20874,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uEu" = (
 /obj/structure/chair/sofa/corner{
 	dir = 8;
@@ -20920,7 +20920,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uHw" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -20929,12 +20929,12 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uHQ" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uIZ" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -20990,7 +20990,7 @@
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uLO" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -21047,7 +21047,7 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uOd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -21057,7 +21057,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uPd" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
@@ -21091,7 +21091,7 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uQT" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -21108,7 +21108,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uRI" = (
 /obj/machinery/light{
 	dir = 1
@@ -21135,7 +21135,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uSU" = (
 /obj/structure/table/wood,
 /obj/item/papercutter{
@@ -21218,7 +21218,7 @@
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "wide_dark-broken4"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uYo" = (
 /obj/item/chair/wood/modern,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -21232,7 +21232,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uZh" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -21251,7 +21251,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "uZU" = (
 /obj/structure/closet/crate/wicker,
 /obj/item/storage/bag/plants,
@@ -21306,7 +21306,7 @@
 "vbY" = (
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vcj" = (
 /obj/structure/table,
 /turf/open/indestructible/ground/outside/road,
@@ -21342,7 +21342,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vdt" = (
 /obj/machinery/shower{
 	dir = 4
@@ -21370,7 +21370,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vfP" = (
 /obj/structure/fence/door/opened{
 	dir = 4
@@ -21382,12 +21382,12 @@
 	icon_state = "gibup1"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vgk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vgG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/autoshaft,
@@ -21401,7 +21401,7 @@
 /obj/structure/fence,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vhp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -21440,7 +21440,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 10
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vix" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
@@ -21492,7 +21492,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vlY" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/f13{
@@ -21510,11 +21510,11 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vmq" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vmv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/stool{
@@ -21569,7 +21569,7 @@
 /area/f13/city)
 "vol" = (
 /turf/closed/wall/f13/tunnel,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vor" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -21582,11 +21582,11 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vpe" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vpH" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -21602,7 +21602,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vqo" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Medical Ward";
@@ -21638,19 +21638,19 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vrA" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vsb" = (
 /obj/structure/fence,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vsg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -21679,7 +21679,7 @@
 "vsv" = (
 /obj/structure/billboard/cola/pristine,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vsD" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/ncr)
@@ -21753,20 +21753,20 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vvf" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vvp" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vvD" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
@@ -21790,14 +21790,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vwv" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 254;
 	destination_y = 64;
 	destination_z = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vwO" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_mosaic,
@@ -21858,7 +21858,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 9
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vzK" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -21870,7 +21870,7 @@
 	pixel_y = 9
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vAk" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/barricade/bars,
@@ -21884,7 +21884,7 @@
 	dir = 1;
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vBs" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -21901,7 +21901,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vCO" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
@@ -21919,7 +21919,7 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vCU" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -21974,7 +21974,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vDv" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -21991,7 +21991,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vDK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool{
@@ -22008,7 +22008,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vEf" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowhorizontal";
@@ -22021,10 +22021,10 @@
 	pixel_y = -15
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vEp" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vEx" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13/wood,
@@ -22034,7 +22034,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vFg" = (
 /obj/structure/reagent_dispensers/rainwater_tank,
 /turf/open/indestructible/ground/outside/savannah,
@@ -22049,7 +22049,7 @@
 /obj/structure/fence,
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vFN" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22120,7 +22120,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vIH" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/remains/human,
@@ -22164,7 +22164,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vMW" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -22191,7 +22191,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vOq" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -22229,7 +22229,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vPt" = (
 /obj/structure/table_frame,
 /obj/item/pen,
@@ -22254,7 +22254,7 @@
 	dir = 8;
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vRU" = (
 /obj/structure/chair/f13foldupchair{
 	dir = 4
@@ -22281,7 +22281,7 @@
 	icon_state = "tree_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vTp" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
@@ -22291,7 +22291,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vTP" = (
 /obj/structure/rack,
 /obj/structure/fluff/paper/stack,
@@ -22313,7 +22313,7 @@
 /area/f13/city)
 "vUK" = (
 /turf/open/indestructible/ground/outside/savannah/bottomright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vUU" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
@@ -22323,7 +22323,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vVd" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -22335,7 +22335,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "vVN" = (
 /obj/structure/statue/wood/headstonewood{
 	pixel_y = 2
@@ -22432,7 +22432,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "waw" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -22444,7 +22444,7 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "waH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/darkbrown,
@@ -22498,7 +22498,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "weN" = (
 /obj/structure/junk/small/bed,
 /turf/open/floor/wood/wood_common,
@@ -22556,12 +22556,12 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wha" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "whs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/water,
@@ -22640,7 +22640,7 @@
 "wkt" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wkC" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/opossum,
@@ -22655,7 +22655,7 @@
 	dir = 8;
 	icon_state = "outerborder"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wls" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/pestspray,
@@ -22728,7 +22728,7 @@
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "woQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -22739,7 +22739,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "woT" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -22761,7 +22761,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wpt" = (
 /obj/structure/table,
 /obj/item/newspaper,
@@ -22773,7 +22773,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 6
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wpC" = (
 /obj/structure/simple_door/glass{
 	name = "Janitorial Closet"
@@ -22783,7 +22783,7 @@
 "wpQ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wqd" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/machinery/light{
@@ -22811,13 +22811,13 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wsA" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_5"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wtK" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -22844,7 +22844,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wvf" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah,
@@ -22934,7 +22934,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wAf" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -22943,7 +22943,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wAD" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -22956,7 +22956,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wAF" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
@@ -22980,7 +22980,7 @@
 "wBR" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wCg" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -23055,7 +23055,7 @@
 	pixel_y = -24
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wFr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/metal/fence,
@@ -23094,7 +23094,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wJj" = (
 /obj/structure/chair/stool{
 	icon_state = "bench"
@@ -23119,13 +23119,13 @@
 	pixel_y = -10
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wKM" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wKO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/wood/wood_common,
@@ -23151,7 +23151,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wLo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
@@ -23183,7 +23183,7 @@
 	icon_state = "floor6-old"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wMr" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -23196,7 +23196,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wMC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -23282,7 +23282,7 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 5
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wQd" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23315,7 +23315,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wSU" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/city)
@@ -23392,7 +23392,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "wXS" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -23450,7 +23450,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xbI" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -23476,7 +23476,7 @@
 "xcY" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xdu" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -23529,7 +23529,7 @@
 "xfe" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xfM" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "rampdowntop"
@@ -23565,7 +23565,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xgv" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/wood/wood_common,
@@ -23600,14 +23600,14 @@
 	dir = 4
 	},
 /turf/open/water,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xhd" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xhj" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall/f13/store,
@@ -23638,11 +23638,11 @@
 "xiI" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xiP" = (
 /mob/living/simple_animal/hostile/mirelurk,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xjb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/mattress,
@@ -23721,7 +23721,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xmf" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/glass,
@@ -23737,7 +23737,7 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xnl" = (
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -23751,7 +23751,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 4
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/metal/barred,
@@ -23764,11 +23764,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xnX" = (
 /obj/dugpit,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xob" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -29;
@@ -23815,7 +23815,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xph" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment,
@@ -23829,7 +23829,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xpx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23851,7 +23851,7 @@
 	pixel_x = -14
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xqf" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23944,7 +23944,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xve" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet{
@@ -23991,14 +23991,14 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xxR" = (
 /obj/structure/sink/well{
 	pixel_x = -18;
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xyc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
@@ -24039,7 +24039,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xzt" = (
 /obj/structure/fence{
 	dir = 4
@@ -24050,7 +24050,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xzv" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -24099,7 +24099,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xBj" = (
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
 /area/f13/wasteland/ncr)
@@ -24108,7 +24108,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xCX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -24167,7 +24167,7 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xGJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24177,7 +24177,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xHc" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -24200,12 +24200,12 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 1
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xHA" = (
 /turf/open/floor/wood/wood_worn/wood_worn_dark{
 	icon_state = "worn_dark-broken2"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xHR" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -24221,7 +24221,7 @@
 "xIr" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xIz" = (
 /obj/structure/rack,
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction{
@@ -24234,7 +24234,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xJu" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks,
@@ -24271,11 +24271,11 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xMm" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xMw" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -24327,7 +24327,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopborderbottom1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xOC" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -24354,7 +24354,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xRB" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -24425,7 +24425,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xWb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool{
@@ -24454,7 +24454,7 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaloutermain2right"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24471,7 +24471,7 @@
 /obj/structure/fence,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xXY" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/road{
@@ -24483,7 +24483,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xYk" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -24508,7 +24508,7 @@
 	pixel_y = -18
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xYA" = (
 /obj/structure/table/booth,
 /turf/open/floor/wood/wood_common,
@@ -24533,7 +24533,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "xZi" = (
 /obj/structure/fence{
 	dir = 4
@@ -24563,7 +24563,7 @@
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yaI" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/rd,
@@ -24630,7 +24630,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yeY" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -24656,7 +24656,7 @@
 	icon_state = "tall_grass_5"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yfO" = (
 /obj/structure/car/rubbish3{
 	pixel_x = -5
@@ -24664,7 +24664,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yfP" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -24672,7 +24672,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "ygu" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -24707,7 +24707,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yha" = (
 /obj/structure/fence{
 	dir = 4;
@@ -24768,7 +24768,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yjH" = (
 /obj/structure/window/spawner/north,
 /obj/structure/chair/office/light{
@@ -24803,7 +24803,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland)
+/area/f13/wasteland/warren)
 "yln" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/rust,

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -106,6 +106,12 @@
 	name = "Legion Fortress Exterior"
 	icon_state = "legionex"
 
+/area/f13/wasteland/rocksprings
+	name = "Rock Springs"
+
+/area/f13/wasteland/warren
+	name = "Warren"
+
 /area/f13/forest
 	name = "Forest"
 	icon_state = "forest"


### PR DESCRIPTION
Fixes badly mapped APCs in the BoS and derelict bunker, and tidies up some other ones as well.
Adds separate Wasteland area subtypes for each map section to cut down on some of the weird weather behavior. TODO: Do the same with building, city, raider, etc.