### PR TITLE
Buffs Large Calibre Munitions - .50 / 12.7

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -138,9 +138,9 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 
 //Bloody shoes/footprints
-#define MAX_SHOE_BLOODINESS			100
+#define MAX_SHOE_BLOODINESS			5//from 100
 #define BLOODY_FOOTPRINT_BASE_ALPHA	150
-#define BLOOD_GAIN_PER_STEP			100
+#define BLOOD_GAIN_PER_STEP			5//from 100
 #define BLOOD_LOSS_PER_STEP			5
 #define BLOOD_LOSS_IN_SPREAD		20
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -681,7 +681,6 @@ commented out pending rework*/
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
-	ADD_TRAIT(H, TRAIT_INSANE_AIM, src)
 
 
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -560,6 +560,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	ADD_TRAIT(H, TRAIT_IRONFIST, src)
 	ADD_TRAIT(H, TRAIT_SILENT_STEP, src)
 	ADD_TRAIT(H, TRAIT_INSANE_AIM, src)
+	ADD_TRAIT(H, TRAIT_FAST_PUMP, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	var/datum/martial_art/rangertakedown/RT = new
 	RT.teach(H)
@@ -597,7 +598,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
 		/obj/item/ammo_box/c4570box/knockback = 1,
 		/obj/item/ammo_box/magazine/amr/penetrator = 1,
-		/obj/item/book/granter/trait/rifleman = 1,
 		)
 
 /datum/outfit/loadout/vrlite
@@ -606,7 +606,6 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	backpack_contents = list(
 		/obj/item/ammo_box/c4570 = 3,
 		/obj/item/gun/ballistic/revolver/sequoia = 1,
-		/obj/item/book/granter/trait/rifleman = 1,
 		)
 
 /datum/outfit/loadout/vrshotgunner

--- a/code/modules/mob/living/carbon/human/species_types/synthanthro.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthanthro.dm
@@ -41,3 +41,7 @@
 		H.nutrition = NUTRITION_LEVEL_FED
 	if(H.nutrition > NUTRITION_LEVEL_FED)
 		H.nutrition = NUTRITION_LEVEL_FED
+	if(H.water < THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL
+	if(H.water > THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL

--- a/code/modules/mob/living/carbon/human/species_types/synthliz.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthliz.dm
@@ -34,3 +34,7 @@
 		H.nutrition = NUTRITION_LEVEL_FED
 	if(H.nutrition > NUTRITION_LEVEL_FED)
 		H.nutrition = NUTRITION_LEVEL_FED
+	if(H.water < THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL
+	if(H.water > THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -125,3 +125,7 @@
 		H.nutrition = NUTRITION_LEVEL_FED
 	if(H.nutrition > NUTRITION_LEVEL_FED)
 		H.nutrition = NUTRITION_LEVEL_FED
+	if(H.water < THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL
+	if(H.water > THIRST_LEVEL_FULL)
+		H.water = THIRST_LEVEL_FULL

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -328,8 +328,8 @@
 	item_state = "amr"
 	mag_type = /obj/item/ammo_box/magazine/amr
 	fire_delay = 12 //Heavy round, tiny bit slower
-	extra_damage = 50
-	extra_penetration = 0.6
+	extra_damage = 60
+	extra_penetration = 1//Chunky munitions.
 	recoil = 1
 	spread = 0
 	force = 10 //Big clumsy and sensitive scope, makes for a poor club
@@ -338,6 +338,11 @@
 	zoom_out_amt = 13
 	fire_sound = 'sound/f13weapons/antimaterielfire.ogg'
 	pump_sound = 'sound/f13weapons/antimaterielreload.ogg'
+
+/obj/item/gun/ballistic/rifle/mag/antimateriel/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
+	..()
+	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+		src.pump(user)
 
 // BETA // Obsolete
 /obj/item/gun/ballistic/rifle/rifletesting

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -142,6 +142,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 0
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
+	wound_bonus = 20
+	bare_wound_bonus = 60
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = -10
@@ -202,7 +204,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a50MG/depleteduranium//Used, currently, for the emplaced MG.
 	name = ".50 DU-bullet"
-	damage = 5//Fire rate is absurd. Makes up for it.
+	damage = 15//Fire rate is absurd. Makes up for it.
 	armour_penetration = 1//:)
 	wound_bonus = 60//Makes up for the low damage. Not to mention that it works well with the fire rate.
 	bare_wound_bonus = 80//As above.


### PR DESCRIPTION
- - -
Balance:
 - AMR is now semi-automatic for those that have the fast-pump trait, which is given automatically to the Veteran Ranger.
 - AMR damage up from fifty(50) to sixty(60).
 - AMR penetration bonus up from 0.6 to 1.
 - Legion Explorer has lost Insane Aim, making it exclusive to the singular Venator and Veteran Ranger roles.
 - HMG round damage up from five(5) to fifteen(15).
 - Standard heavy munitions (.50 / 12.7) given a wound bonus of twenty(20), and a bare wound bonus of sixty(60)
- - -