### PR TITLE
Fixes and upgrades, September 3 2022

### DIFF
--- a/_maps/pahrump.json
+++ b/_maps/pahrump.json
@@ -34,7 +34,7 @@
 			"Baseturf": "/turf/open/indestructible/ground/inside/mountain",
 			"Dungeons": true,
 			"Up": 1,
-			"Down": -1,
+			"Down": 1,
 			"No Parallax": true,
 			"Linkage" : null,
 			"Name": "Lower Sheridan"
@@ -45,7 +45,7 @@
 			"Station": 1,
 			"Surface": true,
 			"Up": 1,
-			"Down": -1,
+			"Down": 1,
 			"No Parallax": true,
 			"Linkage" : "Cross",
 			"Name": "Sheridan"
@@ -54,7 +54,7 @@
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
 			"Up": 1,
-			"Down": -1,
+			"Down": 1,
 			"No Parallax": true,
 			"Linkage" : null,
 			"Above": true,
@@ -63,7 +63,7 @@
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
-			"Down": -1,
+			"Down": 1,
 			"Linkage" : null,
 			"No Parallax": true,
 			"Above": true,
@@ -82,7 +82,7 @@
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
-			"Down": -1,
+			"Down": 1,
 			"Linkage" : null,
 			"No Parallax": true,
 			"Above": true,
@@ -101,7 +101,7 @@
 		{
 			"Gravity": true,
 			"Baseturf": "/turf/open/transparent/openspace",
-			"Down": -1,
+			"Down": 1,
 			"Linkage" : null,
 			"No Parallax": true,
 			"Above": true,

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -40,10 +40,18 @@ SUBSYSTEM_DEF(mapping)
 	// Z-manager stuff
 	var/station_start  // should only be used for maploading-related tasks
 	var/space_levels_so_far = 0
-	var/list/z_list
+	///list of all z level datums in the order of their z (z level 1 is at index 1, etc.)
+	var/list/datum/space_level/z_list
+	///list of all z level indices that form multiz connections and whether theyre linked up or down
+	///list of lists, inner lists are of the form: list("up or down link direction" = TRUE)
+	var/list/multiz_levels = list()
 	var/datum/space_level/transit
 	var/datum/space_level/empty_space
 	var/num_of_res_levels = 1
+
+	///shows the default gravity value for each z level. recalculated when gravity generators change.
+	///associative list of the form: list("[z level num]" = max generator gravity in that z level OR the gravity level trait)
+	var/list/gravity_by_z_level = list()
 
 	var/stat_map_name = "Loading..."
 
@@ -141,7 +149,45 @@ SUBSYSTEM_DEF(mapping)
 	setup_map_transitions()
 	generate_station_area_list()
 	initialize_reserved_level(transit.z_value)
+	generate_z_level_linkages()
+	calculate_default_z_level_gravities()
 	return ..()
+
+/datum/controller/subsystem/mapping/proc/calculate_default_z_level_gravities()
+	for(var/z_level in 1 to length(z_list))
+		calculate_z_level_gravity(z_level)
+
+/datum/controller/subsystem/mapping/proc/generate_z_level_linkages()
+	for(var/z_level in 1 to length(z_list))
+		generate_linkages_for_z_level(z_level)
+
+/datum/controller/subsystem/mapping/proc/generate_linkages_for_z_level(z_level)
+	if(!isnum(z_level) || z_level <= 0)
+		return FALSE
+
+	if(multiz_levels.len < z_level)
+		multiz_levels.len = z_level
+
+	var/linked_down = level_trait(z_level, ZTRAIT_DOWN)
+	var/linked_up = level_trait(z_level, ZTRAIT_UP)
+	multiz_levels[z_level] = list()
+	if(linked_down)
+		multiz_levels[z_level]["[DOWN]"] = TRUE
+	if(linked_up)
+		multiz_levels[z_level]["[UP]"] = TRUE
+
+/datum/controller/subsystem/mapping/proc/calculate_z_level_gravity(z_level_number)
+	if(!isnum(z_level_number) || z_level_number < 1)
+		return FALSE
+
+	var/max_gravity = 0
+
+	for(var/obj/machinery/gravity_generator/main/grav_gen as anything in GLOB.gravity_generators["[z_level_number]"])
+		max_gravity = max(grav_gen.setting, max_gravity)
+
+	max_gravity = max_gravity || level_trait(z_level_number, ZTRAIT_GRAVITY) || 0//just to make sure no nulls
+	gravity_by_z_level["[z_level_number]"] = max_gravity
+	return max_gravity
 
 /*	Nuke threats, for making the blue tiles on the station go RED
 	Used by the AI doomsday and the self destruct nuke.
@@ -216,6 +262,7 @@ SUBSYSTEM_DEF(mapping)
 	clearing_reserved_turfs = SSmapping.clearing_reserved_turfs
 
 	z_list = SSmapping.z_list
+	multiz_levels = SSmapping.multiz_levels
 
 /datum/controller/subsystem/mapping/proc/LoadGroup(list/errorList, name, path, files, list/traits, list/default_traits, silent = FALSE, orientation = SOUTH)
 	. = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1214,7 +1214,9 @@
  * Returns true if this atom has gravity for the passed in turf
  *
  * Sends signals COMSIG_ATOM_HAS_GRAVITY and COMSIG_TURF_HAS_GRAVITY, both can force gravity with
- * the forced gravity var
+ * the forced gravity var.
+ *
+ * micro-optimized to hell because this proc is very hot, being called several times per movement every movement.
  *
  * Gravity situations:
  * * No gravity if you're not in a turf
@@ -1224,37 +1226,29 @@
  * * Gravity if the Z level has an SSMappingTrait for ZTRAIT_GRAVITY
  * * otherwise no gravity
  */
-/atom/proc/has_gravity(turf/T)
-	if(!T || !isturf(T))
-		T = get_turf(src)
+/atom/proc/has_gravity(turf/gravity_turf)
+	if(!isturf(gravity_turf))
+		gravity_turf = get_turf(src)
 
-	if(!T)
-		return 0
+		if(!gravity_turf)//no gravity in nullspace
+			return 0
 
-	var/list/forced_gravity = list()
-	SEND_SIGNAL(src, COMSIG_ATOM_HAS_GRAVITY, T, forced_gravity)
-	if(!forced_gravity.len)
-		SEND_SIGNAL(T, COMSIG_TURF_HAS_GRAVITY, src, forced_gravity)
-	if(forced_gravity.len)
-		var/max_grav
-		for(var/i in forced_gravity)
+	//the list isnt created every time as this proc is very hot, its only accessed if anything is actually listening to the signal too
+	var/static/list/forced_gravity = list()
+	if(SEND_SIGNAL(src, COMSIG_ATOM_HAS_GRAVITY, gravity_turf, forced_gravity))
+		if(!length(forced_gravity))
+			SEND_SIGNAL(gravity_turf, COMSIG_TURF_HAS_GRAVITY, src, forced_gravity)
+
+		var/max_grav = 0
+		for(var/i in forced_gravity)//our gravity is the strongest return forced gravity we get
 			max_grav = max(max_grav, i)
+		forced_gravity.Cut()
+		//cut so we can reuse the list, this is ok since forced gravity movers are exceedingly rare compared to all other movement
 		return max_grav
 
-	if(isspaceturf(T)) // Turf never has gravity
-		return 0
+	var/area/turf_area = gravity_turf.loc
 
-	var/area/A = get_area(T)
-	if(A.has_gravity) // Areas which always has gravity
-		return A.has_gravity
-	else
-		// There's a gravity generator on our z level
-		if(GLOB.gravity_generators["[T.z]"])
-			var/max_grav = 0
-			for(var/obj/machinery/gravity_generator/main/G in GLOB.gravity_generators["[T.z]"])
-				max_grav = max(G.setting,max_grav)
-			return max_grav
-	return SSmapping.level_trait(T.z, ZTRAIT_GRAVITY)
+	return !gravity_turf.force_no_gravity && (SSmapping.gravity_by_z_level["[gravity_turf.z]"] || turf_area.has_gravity)
 
 /**
  * Causes effects when the atom gets hit by a rust effect from heretics

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -119,6 +119,14 @@
 /obj/machinery/door/window/Bumped(atom/movable/AM)
 	if(operating || !density)
 		return
+	if (!ismob(AM)) // Items and other objects shouldn't be able to open doors.
+		if(ismecha(AM)) // An exception is mechs, where we check the occupant's access.
+			var/obj/mecha/mecha = AM
+			if(!requiresID() || allowed(mecha.occupant))
+				open_and_close()
+				return
+			do_animate("deny")
+		return
 	if(!SSticker)
 		return
 	var/mob/M = AM

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -204,7 +204,10 @@
 
 /turf/open/Initialize_Atmos(times_fired)
 	update_visuals()
-	ImmediateCalculateAdjacentTurfs()
+	if(times_fired)
+		init_immediate_calculate_adjacent_turfs()
+	else
+		ImmediateCalculateAdjacentTurfs()
 
 /turf/open/proc/GetHeatCapacity()
 	. = air.heat_capacity()

--- a/code/game/turfs/openspace/openspace.dm
+++ b/code/game/turfs/openspace/openspace.dm
@@ -34,21 +34,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open/transparent/openspace/Initialize() // handle plane and layer here so that they don't cover other obs/turfs in Dream Maker
 	. = ..()
-	is_wall_below()
 	vis_contents += GLOB.openspace_backdrop_one_for_all //Special grey square for projecting backdrop darkness filter on it.
-
-/*
-Prevents players on higher Zs from seeing into buildings they arent meant to.
-*/
-/turf/open/transparent/openspace/proc/is_wall_below()
-	var/turf/A = SSmapping.get_turf_below(src)
-	if(istype(A,/turf/closed/wall))
-		opacity = 1
-
-	else if(!isnull(A))
-		for(var/obj/O in A.contents)
-			if(istype(O,/obj/structure/simple_door))
-				opacity = 1
 
 /turf/open/transparent/openspace/can_have_cabling()
 	if(locate(/obj/structure/lattice/catwalk, src))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -49,6 +49,8 @@
 	var/base_opacity = FALSE
 	///Lazylist of movable atoms providing opacity sources.
 	var/list/atom/movable/opacity_sources
+	///whether or not this turf forces movables on it to have no gravity (unless they themselves have forced gravity)
+	var/force_no_gravity = FALSE
 
 
 /turf/vv_edit_var(var_name, var_value)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -41,15 +41,70 @@
 
 	return FALSE
 
+/// This proc is a more deeply optimized version of immediate_calculate_adjacent_turfs
+/// It contains dumbshit, and also stuff I just can't do at runtime
+/// If you're not editing behavior, just read that proc. It's less bad
+/turf/proc/init_immediate_calculate_adjacent_turfs()
+	//Basic optimization, if we can't share why bother asking other people ya feel?
+	// You know it's gonna be stupid when they include a unit test in the atmos code
+	// Yes, inlining the string concat does save 0.1 seconds
+	#ifdef UNIT_TESTS
+	ASSERT(UP == 16)
+	ASSERT(DOWN == 32)
+	#endif
+	LAZYINITLIST(src.atmos_adjacent_turfs)
+	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs
+	var/blocks_air = src.blocks_air
+	var/canpass = CANATMOSPASS(src, src)
+	var/canvpass = CANVERTICALATMOSPASS(src, src)
+	// I am essentially inlineing two get_dir_multizs here, because they're way too slow on their own. I'm sorry brother
+	var/list/z_traits = SSmapping.multiz_levels[z]
+	for(var/direction in GLOB.cardinals_multiz)
+		// Yes this is a reimplementation of get_step_multiz. It's faster tho. fuck you
+		var/turf/current_turf = (direction & (UP|DOWN)) ? \
+			(direction & UP) ? \
+				(z_traits["16"]) ? \
+					(get_step(locate(x, y, z + z_traits["16"]), NONE)) : \
+				(null) : \
+				(z_traits["32"]) ? \
+					(get_step(locate(x, y, z + z_traits["32"]), NONE)) : \
+				(null) : \
+			(get_step(src, direction))
+		
+		if(!isopenturf(current_turf)) // not interested in you brother
+			continue
+
+		//Can you and me form a deeper relationship, or is this just a passing wind
+		// (direction & (UP | DOWN)) is just "is this vertical" by the by
+		if((direction & (UP|DOWN) ? (canvpass && CANVERTICALATMOSPASS(current_turf, src)) : (canpass && CANATMOSPASS(current_turf, src))) && !(blocks_air || current_turf.blocks_air))
+			LAZYINITLIST(current_turf.atmos_adjacent_turfs)
+			atmos_adjacent_turfs[current_turf] = TRUE
+			current_turf.atmos_adjacent_turfs[src] = TRUE
+		else
+			atmos_adjacent_turfs -= current_turf
+			if (current_turf.atmos_adjacent_turfs)
+				current_turf.atmos_adjacent_turfs -= src
+			UNSETEMPTY(current_turf.atmos_adjacent_turfs)
+			current_turf.set_sleeping(current_turf.blocks_air)
+		// This was originally (isspaceturf(T.get_z_base_turf()), -1), but we don't have space, so
+		// we just pass FALSE to save time.
+		current_turf?.__update_auxtools_turf_adjacency_info(FALSE, -1)
+
+	UNSETEMPTY(atmos_adjacent_turfs)
+	src.atmos_adjacent_turfs = atmos_adjacent_turfs
+	set_sleeping(blocks_air)
+	__update_auxtools_turf_adjacency_info(FALSE)
+
 /turf/proc/ImmediateCalculateAdjacentTurfs()
 	if(SSair.thread_running())
 		CALCULATE_ADJACENT_TURFS(src)
 		return
+	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs // save ourselves a bunch of datum var accesses
 	var/canpass = CANATMOSPASS(src, src)
 	var/canvpass = CANVERTICALATMOSPASS(src, src)
 	for(var/direction in GLOB.cardinals_multiz)
 		var/turf/T = get_step_multiz(src, direction)
-		if(!istype(T))
+		if(!T) // get_step returns null or a turf, no need for an istype
 			continue
 		var/opp_dir = REVERSE_DIR(direction)
 		if(isopenturf(T) && !(blocks_air || T.blocks_air) && ((direction & (UP|DOWN))? (canvpass && CANVERTICALATMOSPASS(T, src)) : (canpass && CANATMOSPASS(T, src))) )

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -21,9 +21,10 @@ GLOBAL_LIST_INIT(auxtools_atmos_initialized,FALSE)
 /datum/gas_mixture/New(volume)
 	if (!isnull(volume))
 		initial_volume = volume
-	AUXTOOLS_CHECK(AUXMOS)
-	if(!GLOB.auxtools_atmos_initialized && auxtools_atmos_init())
-		GLOB.auxtools_atmos_initialized = TRUE
+	if(!GLOB.auxtools_atmos_initialized)
+		AUXTOOLS_CHECK(AUXMOS)
+		if(auxtools_atmos_init())
+			GLOB.auxtools_atmos_initialized = TRUE
 	__gasmixture_register()
 	reaction_results = new
 

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -18,6 +18,10 @@ GLOBAL_LIST_INIT(auxtools_atmos_initialized,FALSE)
 
 /proc/auxtools_atmos_init()
 
+// So that this auxmos proc shows up properly in profiling.
+/datum/gas_mixture/proc/gasmixture_register_wrapper()
+	__gasmixture_register()
+
 /datum/gas_mixture/New(volume)
 	if (!isnull(volume))
 		initial_volume = volume
@@ -25,7 +29,7 @@ GLOBAL_LIST_INIT(auxtools_atmos_initialized,FALSE)
 		AUXTOOLS_CHECK(AUXMOS)
 		if(auxtools_atmos_init())
 			GLOB.auxtools_atmos_initialized = TRUE
-	__gasmixture_register()
+	gasmixture_register_wrapper()
 	reaction_results = new
 
 /datum/gas_mixture/vv_edit_var(var_name, var_value)

--- a/code/modules/fallout/turf/floor.dm
+++ b/code/modules/fallout/turf/floor.dm
@@ -36,7 +36,7 @@
 	if(istype(C, /obj/item/screwdriver))
 		if(broken || burnt)
 			new /obj/item/stack/sheet/mineral/wood(src)
-		else
+		else if (floor_tile)
 			new floor_tile(src)
 		to_chat(user, "<span class='danger'>You unscrew the planks.</span>")
 		make_plating()

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -41,9 +41,9 @@
 
 /datum/crafting_recipe/food/longpork_stew
 	name = "Longpork Stew"
-	reqs = list(/obj/item/reagent_containers/food/snacks/meat/slab/human= 1,
-				/obj/item/reagent_containers/glass/bowl = 1,
-				/datum/reagent/water = 10
+	reqs = list(/datum/reagent/water = 10, // must be before the bowl or else it'll runtime
+				/obj/item/reagent_containers/food/snacks/meat/slab/human= 1,
+				/obj/item/reagent_containers/glass/bowl = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/longpork_stew
 	subcategory = CAT_WASTEFOOD

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -248,8 +248,8 @@
 /obj/structure/bonfire/proc/Burn()
 	var/turf/current_location = get_turf(src)
 	current_location.hotspot_expose(1000,100,1)
-	for(var/A in current_location)
-		if(A == src)
+	for(var/atom/A in current_location)
+		if(A == src || QDELETED(A))
 			continue
 		if(isobj(A))
 			var/obj/O = A
@@ -261,8 +261,8 @@
 
 /obj/structure/bonfire/proc/Cook()
 	var/turf/current_location = get_turf(src)
-	for(var/A in current_location)
-		if(A == src)
+	for(var/atom/A in current_location)
+		if(A == src || QDELETED(A))
 			continue
 		else if(isliving(A)) //It's still a fire, idiot.
 			var/mob/living/L = A

--- a/code/modules/mapping/space_management/multiz_helpers.dm
+++ b/code/modules/mapping/space_management/multiz_helpers.dm
@@ -12,7 +12,7 @@
 	var/other_z = center_z
 	var/offset
 	while((offset = SSmapping.level_trait(other_z, ZTRAIT_DOWN)))
-		other_z += offset
+		other_z -= offset
 		. += other_z
 	other_z = center_z
 	while((offset = SSmapping.level_trait(other_z, ZTRAIT_UP)))

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -51,18 +51,18 @@
 
 // Attempt to get the turf below the provided one according to Z traits
 /datum/controller/subsystem/mapping/proc/get_turf_below(turf/T)
-	if (!T)
+	if (!T || !initialized)
 		return
-	var/offset = level_trait(T.z, ZTRAIT_DOWN)
+	var/offset = multiz_levels[T.z]["[DOWN]"]
 	if (!offset)
 		return
-	return locate(T.x, T.y, T.z + offset)
+	return locate(T.x, T.y, T.z - offset)
 
 // Attempt to get the turf above the provided one according to Z traits
 /datum/controller/subsystem/mapping/proc/get_turf_above(turf/T)
-	if (!T)
+	if (!T || !initialized)
 		return
-	var/offset = level_trait(T.z, ZTRAIT_UP)
+	var/offset = multiz_levels[T.z]["[UP]"]
 	if (!offset)
 		return
 	return locate(T.x, T.y, T.z + offset)

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -25,6 +25,8 @@
 	// TODO: sleep here if the Z level needs to be cleared
 	var/datum/space_level/S = new z_type(new_z, name, traits)
 	z_list += S
+	generate_linkages_for_z_level(new_z)
+	calculate_z_level_gravity(new_z)
 	return S
 
 /datum/controller/subsystem/mapping/proc/get_level(z)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -358,6 +358,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return 1
 
 /mob/living/proc/get_key(message)
+	if (length(message) < 2) // So that say ":" doesn't runtime.
+		return
 	var/key = message[1]
 	if(key in GLOB.department_radio_prefixes)
 		return lowertext(message[1 + length(key)])

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -382,6 +382,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 				GLOB.gravity_generators["[z]"] |= src
 			else
 				GLOB.gravity_generators["[z]"] -= src
+			SSmapping.calculate_z_level_gravity(z)
 
 /obj/machinery/gravity_generator/main/proc/change_setting(value)
 	if(value != setting)


### PR DESCRIPTION
- Fixes runtime from bonfires burning items.
- Fixes runtime from items being thrown into windoors.
- Fixes runtime from saying "." or ":".
- Fixes runtime from dismantling f13 wood floors.
- Fixes a runtime that meant longpork stew didn't consume its ingredients properly.
- Makes z-level logic (gravity, above/below) much faster.
- Shaves like 10-20 seconds off init with air system optimisations.
- Adds a wrapper proc to help debug our atmos lag.