### PR TITLE
Fix nests defaulting to infinite

### DIFF
--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -18,7 +18,7 @@
 	layer = BELOW_OBJ_LAYER
 	var/radius = 7
 	var/spawnsound //specify an audio file to play when a mob emerges from the spawner
-	var/infinite = TRUE
+	var/infinite = FALSE
 
 /obj/structure/nest/Initialize()
 	. = ..()


### PR DESCRIPTION
Oops. Didn't realise spawners weren't originally infinite by default.