### PR TITLE
Enclave Changes and Fixes (Highly subjective)

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -1613,10 +1613,13 @@
 /area/f13/enclave)
 "afC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/assembly/signaler/advanced,
+/obj/item/key/collar,
+/obj/item/key/bcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar,
+/obj/item/electropack/shockcollar/explosive,
+/obj/item/electropack/shockcollar/explosive,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "afE" = (
@@ -2217,14 +2220,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
-"ahC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/cash_ncr_high,
-/obj/effect/spawner/lootdrop/f13/cash_legion_high,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/item/storage/bag/money/small,
-/turf/open/floor/f13,
-/area/f13/enclave)
 "ahD" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/enclave,
@@ -2260,7 +2255,6 @@
 	pixel_y = -32;
 	use_power = 0
 	},
-/obj/machinery/light,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "ahK" = (
@@ -5718,15 +5712,16 @@
 /area/f13/radiation)
 "efy" = (
 /obj/structure/closet/crate/secure/weapon{
-	name = "secure crate"
+	name = "secure crate";
+	req_access_txt = "256"
 	},
-/obj/item/assembly/signaler/advanced,
-/obj/item/key/collar,
-/obj/item/key/bcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar,
-/obj/item/electropack/shockcollar/explosive,
-/obj/item/electropack/shockcollar/explosive,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_ncr_high,
+/obj/effect/spawner/lootdrop/f13/cash_legion_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/f13,
 /area/f13/enclave)
 "ege" = (
@@ -8022,9 +8017,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/bunker)
-"gVH" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
-/area/f13/caves)
 "gVI" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13{
@@ -16318,9 +16310,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qkF" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/caves)
 "qkV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17270,7 +17259,7 @@
 	id = "enc_crem"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
-/area/f13/caves)
+/area/f13/enclave)
 "rvr" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -19413,7 +19402,7 @@
 /obj/item/clothing/under/burial,
 /obj/item/clothing/under/burial,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
-/area/f13/caves)
+/area/f13/enclave)
 "ucH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -64566,7 +64555,7 @@ aao
 aej
 aej
 aej
-ahC
+aej
 afv
 aao
 afH
@@ -69412,7 +69401,7 @@ kYl
 kYl
 kYl
 kYl
-qkF
+aao
 rvq
 aaC
 aaC
@@ -69669,8 +69658,8 @@ hrZ
 kYl
 kYl
 kYl
-qkF
-gVH
+aao
+aaC
 aaC
 aaC
 blk
@@ -69926,7 +69915,7 @@ hrZ
 kYl
 kYl
 kYl
-qkF
+aao
 uct
 obf
 abx
@@ -70183,8 +70172,8 @@ hrZ
 kYl
 kYl
 kYl
-qkF
-qkF
+aao
+aao
 aao
 aao
 aao

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -92,8 +92,8 @@
 	suit_store = /obj/item/gun/ballistic/automatic/g11/g11e
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m473 = 3,
-		/obj/item/gun/ballistic/automatic/pistol/pistol14/custom = 1,
-		/obj/item/ammo_box/magazine/m14mm = 2,
+		/obj/item/gun/energy/laser/plasma/glock = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		)
 
 /datum/outfit/loadout/lt_plasma
@@ -101,8 +101,8 @@
 	suit_store = /obj/item/gun/energy/laser/plasma
 	backpack_contents = list(
 		/obj/item/stock_parts/cell/ammo/mfc = 2,
-		/obj/item/gun/energy/laser/plasma/glock = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/gun/ballistic/automatic/pistol/pistol14/custom = 1,
+		/obj/item/ammo_box/magazine/m14mm = 2,
 		)
 
 /datum/outfit/job/enclave/peacekeeper/enclavelt/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -125,7 +125,7 @@
 	flag = F13USGYSGT
 	total_positions = 1
 	spawn_positions = 1
-	access = list(ACCESS_ENCLAVE, ACCESS_CHANGE_IDS)
+	access = list(ACCESS_ENCLAVE, ACCESS_CHANGE_IDS, ACCESS_ENCLAVE_COMMAND)
 	description = "Second in command after Lieutenant, your role is to direct their orders directly to the sergeants and regular troops."
 	supervisors = "The Lieutenant."
 	outfit = /datum/outfit/job/enclave/peacekeeper/f13gysergeant

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -126,7 +126,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	access = list(ACCESS_ENCLAVE, ACCESS_CHANGE_IDS, ACCESS_ENCLAVE_COMMAND)
-	description = "Second in command after Lieutenant, your role is to direct their orders directly to the sergeants and regular troops."
+	description = "Second in command after Lieutenant, your role is to direct their orders directly to the Sergeants and regular troops."
 	supervisors = "The Lieutenant."
 	outfit = /datum/outfit/job/enclave/peacekeeper/f13gysergeant
 	exp_requirements = 1400
@@ -258,7 +258,7 @@
 	flag = F13USSPECIALIST
 	total_positions = 2
 	spawn_positions = 2
-	description = "You are an operative for the remnants of the Enclave. You, unlike the normal privates, have recieved specialist training in either engineering or medicine."
+	description = "You are an operative for the remnants of the Enclave. You, unlike the normal Privates, have recieved specialist training in either engineering or medicine."
 	supervisors = "The Lieutenant and the Sergeants."
 	outfit = /datum/outfit/job/enclave/peacekeeper/f13specialist
 	exp_requirements = 700
@@ -324,7 +324,7 @@
 	flag = F13USPRIVATE
 	total_positions = 4
 	spawn_positions = 4
-	description = "You are an enlisted member of the Enclave. Obey your Lieutenant. He sets the Enclave's policies. Unfortunately, you've not yet received your PA training. <br> (OOC NOTE: If you use this role to TDM, you'll be jobbanned and risk a potential permaban from the server.)"
+	description = "You are an enlisted member of the Enclave. Obey your Lieutenant. They set the Enclave's policies. Unfortunately, you've not yet received your PA training. <br> (OOC NOTE: If you use this role to TDM, you'll be jobbanned and risk a potential permaban from the server.)"
 	supervisors = "The Lieutenant and the Sergeants"
 	outfit = /datum/outfit/job/enclave/peacekeeper/enclavespy
 	exp_type = EXP_TYPE_FALLOUT


### PR DESCRIPTION
Changes:
- Swaps the sidearms for the Enclave Lieutenant's loadouts. Previously, there was no reason to take the ballistics loadout, as the plasma loadout was just straight up better. Now the first loadout gets a ballistic rifle and plasma sidearm, and second loadout gets a plasma rifle and ballistic sidearm.
- Gives the Enclave Gunnery Sergeant Command access. Useful for the next change.
- Adds command access to the Gunnery Sergeant's box, puts the trait books and money inside. Prevents random Privates from taking the Gunny's stuff.
- Places the collars, keys and signaller that were previously in the Gunny's box on the shelf next to it, for easy access.
- Removes one of the shelves in the Gunny's office, as it was just wasting space.
- Moves the borders of the "Enclave Bunker" area to actually include the whole bunker.
- Removes an out of place light in one of the hallways
- Capitalizes some previously uncapitalized ranks in role descriptions, because I'm a freak with OCD, as well as referring to the Lieutenant gender-neutrally. Women can be officers too!