### PR TITLE
Hazmat suit improvement

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -7965,8 +7965,7 @@
 /area/f13/vault)
 "gUq" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg1"
 	},
@@ -18995,8 +18994,7 @@
 /area/f13/city)
 "tGF" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/plasteel/barber{

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -2948,6 +2948,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -5320,6 +5321,10 @@
 "cgn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"cgT" = (
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
+/turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "cho" = (
 /turf/closed/wall/r_wall/f13superstore{
@@ -9633,6 +9638,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"ivb" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
+/turf/open/floor/plasteel/f13,
+/area/f13/tunnel)
 "ivJ" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/f13/wood,
@@ -13597,6 +13607,7 @@
 /obj/machinery/conveyor/inverted,
 /obj/structure/closet/crate/wooden,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "piM" = (
@@ -17468,6 +17479,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -38049,7 +38061,7 @@ bJb
 bJb
 bAY
 bIG
-bAY
+cgT
 bAY
 cpj
 apj
@@ -42415,7 +42427,7 @@ apg
 bAY
 bIQ
 bAY
-bAY
+cgT
 bAY
 apj
 aaa
@@ -57092,7 +57104,7 @@ aae
 aak
 aae
 bCt
-xPV
+ivb
 fOG
 uzY
 wMj

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -3144,9 +3144,8 @@
 /area/f13/wasteland/quarry)
 "alR" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
 /obj/effect/decal/cleanable/vomit,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
 "alS" = (
@@ -9292,10 +9291,9 @@
 /area/f13/bar/heaven)
 "aHx" = (
 /obj/structure/closet,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
@@ -15884,10 +15882,9 @@
 /area/f13/building/bighornbunker)
 "bcj" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /obj/item/storage/pill_bottle/chem_tin/radx,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -52770,8 +52767,7 @@
 /area/f13/building)
 "wEs" = (
 /obj/structure/closet,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/bio_suit/f13/hazmat,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -11001,7 +11001,7 @@
 /area/f13/building)
 "nGt" = (
 /obj/machinery/door/poddoor/preopen{
-	armor = list("melee" = 70, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 65, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	armor = list("melee"=70,"bullet"=100,"laser"=100,"energy"=100,"bomb"=65,"bio"=100,"rad"=100,"fire"=100,"acid"=70);
 	id = 5346;
 	max_integrity = 12000;
 	name = "hardened blast door"
@@ -17606,7 +17606,7 @@
 /area/f13/wasteland/rocksprings)
 "vCT" = (
 /obj/machinery/door/airlock/highsecurity{
-	armor = list("melee" = 70, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
+	armor = list("melee"=70,"bullet"=30,"laser"=20,"energy"=20,"bomb"=10,"bio"=100,"rad"=100,"fire"=80,"acid"=70);
 	locked = 1;
 	name = "Riot Armory"
 	},
@@ -19496,7 +19496,7 @@
 	name = "Federal Penetentiary"
 	},
 /obj/machinery/door/poddoor/preopen{
-	armor = list("melee" = 70, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 65, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70);
+	armor = list("melee"=70,"bullet"=100,"laser"=100,"energy"=100,"bomb"=65,"bio"=100,"rad"=100,"fire"=100,"acid"=70);
 	id = 5346;
 	max_integrity = 12000;
 	name = "hardened blast door"

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -236,6 +236,10 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet)
 	var/helmettype = /obj/item/clothing/head/bio_hood/f13/hazmat
 	
+	/obj/item/clothing/suit/bio_suit/f13/hazmat/item_action_slot_check(slot, mob/user, datum/action/A)
+	if(slot == SLOT_WEAR_SUIT) //we only give the mob the ability to toggle the helmet if he's wearing the hazmat suit.
+		return 1
+	
 /obj/item/clothing/head/bio_hood/f13/hazmat
 	name = "hazmat hood"
 	desc = "My star, my perfect silence."

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -228,7 +228,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_utility.dmi'
 	icon_state = "hazmat"
 	item_state = "hazmat"
-	w_class = WEIGHT_CLASS_HEAVY
+	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 0
 	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE

--- a/code/modules/clothing/suits/f13suits.dm
+++ b/code/modules/clothing/suits/f13suits.dm
@@ -230,7 +230,8 @@
 	item_state = "hazmat"
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 0
-	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)
+	resistance_flags = ACID_PROOF
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 30, "energy" = 25, "bomb" = 16, "bio" = 100, "rad" = 100, "fire" = 35, "acid" = 100)
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 	var/obj/item/clothing/head/bio_hood/f13/hazmat
 	actions_types = list(/datum/action/item_action/toggle_helmet)


### PR DESCRIPTION
Replaced the radiation suits around the map with the fallout hazmat suit in the code because... well we have it, it looks better, and it's named right for what I want to do.

What this does
-Makes the hazmat suits acid proof
-Makes the helmet part of the suit itself, it can be toggled with a hud icon
-Makes it slight fire resistant
-Levels out the melee resistance of the helmet and body piece while raising it slightly
-Makes it so you can store it in your backpack
-Removes the slowdown of the suit itself

Map changes
-Added hazmat suits to several bunkers and appropriate locations such as the deathclaw lab, in the mass fusion reactor pit, and several other locations

Why is this a good thing?
The radiation suits were there mostly as a gimmick item and for flavor with little to no use, and didn't really make sense. Now they're more of a utility item with minimal armoring. It's an added flavor of realism to an otherwise useless item since you could just fold it up and shove it into your bag, but couldn't before this. Overall, it's just an item that needed some love.