### PR TITLE
Medolier Changes

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -727,9 +727,9 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/reagent_containers/medspray,
 		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/glass/bottle
+		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/syringe
+		/obj/item/reagent_containers/syringe,
 		))
 
 /obj/item/storage/belt/medolier/full/PopulateContents()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -723,7 +723,13 @@
 	STR.allow_quick_empty = TRUE
 	STR.click_gather = TRUE
 	STR.can_hold = typecacheof(list(
-		/obj/item/reagent_containers/syringe/dart
+		/obj/item/reagent_containers/syringe/dart,
+		/obj/item/storage/pill_bottle,
+		/obj/item/reagent_containers/medspray,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/glass/bottle
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/syringe
 		))
 
 /obj/item/storage/belt/medolier/full/PopulateContents()


### PR DESCRIPTION
Just some small changes to make the Medoiler an item that's perhaps actually used. Allows it to carry pill bottles, bottles, syringes, stimpacks and medical sprays, rather than only specifically syringe gun syringes. Still should be plenty balanced over the medical belt as it cant carry anything bulky like surgery tools or medical bags. 

Should be a good pick for field medics who want to reliably carry consumables into the field. 