### PR TITLE
Balance Adjustments

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -831,7 +831,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 8
 	},
-/turf/closed/wall/r_wall/f13/vault,
+/turf/open/floor/plating,
 /area/f13/brotherhood)
 "asg" = (
 /obj/structure/rack,
@@ -7603,6 +7603,12 @@
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
+/area/f13/brotherhood)
+"eOS" = (
+/obj/machinery/msgterminal/brotherhood{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ePX" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -80220,7 +80226,7 @@ oVq
 sWt
 sWt
 fse
-fse
+eOS
 fse
 sWt
 sWt

--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -1,15 +1,83 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "white"
+	},
+/area/f13/building)
+"ab" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/defender,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
+"ad" = (
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/carpet/black,
+/area/f13/legion)
+"ae" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/wood_common{
+	icon_state = "common-broken4"
+	},
+/area/f13/building)
+"af" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/drain,
+/mob/living/simple_animal/hostile/vault/security{
+	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
+	faction = list("powder");
+	name = "Powder Ganger Guard"
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"ag" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/wood/wood_common/wood_common_light,
+/area/f13/building)
+"ah" = (
+/obj/machinery/door/poddoor/shutters/old/preopen{
+	id = 23000;
+	name = "Prison Lockdown"
+	},
+/mob/living/simple_animal/hostile/vault/security{
+	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
+	faction = list("powder");
+	name = "Powder Ganger rGuard"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/area/f13/building)
 "aq" = (
 /obj/structure/curtain{
 	color = "#845f58";
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ar" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "av" = (
 /obj/machinery/computer/camera_advanced{
 	desc = "Used to access the various cameras in the prison.";
@@ -34,12 +102,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "aB" = (
 /obj/item/stack/sheet/mineral/wood/twenty,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "aC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -56,19 +124,19 @@
 	pixel_x = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "aO" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "aY" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -83,14 +151,14 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bp" = (
 /obj/structure/barricade/sandbags,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bq" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -110,13 +178,13 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "by" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bz" = (
 /obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -129,7 +197,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/bundle/f13/armor/combat/mk2,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bF" = (
 /obj/structure/sink{
 	dir = 8;
@@ -148,7 +216,11 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"bJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/legion)
 "bK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -162,7 +234,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken6"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "bV" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -187,14 +259,28 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"bW" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	light_color = "#f4e3b0"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
+"bZ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/legion)
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13chair2{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ce" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -222,17 +308,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building)
-"cj" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/wood/wood_common{
-	icon_state = "common-broken4"
-	},
-/area/f13/wasteland/rocksprings)
 "cn" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -244,14 +319,14 @@
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cq" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cs" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -259,7 +334,7 @@
 	name = "wood post"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cw" = (
 /obj/machinery/computer,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -277,25 +352,25 @@
 	},
 /obj/structure/bed/wooden,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cF" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cI" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "cL" = (
 /obj/item/flag/legion,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "cW" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "cX" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2";
@@ -312,7 +387,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dh" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/pickaxe,
@@ -331,7 +406,7 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dm" = (
 /obj/structure/bed,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -340,16 +415,16 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "dq" = (
 /obj/effect/landmark/start/f13/centurion,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "dr" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dt" = (
 /obj/item/kirbyplants/random,
 /obj/structure/curtain{
@@ -357,11 +432,11 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dv" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dw" = (
 /turf/closed/wall/mineral/concrete/blastproof,
 /area/f13/building)
@@ -392,11 +467,11 @@
 	},
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dF" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dJ" = (
 /obj/structure/frame/machine,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -408,12 +483,12 @@
 "dL" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dP" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dR" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -429,7 +504,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "dX" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -440,7 +515,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "eh" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -449,12 +524,12 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken4"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "eo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ep" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -463,7 +538,7 @@
 /obj/structure/bed/old,
 /obj/item/bedsheet,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "es" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -489,13 +564,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 4
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "eE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 5
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "eN" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -511,7 +586,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "fg" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -519,7 +594,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "fi" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -552,19 +627,19 @@
 /obj/effect/spawner/bundle/f13/armor/combat,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "fs" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ft" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "fy" = (
 /obj/structure/closet/cabinet,
 /obj/item/pda,
@@ -577,7 +652,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"fz" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/transparent/openspace,
+/area/f13/legion)
 "fA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -590,12 +671,12 @@
 /obj/effect/landmark/start/f13/vetlegionary,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "fP" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "fW" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -611,18 +692,21 @@
 /obj/structure/chair/stool/retro/tan,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ge" = (
 /obj/structure/sign/poster/contraband/pinup_anthro15,
 /turf/closed/wall/f13/tunnel,
 /area/f13/building)
+"gi" = (
+/turf/open/transparent/openspace,
+/area/f13/legion)
 "gj" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "gr" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -642,7 +726,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 9
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "gy" = (
 /obj/item/kirbyplants/random,
 /obj/structure/railing{
@@ -650,11 +734,11 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gz" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gB" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -663,7 +747,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gD" = (
 /obj/machinery/door/unpowered/celldoor,
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -687,7 +771,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 10
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "gG" = (
 /obj/machinery/shower{
 	dir = 4
@@ -697,7 +781,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gH" = (
 /obj/machinery/light{
 	dir = 1
@@ -721,13 +805,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "gW" = (
 /obj/structure/simple_door/wood{
 	name = "recovery room"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "gZ" = (
 /obj/structure/camera_assembly{
 	dir = 5
@@ -737,7 +821,7 @@
 "ha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "hf" = (
 /obj/machinery/vending/cigarette,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -750,7 +834,7 @@
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hu" = (
 /obj/structure/sink{
 	dir = 8;
@@ -760,7 +844,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hv" = (
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
@@ -774,7 +858,7 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hz" = (
 /obj/structure/debris/v3,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -788,20 +872,20 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hD" = (
 /obj/structure/bookcase{
 	icon_state = "book-3"
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hF" = (
 /obj/structure/bookcase,
 /turf/open/indestructible/ground/outside/desert,
@@ -815,7 +899,7 @@
 	name = "Renegade Lieutenant"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hH" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2";
@@ -836,7 +920,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "hK" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -855,7 +939,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "hS" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -868,7 +952,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hV" = (
 /obj/structure/junk/small/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -877,11 +961,11 @@
 /area/f13/building)
 "hW" = (
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "hZ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ie" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -904,7 +988,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "in" = (
 /obj/machinery/button/door{
 	id = 23555;
@@ -916,7 +1000,7 @@
 "ir" = (
 /obj/structure/junk/small,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "iu" = (
 /obj/machinery/iv_drip,
 /obj/machinery/iv_drip,
@@ -934,7 +1018,7 @@
 "iv" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ix" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -967,14 +1051,14 @@
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "iG" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "iM" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -996,13 +1080,13 @@
 "iU" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "iV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "iZ" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -1014,13 +1098,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jh" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jx" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
@@ -1040,7 +1124,7 @@
 /obj/structure/table/wood,
 /obj/item/binoculars,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jB" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -1048,7 +1132,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1061,17 +1145,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jN" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jO" = (
 /obj/structure/window/fulltile/wood/broken,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "jQ" = (
 /obj/machinery/power/apc,
 /turf/closed/wall/f13/tunnel,
@@ -1080,11 +1164,11 @@
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "kc" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "kf" = (
 /obj/structure/debris/v3,
 /turf/open/floor/plasteel/stairs{
@@ -1108,7 +1192,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "km" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -1122,7 +1206,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ku" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -1136,14 +1220,14 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "kx" = (
 /turf/closed/wall/f13/sunset/brick_small,
 /area/f13/wasteland/rocksprings)
@@ -1185,13 +1269,13 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "kT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "kX" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1205,11 +1289,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ld" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "lh" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -1219,7 +1303,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "lm" = (
 /obj/machinery/chem_heater,
 /obj/structure/camera_assembly{
@@ -1279,7 +1363,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "lA" = (
 /mob/living/simple_animal/hostile/vault/security{
 	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
@@ -1311,7 +1395,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "lM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1347,14 +1431,14 @@
 	light_color = "red"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mc" = (
 /obj/structure/chair/wood/dining{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mh" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -1363,7 +1447,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "mk" = (
 /obj/structure/lattice,
 /turf/open/transparent/openspace,
@@ -1373,7 +1457,7 @@
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mv" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/transparent/openspace,
@@ -1387,14 +1471,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mz" = (
 /obj/structure/junk/cabinet,
 /obj/structure/sign/poster/contraband/free_tonto{
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -1415,7 +1499,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "mM" = (
 /obj/machinery/button/door{
 	id = 56545;
@@ -1433,7 +1517,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "na" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1442,7 +1526,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "nc" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/under/rank/prisoner,
@@ -1468,7 +1552,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ng" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1480,7 +1564,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "np" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -1489,7 +1573,7 @@
 /obj/structure/table,
 /obj/item/stack/circuit_stack,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "nq" = (
 /obj/structure/chair/wood/dining,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1501,17 +1585,17 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "nt" = (
 /obj/effect/landmark/start/f13/decanvet,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "nx" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "nC" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/head/helmet/f13/ncr/rangercombat/eliteriot,
@@ -1534,7 +1618,7 @@
 /obj/structure/dresser,
 /obj/item/pda,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "nO" = (
 /obj/structure/debris/v1,
 /turf/open/floor/plasteel/stairs{
@@ -1547,7 +1631,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "nQ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/shoes/ballandchain,
@@ -1586,7 +1670,7 @@
 	icon_state = "board-1"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "od" = (
 /obj/structure/simple_door/bunker{
 	name = "Medical Storage"
@@ -1602,7 +1686,12 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
+"op" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood/wood_fancy,
+/area/f13/legion)
 "ov" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1612,7 +1701,7 @@
 	name = "Washroom"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "ox" = (
 /obj/structure/closet/crate/footchest,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -1621,7 +1710,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "oB" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -1633,7 +1722,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "oI" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -1642,13 +1731,16 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"oP" = (
+/turf/open/floor/wood/wood_fancy,
+/area/f13/legion)
 "oT" = (
 /obj/structure/junk/arcade,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pa" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1662,10 +1754,6 @@
 	},
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"ph" = (
-/obj/effect/landmark/start/f13/venator,
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
 "pj" = (
 /obj/structure/table,
 /obj/item/integrated_circuit/logic/binary/and,
@@ -1681,11 +1769,11 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pk" = (
 /obj/effect/landmark/start/f13/orator,
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "pn" = (
 /obj/structure/junk/drawer{
 	icon_state = "junk_bench"
@@ -1709,7 +1797,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pB" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1717,7 +1805,7 @@
 "pD" = (
 /obj/structure/junk/small/tv,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pE" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1727,7 +1815,7 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pI" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1740,7 +1828,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pN" = (
 /obj/machinery/power/rtg,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1752,13 +1840,13 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken5"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "pW" = (
 /obj/structure/curtain{
 	color = "#5c131b"
@@ -1771,7 +1859,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qd" = (
 /obj/structure/simple_door/bunker{
 	name = "Pharmacy"
@@ -1796,11 +1884,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ql" = (
 /obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qp" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1827,7 +1915,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qx" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -1837,7 +1925,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -1852,14 +1940,14 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qC" = (
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qD" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -1873,7 +1961,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qG" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/glass,
@@ -1882,7 +1970,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qI" = (
 /obj/structure/table/snooker{
 	dir = 9
@@ -1898,20 +1986,20 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "qN" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "qO" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "qP" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1921,7 +2009,7 @@
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rf" = (
 /obj/structure/table/snooker{
 	dir = 1
@@ -1934,7 +2022,7 @@
 	pixel_y = -32
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rl" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -1942,13 +2030,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "rn" = (
 /obj/structure/bookcase{
 	icon_state = "book-3"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "ro" = (
 /obj/structure/lattice,
 /turf/closed/indestructible/rock{
@@ -1959,12 +2047,12 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rq" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ru" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -1986,44 +2074,44 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rB" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-2"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "rD" = (
 /obj/structure/bookcase{
 	icon_state = "book-4"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "rQ" = (
 /obj/structure/railing{
 	layer = 4.1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "rU" = (
 /obj/structure/closet/crate{
 	anchored = 1;
 	can_be_unanchored = 1
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "rX" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "sc" = (
 /obj/structure/bed/mattress/pregame,
 /obj/structure/camera_assembly,
@@ -2035,13 +2123,13 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "sg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "sl" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2050,7 +2138,7 @@
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "sy" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -2074,11 +2162,11 @@
 /area/f13/building)
 "sP" = (
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "sT" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "sU" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -2086,7 +2174,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "sW" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/wasteland/rocksprings)
@@ -2100,7 +2188,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ta" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -2111,17 +2199,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "td" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ti" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "tj" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -2135,18 +2223,13 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
-"tn" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "tr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "tv" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -2161,13 +2244,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "tB" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "tF" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -2186,24 +2269,10 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "tI" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
-"ua" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/mob/living/simple_animal/hostile/renegade,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "white"
-	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "uf" = (
 /obj/machinery/door/poddoor{
 	id = 5654
@@ -2225,23 +2294,23 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ui" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "uj" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "un" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "up" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -2253,30 +2322,30 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "us" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "uz" = (
 /obj/structure/bed/wooden,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "uB" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "uF" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "uH" = (
 /obj/structure/simple_door/bunker{
 	name = "Service Ladder"
@@ -2293,7 +2362,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "uL" = (
 /mob/living/simple_animal/hostile/renegade/engie{
 	desc = "Demolitions and engineering expert.";
@@ -2322,7 +2391,7 @@
 	pixel_x = 15
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "uW" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -2336,7 +2405,7 @@
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "va" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -2344,13 +2413,13 @@
 "vd" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ve" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vg" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/granter/trait/pa_wear,
@@ -2363,12 +2432,12 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken5"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vi" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vj" = (
 /obj/structure/toilet/secret/high_loot{
 	dir = 8
@@ -2378,7 +2447,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vk" = (
 /obj/structure/camera_assembly,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2419,7 +2488,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2438,7 +2507,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2458,7 +2527,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken6"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "vS" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -2487,7 +2556,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wk" = (
 /obj/structure/simple_door/bunker{
 	name = "Machine Shop & Generator"
@@ -2497,7 +2566,7 @@
 /area/f13/building)
 "wn" = (
 /obj/machinery/door/airlock/highsecurity{
-	armor = list("melee"=55,"bullet"=30,"laser"=20,"energy"=20,"bomb"=10,"bio"=100,"rad"=100,"fire"=80,"acid"=70);
+	armor = list("melee" = 55, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
 	name = "Guard Station"
 	},
 /obj/machinery/door/poddoor/shutters/old/preopen{
@@ -2514,7 +2583,7 @@
 /area/f13/building)
 "wv" = (
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wz" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
@@ -2523,7 +2592,7 @@
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wH" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt{
@@ -2547,7 +2616,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wJ" = (
 /obj/structure/barricade/bars{
 	max_integrity = 1200;
@@ -2556,7 +2625,7 @@
 	},
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "wN" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2565,20 +2634,20 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken3"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wO" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wQ" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-2"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wR" = (
 /obj/structure/fluff/railing{
 	dir = 1
@@ -2629,7 +2698,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "wW" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -2645,20 +2714,20 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/hos,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "xf" = (
 /obj/structure/chair/wood/fancy,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "xg" = (
 /obj/structure/fluff/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "xk" = (
 /obj/structure/sign/warning/explosives,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -2668,7 +2737,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "xo" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -2679,7 +2748,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "xt" = (
 /obj/structure/junk/micro,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2696,7 +2765,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "xx" = (
 /obj/structure/simple_door/glass{
 	name = "Psychology Office"
@@ -2707,7 +2776,7 @@
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "xD" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -2724,7 +2793,7 @@
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "xH" = (
 /obj/structure/camera_assembly{
 	dir = 10
@@ -2740,7 +2809,7 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "xN" = (
 /obj/item/ingot/adamantine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2769,7 +2838,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yr" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -2780,7 +2849,7 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "yt" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2790,7 +2859,7 @@
 	name = "renegade telecomms server"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2804,6 +2873,13 @@
 	name = "tile"
 	},
 /area/f13/building)
+"yC" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "yH" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2813,7 +2889,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yP" = (
 /obj/item/paper/fluff/jobs/medical/hippocratic,
 /obj/structure/table/glass,
@@ -2822,7 +2898,7 @@
 "yW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yX" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/dice,
@@ -2830,7 +2906,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yY" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -2839,7 +2915,7 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/brown,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "yZ" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -2847,7 +2923,7 @@
 	},
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "zc" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -2873,32 +2949,20 @@
 "zF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
-"zH" = (
-/mob/living/simple_animal/hostile/vault/security{
-	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
-	faction = list("powder");
-	name = "Powder Ganger rGuard"
-	},
-/obj/machinery/door/poddoor/shutters/old/preopen{
-	id = 23000;
-	name = "Prison Lockdown"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
-/area/f13/building)
+/area/f13/legion)
 "zR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "zU" = (
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "zX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "zZ" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -2912,7 +2976,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ad" = (
 /obj/machinery/door/unpowered/celldoor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2922,7 +2986,7 @@
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ag" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -2938,7 +3002,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Aw" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -2957,7 +3021,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "AF" = (
 /obj/machinery/light{
 	dir = 4
@@ -2985,7 +3049,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Be" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -2994,7 +3058,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Bg" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3032,7 +3096,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Bw" = (
 /mob/living/simple_animal/hostile/megafauna/behemoth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3063,24 +3127,24 @@
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "BI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "BK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light{
 	icon_state = "common_light-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "BN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "BP" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -3094,14 +3158,14 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "BR" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "BS" = (
 /turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "BY" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -3111,7 +3175,7 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Cb" = (
 /obj/machinery/door/unpowered/securedoor{
 	damage_deflection = 28;
@@ -3121,29 +3185,29 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Cd" = (
 /obj/structure/window/fulltile/house,
 /turf/closed/wall/f13/wood/house,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ce" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Cl" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Co" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "white"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Cr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "CA" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -3166,7 +3230,7 @@
 "CL" = (
 /obj/machinery/workbench,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "CQ" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
@@ -3181,7 +3245,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "CS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/glass,
@@ -3191,7 +3255,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "CU" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -3199,7 +3263,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Dd" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3219,7 +3283,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Dt" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -3227,7 +3291,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Dw" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3236,12 +3300,12 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "DF" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "DG" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War wall made of solid concrete.";
@@ -3265,11 +3329,11 @@
 "DV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ea" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ed" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -3282,7 +3346,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "EF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3306,7 +3370,7 @@
 /obj/item/screwdriver,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "EV" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland/rocksprings)
@@ -3316,13 +3380,24 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"GK" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "Hi" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/rocksprings)
+"Ij" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "IE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -3342,34 +3417,44 @@
 	name = "tile"
 	},
 /area/f13/building)
+"IP" = (
+/obj/machinery/door/unpowered/securedoor{
+	damage_deflection = 28;
+	max_integrity = 600;
+	name = "Venator's Quarters";
+	obj_integrity = 600;
+	req_access_txt = "123"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
 "Jk" = (
 /obj/structure/curtain{
 	color = "#363636";
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Jm" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Jn" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Jo" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Js" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Jt" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 8
@@ -3391,22 +3476,22 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "JB" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "JC" = (
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken6"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "JD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "JG" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -3414,11 +3499,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "JO" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "JP" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3431,7 +3516,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "JS" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -3439,7 +3524,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "JV" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/rocksprings)
@@ -3467,7 +3552,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Kc" = (
 /obj/structure/railing/handrail/rusty/underlayer{
 	pixel_y = -4
@@ -3484,7 +3569,7 @@
 /area/f13/building)
 "Kl" = (
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Kp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -3494,11 +3579,11 @@
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Kv" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ky" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -3506,17 +3591,17 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "KE" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "KG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/drifter,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "KJ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -3525,11 +3610,6 @@
 	name = "metal plating"
 	},
 /area/f13/building)
-"KK" = (
-/mob/living/simple_animal/hostile/renegade/defender,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
 "KL" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -3539,13 +3619,13 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "KM" = (
 /obj/structure/table/wood,
 /obj/item/melee/onehanded/knife/bowie,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "KT" = (
 /obj/structure/table/wood,
 /obj/item/radio/tribal{
@@ -3554,14 +3634,14 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "KU" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "La" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3570,7 +3650,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lb" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -3579,7 +3659,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lc" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -3596,7 +3676,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lg" = (
 /obj/machinery/button/door{
 	id = 5654;
@@ -3613,13 +3693,13 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lk" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lm" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged{
 	faction = list("powder");
@@ -3630,7 +3710,7 @@
 "Lo" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Lp" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 23000;
@@ -3670,7 +3750,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "LA" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/unum,
@@ -3681,7 +3761,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "LN" = (
 /obj/machinery/computer/terminal,
 /obj/structure/table/wood,
@@ -3696,7 +3776,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "LS" = (
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/wasteland/rocksprings)
@@ -3722,7 +3802,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Me" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3730,18 +3810,18 @@
 "Mj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Mm" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Mr" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Ms" = (
 /obj/machinery/vending/games,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -3753,10 +3833,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "MC" = (
 /obj/machinery/hypnochair,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/building)
+"MD" = (
+/turf/open/transparent/openspace,
 /area/f13/building)
 "MJ" = (
 /obj/structure/fluff/railing{
@@ -3771,10 +3854,10 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "MT" = (
 /turf/open/floor/carpet/red,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "MX" = (
 /obj/machinery/door/poddoor/shutters/old/preopen{
 	id = 1853;
@@ -3788,7 +3871,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Nj" = (
 /obj/machinery/door/unpowered/celldoor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3804,7 +3887,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Nu" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -3813,7 +3896,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "NG" = (
 /obj/machinery/button/door{
 	id = 23001;
@@ -3852,7 +3935,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "NS" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
@@ -3872,18 +3955,18 @@
 "NW" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "NY" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "NZ" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Oc" = (
 /obj/structure/camera_assembly{
 	dir = 8
@@ -3893,6 +3976,10 @@
 "Og" = (
 /obj/structure/junk/machinery,
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"Oi" = (
+/obj/structure/lattice,
+/turf/open/transparent/openspace,
 /area/f13/building)
 "Oo" = (
 /obj/structure/bookshelf{
@@ -3917,13 +4004,13 @@
 "OC" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "OE" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "OU" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -3939,7 +4026,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_common,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Pf" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -3951,20 +4038,20 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Po" = (
 /obj/structure/table/wood/club,
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ps" = (
 /obj/structure/table,
 /obj/item/documents{
 	desc = "Documents containing operational intelligence of the Renegades."
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Pu" = (
 /obj/machinery/conveyor{
 	dir = 4
@@ -3981,21 +4068,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PA" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PB" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PC" = (
 /obj/structure/fluff/railing{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PH" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -4005,11 +4092,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PI" = (
 /obj/structure/fluff/railing,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "PJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -4027,12 +4114,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "PY" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Qc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -4040,13 +4127,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Qd" = (
 /obj/structure/bookcase{
 	icon_state = "book-1"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Qf" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
@@ -4088,7 +4175,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Qx" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -4113,7 +4200,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "QK" = (
 /obj/effect/overlay/junk/toilet{
 	dir = 8
@@ -4122,7 +4209,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "QQ" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -4137,7 +4224,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "QS" = (
 /obj/machinery/computer/terminal,
 /obj/structure/table/reinforced,
@@ -4180,7 +4267,7 @@
 /obj/structure/chair/wood/dining,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Rv" = (
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -4204,16 +4291,23 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
+"RM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase{
+	icon_state = "book-1"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
 "RO" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "RQ" = (
 /obj/structure/punching_bag,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "RS" = (
 /obj/structure/debris/v2,
 /obj/structure/debris/v3,
@@ -4237,7 +4331,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "RY" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace,
@@ -4254,10 +4348,20 @@
 	},
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Sl" = (
 /obj/structure/toilet/secret/low_loot,
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"Ss" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
 /area/f13/building)
 "Sx" = (
 /obj/machinery/light/fo13colored/Red{
@@ -4278,7 +4382,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "SI" = (
 /obj/machinery/power/smes,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4294,7 +4398,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ST" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/black,
@@ -4304,12 +4408,15 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Td" = (
 /obj/structure/holohoop{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/building)
+"Te" = (
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Tf" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
@@ -4325,7 +4432,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Tv" = (
 /obj/structure/fluff/railing{
 	dir = 8
@@ -4343,13 +4450,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 8
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "TE" = (
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "TF" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -4378,7 +4485,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "TV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4392,7 +4499,7 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "TZ" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -4406,14 +4513,14 @@
 	},
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Ui" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Uk" = (
 /obj/machinery/light,
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
@@ -4427,14 +4534,14 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Uo" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/cyan,
 /obj/item/electronics/apc,
 /obj/item/assembly/signaler,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Uq" = (
 /obj/structure/table,
 /obj/item/electronic_assembly/medium/radio{
@@ -4443,14 +4550,14 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Uu" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Uv" = (
 /obj/item/trash/f13/c_ration_1,
 /obj/item/trash/f13/c_ration_2{
@@ -4462,7 +4569,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Uw" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -4481,7 +4588,7 @@
 	},
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "UG" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/under/rank/medical/chemist,
@@ -4500,7 +4607,7 @@
 "UI" = (
 /obj/effect/landmark/start/f13/vetlegionary,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "UJ" = (
 /obj/machinery/autolathe,
 /obj/machinery/light,
@@ -4519,16 +4626,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "UQ" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "UX" = (
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"Va" = (
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "Vf" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4541,7 +4651,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
 	dir = 6
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Vg" = (
 /obj/structure/debris/v2,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -4550,14 +4660,14 @@
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/wood/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Vk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Vl" = (
 /obj/structure/sign/poster/contraband/pinup_anthro4,
 /turf/closed/wall/f13/tunnel,
@@ -4577,7 +4687,7 @@
 	req_access_txt = "123"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Vu" = (
 /obj/machinery/door/poddoor/shutters/radiation,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4587,7 +4697,7 @@
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "VC" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -4604,7 +4714,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "VJ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/glass/ten,
@@ -4615,7 +4725,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "VQ" = (
 /obj/machinery/door/poddoor{
 	id = 56545
@@ -4640,11 +4750,11 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_med,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "VX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Wa" = (
 /obj/structure/bed/mattress/pregame,
 /obj/machinery/light/small{
@@ -4660,20 +4770,23 @@
 /turf/open/floor/wood/wood_wide{
 	icon_state = "wide-broken1"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Wf" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/rocksprings)
+"Wi" = (
+/turf/closed/wall/f13/sunset/brick_small_dark,
+/area/f13/legion)
 "Wm" = (
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "red"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Wx" = (
 /obj/structure/fluff/railing/corner{
 	dir = 4
@@ -4684,7 +4797,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "WG" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -4722,7 +4835,7 @@
 "WV" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Xe" = (
 /obj/structure/bookshelf{
 	density = 1;
@@ -4735,19 +4848,23 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Xo" = (
 /obj/structure/chair/wood/dining{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"Xq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "Xs" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Xt" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -4757,7 +4874,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Xu" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/radiation)
@@ -4776,7 +4893,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "XG" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4808,13 +4925,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "XU" = (
 /obj/machinery/msgterminal{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "XW" = (
 /obj/structure/mirror,
 /turf/open/transparent/openspace,
@@ -4824,7 +4941,7 @@
 /turf/open/floor/wood/wood_fancy/wood_fancy_light{
 	icon_state = "fancy_light-broken4"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ye" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -4832,7 +4949,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "Yg" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/random,
@@ -4843,18 +4960,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
-"Yh" = (
-/obj/effect/landmark/start/f13/venator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
 "Yl" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall/f13/tunnel,
 /area/f13/building)
 "Yn" = (
 /obj/machinery/door/airlock/highsecurity{
-	armor = list("melee"=55,"bullet"=30,"laser"=20,"energy"=20,"bomb"=10,"bio"=100,"rad"=100,"fire"=80,"acid"=70);
+	armor = list("melee" = 55, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
 	name = "Guard Station"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4865,14 +4977,14 @@
 	icon_state = "board-1"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Ys" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "YD" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -4891,7 +5003,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "YR" = (
 /obj/machinery/defibrillator_mount/loaded,
 /turf/closed/wall/mineral/concrete/blastproof,
@@ -4909,7 +5021,7 @@
 /turf/open/floor/wood/wood_fancy{
 	icon_state = "fancy-broken4"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "YZ" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/mask/surgical,
@@ -4935,7 +5047,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Zl" = (
 /mob/living/simple_animal/hostile/ghoul/glowing/strong,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4950,31 +5062,19 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_common/wood_common_light,
-/area/f13/wasteland/rocksprings)
-"Zs" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/vault/security{
-	desc = "Imagine being a criminal and dressing as a guard. What a joke.";
-	faction = list("powder");
-	name = "Powder Ganger Guard"
-	},
-/obj/structure/drain,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "Zt" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "Zx" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ZA" = (
 /obj/structure/anvil/obtainable/table,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -4989,7 +5089,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/wood_fancy,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "ZL" = (
 /obj/machinery/conveyor_switch/oneway,
 /obj/machinery/light/fo13colored/Red{
@@ -5005,7 +5105,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "ZQ" = (
 /obj/item/kirbyplants/random,
 /obj/structure/curtain{
@@ -5013,11 +5113,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/rocksprings)
+/area/f13/building)
 "ZT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 
 (1,1,1) = {"
 sW
@@ -8139,19 +8239,19 @@ UL
 UL
 AI
 AI
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 AI
 AI
 DH
@@ -8396,7 +8496,7 @@ UL
 UL
 AI
 AI
-LS
+Wi
 OC
 tI
 tI
@@ -8404,7 +8504,7 @@ tI
 uI
 Cr
 OC
-LS
+Wi
 gv
 TD
 gF
@@ -8499,7 +8599,7 @@ DH
 co
 qG
 QF
-mk
+Oi
 vh
 up
 co
@@ -8653,10 +8753,10 @@ UL
 UL
 DH
 DH
-LS
+Wi
 Cr
 JQ
-DH
+gi
 PR
 Cr
 Cr
@@ -8755,9 +8855,9 @@ DH
 DH
 wQ
 wN
-mk
-mk
-mk
+Oi
+Oi
+Oi
 eo
 wv
 wv
@@ -8910,19 +9010,19 @@ UL
 UL
 DH
 DH
-LS
+Wi
 tI
 rQ
-DH
+gi
 PR
 Cr
 Cr
 tI
-LS
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
+Wi
 Ed
 DH
 DH
@@ -9013,7 +9113,7 @@ DH
 Kr
 LP
 XZ
-mk
+Oi
 bQ
 yW
 wv
@@ -9167,7 +9267,7 @@ UL
 UL
 DH
 DH
-LS
+Wi
 ZN
 hP
 Qv
@@ -9179,7 +9279,7 @@ Cr
 sU
 Cr
 tI
-LS
+Wi
 DH
 DH
 DH
@@ -9261,8 +9361,8 @@ DH
 DH
 wv
 mz
-UL
-UL
+Te
+Te
 Af
 wv
 DH
@@ -9424,19 +9524,19 @@ UL
 UL
 DH
 DH
-LS
+Wi
 NY
 tI
-LS
+Wi
 gW
-LS
-LS
+Wi
+Wi
 gW
-LS
-LS
+Wi
+Wi
 gW
-LS
-LS
+Wi
+Wi
 DH
 DH
 DH
@@ -9528,11 +9628,11 @@ wv
 wv
 wv
 wv
-DH
+MD
 Dq
 wv
 ox
-tn
+ag
 BK
 pD
 wv
@@ -9681,19 +9781,19 @@ UL
 UL
 DH
 DH
-LS
+Wi
 Mm
 Cr
-LS
+Wi
 Kl
 rU
-LS
+Wi
 Kl
 CR
-LS
+Wi
 BN
 rU
-LS
+Wi
 DH
 DH
 DH
@@ -9786,7 +9886,7 @@ TV
 lw
 wv
 wv
-cj
+ae
 wv
 oT
 tr
@@ -9938,19 +10038,19 @@ DH
 DH
 DH
 DH
-LS
+Wi
 sl
 iG
-LS
+Wi
 xu
 ep
-LS
+Wi
 xu
 ep
-LS
+Wi
 Pe
 ep
-LS
+Wi
 DH
 DH
 DH
@@ -10195,19 +10295,19 @@ DH
 DH
 DH
 DH
-LS
+Wi
 ar
 ar
-LS
+Wi
 ar
 ar
-LS
+Wi
 ar
 ar
-LS
+Wi
 ar
 ar
-LS
+Wi
 DH
 DH
 DH
@@ -10803,7 +10903,7 @@ DH
 DH
 dL
 im
-DH
+MD
 wv
 wv
 wv
@@ -14611,12 +14711,12 @@ DH
 DH
 DH
 DH
-LS
+Wi
 wJ
 wJ
-LS
+Wi
 lh
-LS
+Wi
 tj
 DH
 DH
@@ -14869,10 +14969,10 @@ DH
 DH
 DH
 wJ
-UL
-DH
+Va
+gi
 Ug
-UL
+Va
 wJ
 DH
 DH
@@ -15126,10 +15226,10 @@ DH
 DH
 DH
 wJ
-UL
+Va
 Mr
-iB
-UL
+yC
+Va
 wJ
 DH
 DH
@@ -15383,10 +15483,10 @@ DH
 DH
 DH
 wJ
-UL
-UL
-UL
-UL
+Va
+Va
+Va
+Va
 wJ
 DH
 DH
@@ -15640,10 +15740,10 @@ DH
 DH
 DH
 wJ
-UL
-UL
-UL
-UL
+Va
+Va
+Va
+Va
 wJ
 DH
 DH
@@ -15896,12 +15996,12 @@ DH
 DH
 DH
 eN
-LS
+Wi
 lh
 wJ
 wJ
 lh
-LS
+Wi
 cn
 DH
 DH
@@ -16153,11 +16253,11 @@ DH
 DH
 DH
 CA
-UL
-UL
-AR
-CA
-UL
+Va
+Va
+bZ
+fz
+Va
 kS
 AR
 DH
@@ -16410,12 +16510,12 @@ DH
 DH
 DH
 CA
-UL
-UL
-AR
-CA
-UL
-UL
+Va
+Va
+bZ
+fz
+Va
+Va
 AR
 DH
 DH
@@ -16668,11 +16768,11 @@ DH
 DH
 CA
 Vk
-UL
-AR
-CA
-UL
-UL
+Va
+bZ
+fz
+Va
+Va
 AR
 DH
 DH
@@ -16924,12 +17024,12 @@ DH
 DH
 DH
 fi
-LS
+Wi
 Cb
 wJ
 wJ
 Cb
-LS
+Wi
 tj
 DH
 DH
@@ -17182,10 +17282,10 @@ DH
 DH
 DH
 wJ
-UL
-UL
-UL
-UL
+Va
+Va
+Va
+Va
 wJ
 DH
 DH
@@ -17439,10 +17539,10 @@ DH
 DH
 DH
 wJ
-UL
-UL
-UL
-UL
+Va
+Va
+Va
+Va
 wJ
 DH
 DH
@@ -17687,7 +17787,7 @@ DH
 DH
 DH
 DH
-MT
+DH
 DH
 DH
 DH
@@ -17696,10 +17796,10 @@ DH
 DH
 DH
 wJ
-UL
+Va
 uF
 of
-UL
+Va
 wJ
 DH
 DH
@@ -17953,10 +18053,10 @@ DH
 DH
 DH
 wJ
-UL
-DH
+Va
+gi
 Ug
-UL
+Va
 wJ
 DH
 DH
@@ -18209,12 +18309,12 @@ DH
 DH
 DH
 DH
-LS
+Wi
 wJ
 wJ
-LS
+Wi
 Cb
-LS
+Wi
 cn
 DH
 DH
@@ -18451,23 +18551,23 @@ kx
 AI
 AI
 kx
-LS
-LS
+Wi
+Wi
 ar
 ar
-LS
-LS
+Wi
+Wi
 Dd
 cn
 DH
 eN
 Dd
-LS
-LS
+Wi
+Wi
 ar
 ar
-LS
-LS
+Wi
+Wi
 DH
 CA
 UL
@@ -18708,23 +18808,23 @@ kx
 AI
 AI
 kx
-LS
-db
+Wi
+op
 Uu
 JS
-db
-LS
+op
+Wi
 cL
 cy
 Dd
 wW
 cL
-LS
+Wi
 rD
 mR
 NR
 nL
-LS
+Wi
 DH
 CA
 UL
@@ -18965,23 +19065,23 @@ Qo
 Qf
 Qf
 Qo
-LS
+Wi
 rl
-Yh
-ph
+ac
+ad
 hJ
 ar
-UL
-UL
-UL
-UL
-UL
-LS
+Va
+Va
+Va
+Va
+Va
+Wi
 RO
 sg
 ha
 sP
-LS
+Wi
 DH
 CA
 UL
@@ -19222,23 +19322,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 xo
 BS
 BS
 RQ
-LS
+Wi
 SG
-UL
-UL
-UL
+Va
+Va
+Va
 Ce
-LS
+Wi
 RO
 dq
 MT
 zF
-LS
+Wi
 DH
 CA
 UL
@@ -19479,23 +19579,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 KM
 BS
-ph
-VX
+BS
+bJ
 Br
-UL
-UL
-UL
-UL
-UL
-LS
+Va
+Va
+Va
+Va
+Va
+Wi
 zF
 JG
 xc
 sP
-LS
+Wi
 DH
 fi
 EV
@@ -19736,23 +19836,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 ZJ
 BS
 BS
-hW
-LS
-UL
-UL
-UL
-UL
-UL
-LS
+oP
+Wi
+Va
+Va
+Va
+Va
+Va
+Wi
 Um
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
 DH
 DH
 EV
@@ -19993,23 +20093,23 @@ Qo
 Qf
 Qf
 Qo
-LS
+Wi
 qN
-ph
-ph
+ad
+ad
 yr
 ar
-UL
-UL
-UL
-UL
-UL
-LS
-DV
-Lo
-LS
-DH
-LS
+Va
+Va
+Va
+Va
+Va
+Wi
+Xq
+Ij
+Wi
+gi
+Wi
 DH
 AI
 EV
@@ -20250,23 +20350,23 @@ DH
 DH
 DH
 DH
-LS
-db
-VX
+Wi
+op
+bJ
 LG
-db
-LS
-UL
-UL
-UL
-UL
-UL
-LS
-UL
+op
+Wi
+Va
+Va
+Va
+Va
+Va
+Wi
+Va
 JA
-DV
-UL
-LS
+Xq
+Va
+Wi
 AI
 AI
 EV
@@ -20507,23 +20607,23 @@ DH
 DH
 DH
 DH
-LS
-LS
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 SG
-UL
-UL
-UL
+Va
+Va
+Va
 Ce
-LS
-LS
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 AI
 AI
 EV
@@ -20764,23 +20864,23 @@ DH
 DH
 DH
 DH
-LS
+Wi
 qN
-VX
+bJ
 Qc
 qN
-LS
-UL
-UL
-UL
-UL
-UL
-LS
-UL
+Wi
+Va
+Va
+Va
+Va
+Va
+Wi
+Va
 Ye
-DV
-DV
-LS
+Xq
+Xq
+Wi
 AI
 AI
 EV
@@ -21021,23 +21121,23 @@ Qo
 Qf
 Qf
 Qo
-LS
+Wi
 tH
 UI
 UI
 uZ
 ar
-UL
-UL
-UL
-UL
-UL
-LS
-DV
-Lo
-LS
-DH
-LS
+Va
+Va
+Va
+Va
+Va
+Wi
+Xq
+Ij
+Wi
+gi
+Wi
 AI
 AI
 EV
@@ -21278,23 +21378,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 qN
 ZT
 BS
 ft
-LS
-UL
+Wi
+Va
 UQ
 uF
 of
-UL
-LS
+Va
+Wi
 qM
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
 AI
 AI
 EV
@@ -21535,23 +21635,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 dp
 BS
 nt
-hW
+oP
 Vs
-UL
+Va
 cW
-DH
-pa
-UL
-LS
+gi
+GK
+Va
+Wi
 zF
 AZ
 RO
 nL
-LS
+Wi
 AI
 AI
 EV
@@ -21792,23 +21892,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 CU
 BS
 BS
 CU
-LS
+Wi
 SG
 cW
-DH
-pa
+gi
+GK
 Ce
-LS
+Wi
 zF
 MT
 kT
 zF
-LS
+Wi
 AI
 AI
 EV
@@ -22049,23 +22149,23 @@ Qo
 Qf
 Qf
 Qo
-LS
+Wi
 tH
 fJ
 UI
 mh
 ar
-UL
-UL
-UL
-UL
-UL
-LS
+Va
+Va
+Va
+Va
+Va
+Wi
 Qd
 pk
 MT
 zF
-LS
+Wi
 AI
 AI
 EV
@@ -22306,23 +22406,23 @@ kx
 AI
 AI
 kx
-LS
+Wi
 hD
-hW
+oP
 xf
 un
-LS
+Wi
 cL
-AI
-AI
-AI
+Wi
+IP
+Wi
 cL
-LS
+Wi
 rn
 sP
 sP
 xc
-LS
+Wi
 AI
 AI
 EV
@@ -22563,23 +22663,23 @@ kx
 AI
 AI
 kx
-LS
-LS
-LS
-LS
-LS
-LS
-AI
-AI
-AI
-AI
-AI
-LS
-LS
-LS
-LS
-LS
-LS
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+sP
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 AI
 AI
 EV
@@ -22826,12 +22926,12 @@ AI
 AI
 AI
 AI
-AI
-AI
-AI
-AI
-AI
-AI
+Wi
+zF
+sP
+RO
+RO
+Wi
 AI
 AI
 AI
@@ -23083,12 +23183,12 @@ AI
 AI
 AI
 AI
-AI
-AI
-AI
-AI
-AI
-AI
+Wi
+RM
+MT
+kT
+RO
+Wi
 AI
 AI
 AI
@@ -23340,12 +23440,12 @@ AI
 AI
 AI
 AI
-AI
-AI
-AI
-AI
-AI
-AI
+Wi
+rn
+MT
+MT
+zF
+Wi
 AI
 AI
 AI
@@ -23597,12 +23697,12 @@ AI
 AI
 AI
 AI
-AI
-AI
-AI
-AI
-AI
-AI
+Wi
+sP
+bW
+nL
+xc
+Wi
 AI
 AI
 AI
@@ -23854,12 +23954,12 @@ AI
 AI
 AI
 AI
-AI
-AI
-AI
-AI
-AI
-AI
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 AI
 AI
 AI
@@ -27760,8 +27860,8 @@ EV
 AI
 AI
 zU
-UL
-UL
+Te
+Te
 zU
 zU
 zU
@@ -28017,16 +28117,16 @@ AI
 AI
 AI
 zU
-DH
+MD
 nP
 yp
 DV
 DV
 DV
 Lx
-UL
+Te
 DV
-UL
+Te
 ld
 zU
 AI
@@ -28274,7 +28374,7 @@ AI
 AI
 AI
 zU
-DH
+MD
 Pz
 DV
 zU
@@ -33204,13 +33304,13 @@ DG
 DH
 DH
 DH
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
 dL
 dL
-DG
+Ss
 DH
 DH
 DH
@@ -33461,13 +33561,13 @@ DH
 DH
 DH
 DH
-DG
+Ss
 Be
 pI
-DG
+Ss
 aH
 VE
-DG
+Ss
 DH
 DH
 DH
@@ -33718,13 +33818,13 @@ DH
 DH
 mk
 mk
-DG
+Ss
 kX
 Zx
 XD
 DV
 DV
-DG
+Ss
 DH
 DH
 DH
@@ -33975,13 +34075,13 @@ DH
 DH
 mk
 mk
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
 MK
 cc
-DG
+Ss
 DH
 DH
 DH
@@ -34232,13 +34332,13 @@ DH
 mk
 mk
 mk
-DG
+Ss
 WV
 ql
 Kv
 DV
 nh
-DG
+Ss
 DH
 DH
 DH
@@ -34445,7 +34545,7 @@ FC
 As
 zU
 Wz
-DH
+MD
 zU
 AI
 AI
@@ -34489,13 +34589,13 @@ mk
 mk
 mk
 mk
-DG
+Ss
 Mc
 Xm
 Xm
-UL
+Te
 Np
-DG
+Ss
 DH
 DH
 DH
@@ -34702,7 +34802,7 @@ dr
 hE
 sT
 Wc
-DH
+MD
 zU
 AI
 AI
@@ -34744,15 +34844,15 @@ DH
 mk
 DH
 DH
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
 JO
-DG
+Ss
 dL
-DG
-DG
+Ss
+Ss
 Wx
 DH
 DH
@@ -35002,12 +35102,12 @@ mk
 mk
 mk
 nd
-UL
-DG
+Te
+Ss
 ql
-UL
-UL
-UL
+Te
+Te
+Te
 KG
 bp
 wR
@@ -35517,9 +35617,9 @@ aJ
 ro
 mL
 yp
-DG
-UL
-UL
+Ss
+Te
+Te
 MJ
 Tv
 Tv
@@ -35768,14 +35868,14 @@ DH
 DH
 DH
 DH
-DG
+Ss
 ug
 RW
-DG
+Ss
 yp
 yp
 JO
-UL
+Te
 DV
 wR
 DH
@@ -36025,14 +36125,14 @@ DH
 DH
 DH
 DH
-DG
+Ss
 QK
 vA
-DG
+Ss
 wD
 PA
-DG
-UL
+Ss
+Te
 DV
 wR
 DH
@@ -36282,13 +36382,13 @@ DH
 DH
 DH
 mv
-DG
-DG
-DG
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 kv
 DV
 wR
@@ -36545,7 +36645,7 @@ yp
 rX
 KE
 Lk
-DG
+Ss
 DV
 PH
 wR
@@ -36804,7 +36904,7 @@ DV
 Dw
 jO
 vd
-UL
+Te
 wR
 DH
 DH
@@ -37053,15 +37153,15 @@ DH
 DH
 DH
 lF
-DG
-DG
+Ss
+Ss
 cq
-DG
+Ss
 DV
 DV
-DG
-UL
-UL
+Ss
+Te
+Te
 wR
 DH
 DH
@@ -37310,15 +37410,15 @@ DH
 DH
 DH
 DH
-DG
+Ss
 gG
 aJ
-DG
-UL
+Ss
+Te
 DV
 JO
-UL
-UL
+Te
+Te
 wR
 DH
 DH
@@ -37567,13 +37667,13 @@ DH
 DH
 DH
 DH
-DG
+Ss
 vj
 wc
-DG
+Ss
 cI
 PA
-DG
+Ss
 DV
 DV
 wR
@@ -37824,15 +37924,15 @@ DH
 DH
 DH
 mv
-DG
-DG
-DG
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 hC
-UL
+Te
 wR
 DH
 DH
@@ -38087,9 +38187,9 @@ yp
 DV
 tB
 kc
-DG
-UL
-UL
+Ss
+Te
+Te
 wR
 DH
 DH
@@ -38345,7 +38445,7 @@ Ys
 yp
 nr
 dL
-UL
+Te
 cs
 wR
 DH
@@ -38595,15 +38695,15 @@ DH
 DH
 DH
 lF
-DG
-DG
+Ss
+Ss
 XD
-DG
-UL
+Ss
+Te
 DV
-DG
+Ss
 PI
-DH
+MD
 wR
 DH
 DH
@@ -38852,15 +38952,15 @@ DH
 DH
 DH
 DH
-DG
+Ss
 my
 aJ
-DG
+Ss
 DV
-UL
+Te
 JO
 PI
-DH
+MD
 wR
 DH
 DH
@@ -39109,13 +39209,13 @@ DH
 DH
 DH
 DH
-DG
+Ss
 wI
 vA
-DG
+Ss
 WV
 PA
-DG
+Ss
 xg
 PC
 tF
@@ -39366,13 +39466,13 @@ DH
 DH
 DH
 DH
-DG
-DG
-DG
-DG
-DG
-DG
-DG
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
+Ss
 kq
 uN
 wR
@@ -46510,14 +46610,14 @@ DH
 DH
 DH
 No
-UL
+Te
 Wm
-UL
-UL
-UL
-UL
+Te
+Te
+Te
+Te
 Wm
-UL
+Te
 lu
 DH
 DH
@@ -47024,14 +47124,14 @@ DH
 DH
 DH
 No
-UL
+Te
 dL
 Lc
 Eh
 Xt
 YD
 dL
-UL
+Te
 lu
 DH
 DH
@@ -47281,14 +47381,14 @@ DH
 DH
 DH
 No
-UL
+Te
 dL
 gB
 td
 td
 gU
 dL
-UL
+Te
 lu
 DH
 DH
@@ -47538,14 +47638,14 @@ DH
 DH
 DH
 No
-UL
+Te
 NW
 jJ
 ej
 xz
 jy
 dL
-UL
+Te
 lu
 DH
 DH
@@ -47795,14 +47895,14 @@ DH
 DH
 DH
 No
-UL
+Te
 dL
 wV
 td
 KT
 rh
 dL
-UL
+Te
 lu
 DH
 DH
@@ -48052,14 +48152,14 @@ DH
 DH
 DH
 No
-UL
+Te
 dL
 mb
 fd
 fd
 zZ
 dL
-UL
+Te
 lu
 DH
 DH
@@ -48566,14 +48666,14 @@ DH
 DH
 DH
 No
-UL
+Te
 TE
-UL
-UL
-UL
-UL
+Te
+Te
+Te
+Te
 Vx
-UL
+Te
 lu
 DH
 DH
@@ -53635,8 +53735,8 @@ fg
 tz
 uz
 wv
-UL
-UL
+Te
+Te
 wv
 DH
 DH
@@ -53893,7 +53993,7 @@ vN
 VX
 JO
 lL
-DH
+MD
 wv
 DH
 DH
@@ -54150,7 +54250,7 @@ hW
 jX
 wv
 KU
-DH
+MD
 wv
 DH
 DH
@@ -55435,7 +55535,7 @@ wv
 wv
 wv
 iV
-UL
+Te
 wv
 DH
 DH
@@ -55688,11 +55788,11 @@ DH
 eN
 wv
 aZ
-ua
+aa
 ry
 wv
 nb
-UL
+Te
 wv
 cn
 DH
@@ -56205,7 +56305,7 @@ wv
 wv
 wv
 wv
-UL
+Te
 qk
 dL
 pa
@@ -56220,7 +56320,7 @@ DH
 DH
 DH
 Mj
-UL
+Te
 Mj
 DH
 DH
@@ -56462,7 +56562,7 @@ Ps
 Uo
 XU
 wv
-UL
+Te
 JB
 wv
 iB
@@ -56476,8 +56576,8 @@ DH
 DH
 DH
 DH
-DH
-UL
+MD
+Te
 Mj
 DH
 DH
@@ -56719,7 +56819,7 @@ Uq
 td
 dA
 wv
-KK
+ab
 Lo
 wv
 DH
@@ -57496,7 +57596,7 @@ wv
 DH
 DH
 BQ
-DH
+MD
 Mj
 BQ
 DH
@@ -57753,8 +57853,8 @@ wv
 DH
 DH
 Mj
-UL
-UL
+Te
+Te
 Mj
 DH
 DH
@@ -64528,7 +64628,7 @@ Rg
 dw
 oI
 lM
-Zs
+af
 lM
 gN
 dw
@@ -66077,7 +66177,7 @@ aC
 ng
 nV
 ng
-zH
+ah
 eU
 eU
 dw

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -642,11 +642,11 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	name = "Legion Slavemaster"
 
 /obj/effect/landmark/start/f13/explorer
-	name = "Legion Scout"
+	name = "Legion Explorer"
 	icon_state = "Legionary"
 
 /obj/effect/landmark/start/f13/venator
-	name = "Legion Explorer"
+	name = "Legion Venator"
 	icon_state = "Legionary"
 
 /obj/effect/landmark/start/f13/auxilia

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1090,12 +1090,18 @@
 	assignment = "centurion medallion"
 
 /obj/item/card/id/dogtag/legvenator
-	name = "explorer medallion"
+	name = "venator medallion"
 	desc = "A golden disc awarded to the elite hunters of the legion. If you are close enough to read the insignia you won't be alive much longer."
 	icon_state = "legionmedallioncent"
 	item_state = "card-id_leg2"
-	assignment = "Venator"
+	assignment = "venator medallion"
 
+/obj/item/card/id/dogtag/legexplorer
+	name = "explorer medallion"
+	desc = "A golden disc awarded to the scouts of the legion."
+	icon_state = "legionmedallioncent"
+	item_state = "card-id_leg2"
+	assignment = "explorer medallion"
 
 /obj/item/card/id/dogtag/legpriest
 	name = "priestess medallion"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -59,8 +59,8 @@ Elder
 
 	exp_requirements = 3000
 
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 
 	outfit = /datum/outfit/job/bos/f13elder
 
@@ -233,6 +233,7 @@ Head Scribe
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 /datum/outfit/job/bos/f13headscribe
 	name = "Head Scribe"
@@ -404,6 +405,9 @@ Star Paladin
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 /datum/outfit/job/bos/f13seniorpaladin
 	name =	"Senior Paladin"
@@ -600,6 +604,7 @@ Senior Scribe
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 /datum/outfit/job/bos/f13seniorscribe
 	name =	"Senior Scribe"
@@ -685,6 +690,7 @@ Scribe
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
 	ADD_TRAIT(H, TRAIT_MEDICALGRADUATE, src)
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 /datum/outfit/loadout/scribea
 	name = "Junior Scribe"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -72,6 +72,9 @@ Elder
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 /datum/outfit/job/bos/f13elder
 	name = "Baron"

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -396,6 +396,7 @@
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, src)
 	ADD_TRAIT(H, TRAIT_UNETHICAL_PRACTITIONER, src) // Brainwashing
 	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 // Enclave Citizen
 // Really only used for ID console

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -165,6 +165,9 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 /////////////////
 //// Officers ///
@@ -369,7 +372,7 @@ commented out pending rework*/
 		/obj/item/ammo_box/shotgun/buck = 2,
 		/obj/item/gun/ballistic/revolver/m29 = 1,
 		)
-		
+
 /datum/outfit/loadout/decvetspecialist
 	name = "Mark of the Heedful"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/decan
@@ -678,13 +681,14 @@ commented out pending rework*/
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
+	ADD_TRAIT(H, TRAIT_INSANE_AIM, src)
 
 
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
 	name = "Legion Explorer"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13explorer
-	id = /obj/item/card/id/dogtag/legprime
+	id = /obj/item/card/id/dogtag/legexplorer
 	suit = /obj/item/clothing/suit/armor/f13/legion/vet/explorer
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/explorer
 	neck = /obj/item/storage/belt/holster
@@ -1291,6 +1295,10 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
+	ADD_TRAIT(H, TRAIT_INSANE_AIM, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator
 	name = "Legion Venator"
@@ -1330,7 +1338,7 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	name = "Legion Slavemaster"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13legionary
 	id =			/obj/item/card/id/dogtag/legslavemaster
-	uniform =		/obj/item/clothing/under/gladiator
+//	uniform =		/obj/item/clothing/under/gladiator
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/prime/slavemaster
 	belt = 			/obj/item/melee/onehanded/slavewhip
 	head = 			/obj/item/clothing/head/helmet/f13/legion/prime/slavemaster
@@ -1351,6 +1359,9 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	ADD_TRAIT(H, TRAIT_TRIBAL, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 
 // Legion Citizen

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -275,6 +275,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 
 // SERGEANT
@@ -556,9 +559,13 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_IRONFIST, src)
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
+	ADD_TRAIT(H, TRAIT_INSANE_AIM, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	var/datum/martial_art/rangertakedown/RT = new
 	RT.teach(H)
+	if(H.mind)
+		var/obj/effect/proc_holder/spell/terrifying_presence/S = new /obj/effect/proc_holder/spell/terrifying_presence
+		H.mind.AddSpell(S)
 
 /datum/outfit/job/ncr/f13vetranger
 	name = "NCR Veteran Ranger"


### PR DESCRIPTION
- - -
Map:
 - Rock Springs upper given interiors.
 - Venator quarters added.
 - Brotherhood given a communications terminal.
- - -
Balance:
 - Science focused jobs, Enclave Scientist and Scribes specifically, given poor aim.
 - Sniping focused roles, Veteran Ranger, Venator and Explorer, given insane aim.
 - Various head roles given terrifying presence.
 - Enables the Baron role.
- - -
Fixes:
 - Venator given proper spawn and ID.
 - Explorer given proper spawn and ID.
 - Slavemaster no longer starts nude for a majority of species, aside from Human. Comments out the unique undersuit to accomplish this.
- - -