### PR TITLE
Plating Under Catwalks

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -84,7 +84,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "aau" = (
 /obj/machinery/button/door{
@@ -93,7 +93,7 @@
 	pixel_x = -32
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "aav" = (
 /obj/machinery/door/poddoor/shutters{
@@ -6854,7 +6854,7 @@
 /area/f13/tunnel)
 "dHk" = (
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "dHo" = (
 /obj/machinery/light,
@@ -7853,7 +7853,7 @@
 	dir = 1;
 	pixel_y = 23
 	},
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "frn" = (
 /obj/structure/decoration/vent/rusty,
@@ -11268,7 +11268,7 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "lpx" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -14954,7 +14954,7 @@
 	dir = 4;
 	pixel_x = 20
 	},
-/turf/open/water,
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "rkQ" = (
 /obj/structure/table/wood,
@@ -18951,6 +18951,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
+/area/f13/tunnel)
+"xUA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/handrail/g_central{
+	pixel_y = -16
+	},
+/turf/open/floor/plating,
 /area/f13/tunnel)
 "xUW" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -66741,7 +66748,7 @@ bJq
 bJq
 fqQ
 dHk
-bTJ
+xUA
 bJq
 bJq
 bJq


### PR DESCRIPTION
- - -
Simple change to catwalks in lower Pahrump, setting them to be plated beneath. Because, for some reason, they don't stop you from walking ON tiles that they cover. This led to players being irradiated without reason.
- - -