### PR TITLE
Misc Enclave Food Fixes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -1381,6 +1381,7 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/condiment/soymilk,
 /turf/open/floor/plasteel/hydrofloor,
 /area/f13/enclave)
 "aeJ" = (
@@ -1430,7 +1431,10 @@
 /turf/open/floor/plating,
 /area/f13/enclave)
 "aeT" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null;
+	req_access_txt = "134"
+	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/f13/enclave)
 "aeU" = (
@@ -18518,7 +18522,7 @@
 "qBx" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 10, /obj/item/reagent_containers/pill/patch/silver_sulf = 10, /obj/item/reagent_containers/medspray/styptic = 4, /obj/item/reagent_containers/medspray/silver_sulf = 4, /obj/item/reagent_containers/pill/charcoal = 2, /obj/item/reagent_containers/medspray/sterilizine = 2)
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,


### PR DESCRIPTION
Does a couple of things.

- (HOPEFULLY) fixes the access on the fridge, allowing Enclave members to open it. This is, of course, assuming that I did it correctly. Regardless, it's not gonna break anything if it doesn't work, as it was already broken.
- Adds soy milk to the other fridge. Several recipes (most notably cakes and chocolate) require soy milk, which the Enclave doesn't have any ability to acquire, to my knowledge. This is mostly for RP, and I don't see its addition as problematic.