### PR TITLE
Car Welding Advanced-Pre War Salvage Buff

### DIFF
--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -63,7 +63,7 @@
 	for(var/i2 in 1 to (2+modifier))
 		new /obj/item/salvage/low(usr_turf)
 	for(var/i3 in 1 to (1+modifier)) //this is just less lines for the same thing
-		if(prob(3))
+		if(prob(6))
 			new /obj/item/salvage/high(usr_turf)
 	uses_left--
 	inuse = FALSE //putting this after the -- because the first check prevents cheesing


### PR DESCRIPTION
Buffs the chance of getting advanced pre-war salvage from cars from a whopping 3 percent to 6 percent. On high pop, getting salvage becomes extremely painful when a handful of people will run to all the meta machinery places and take it all for themselves. Last round as of this PR, I scrapped every single car in yuma, taking about an a hour, only to get nine pieces of advanced salvage. Which also means I left none for everyone else and barely had enough for myself.

Yes this is a salt PR.