### PR TITLE
Gives follower admin same traits as doctor

### DIFF
--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -67,6 +67,8 @@ Administrator
 	ADD_TRAIT(H, TRAIT_RESEARCHER, src)
 	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
+	ADD_TRAIT(H, TRAIT_RESEARCHER, src)
+	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)
 
 /datum/outfit/job/followers/f13leadpractitioner
 	name =	"Followers Administrator"

--- a/code/modules/projectiles/guns/energy/plasmaf13.dm
+++ b/code/modules/projectiles/guns/energy/plasmaf13.dm
@@ -35,6 +35,7 @@
 /obj/item/gun/energy/laser/plasma/pistol/worn/gutsy
 	name ="\improper integrated plasma pistol"
 	desc = "A pistol-sized miniaturized plasma caster built by REPCONN. It fires a bolt of superhot ionized gas."
+	selfcharge = EGUN_SELFCHARGE_BORG
 
 //Glock 86 Plasma pistol
 /obj/item/gun/energy/laser/plasma/glock


### PR DESCRIPTION
Gives the admin the same traits as the doctors; they lacked researcher. Also gave them the advanced cyberneticist trait because they didn't have the basic one, and the admin is supposed to be the most experienced of the bunch there.