### PR TITLE
Fix for surface blocks generating before mapload

### DIFF
--- a/code/modules/mapping/space_management/multiz_helpers.dm
+++ b/code/modules/mapping/space_management/multiz_helpers.dm
@@ -58,6 +58,8 @@
 
 GLOBAL_LIST_EMPTY(surface_zblocks)
 /proc/get_surface_zblock(surface_z)
+	if(!SSmapping.initialized) // Don't bother; it'll be invalid until maploading is done.
+		return list()
 	// this assumes we pass in a surface level
 	if (!SSmapping.level_trait(surface_z, ZTRAIT_SURFACE))
 		CRASH("Non-surface level [surface_z] passed to get_surface_zblocks!")


### PR DESCRIPTION
This isn't really a big deal, just a minor annoyance that might result in weather not reaching the higher levels of a z-stack. It's not mission critical or anything, but it's a good fix to have regardless.