### PR TITLE
Khan-B-Gone

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -100,8 +100,8 @@
 	id = "prospector2open"
 	},
 /obj/machinery/door/unpowered/securedoor{
-	name = "Prospector Entrance";
-	req_one_access_txt = "48"
+	name = "Prospector Side Entrance";
+	req_one_access_txt = "25"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
@@ -614,10 +614,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"amP" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "amT" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/citizenship_permits,
@@ -1117,11 +1113,21 @@
 	},
 /area/f13/brotherhood)
 "aXt" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/structure/railing/wood{
+	layer = 0;
+	pixel_y = 7
+	},
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
+	},
 /obj/structure/railing/wood{
 	dir = 8;
 	pixel_x = -3
 	},
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "aYa" = (
@@ -1351,20 +1357,10 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "bre" = (
-/obj/structure/closet/crate/large{
-	layer = 1
-	},
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
+/obj/structure/rack/shelf_metal,
+/obj/item/export/bottle/white_bloodmoon,
+/obj/item/export/bottle/whiskey,
+/obj/item/export/bottle/wine,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "bsl" = (
@@ -2996,10 +2992,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bLA" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "bLB" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -3389,10 +3381,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building)
-"bMS" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "bMT" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -5372,11 +5360,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"ciV" = (
-/obj/machinery/reagentgrinder/constructed,
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "ciX" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/soylentgreen,
@@ -5921,14 +5904,6 @@
 "cqO" = (
 /turf/open/water,
 /area/f13/radiation)
-"cqZ" = (
-/obj/structure/rack/shelf_metal,
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "csU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -6355,24 +6330,10 @@
 	},
 /area/f13/brotherhood)
 "das" = (
-/obj/structure/closet/crate/large{
-	layer = 0
-	},
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_color = "#f4e3b0"
+/obj/structure/fermenting_barrel,
+/obj/structure/railing/wood{
+	layer = 0;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
@@ -7157,27 +7118,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"ehZ" = (
-/obj/structure/closet/crate/large{
-	layer = 1
-	},
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/obj/effect/spawner/lootdrop/f13/medical/surgical/blood,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "eiq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -7631,18 +7571,6 @@
 /obj/item/clothing/head/helmet/skull,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"eRH" = (
-/obj/machinery/workbench,
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_color = "#f4e3b0"
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "eRL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7909,13 +7837,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/vault,
 /area/f13/brotherhood)
-"ftm" = (
-/obj/machinery/chem_master,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "ftM" = (
 /obj/structure/table/wood/poker,
 /obj/item/dice,
@@ -8226,10 +8147,6 @@
 /obj/item/clothing/head/helmet/f13/combat/environmental,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
-"gaI" = (
-/obj/machinery/smartfridge/bottlerack/drug_storage,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "gck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9260,19 +9177,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "hMi" = (
-/obj/structure/closet/crate/large{
-	layer = 0
+/obj/structure/fermenting_barrel,
+/obj/structure/railing/wood{
+	layer = 0;
+	pixel_y = 7
+	},
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
 	},
 /obj/structure/railing/wood{
 	dir = 8;
 	pixel_x = -3
 	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "hMq" = (
@@ -9931,14 +9848,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"iXq" = (
-/obj/machinery/chem_heater,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "iXJ" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/pistol,
@@ -10297,6 +10206,10 @@
 	dir = 8;
 	pixel_x = -3
 	},
+/obj/structure/rack/shelf_metal,
+/obj/item/export/bottle/white_bloodmoon,
+/obj/item/export/bottle/whiskey,
+/obj/item/export/bottle/wine,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "jAH" = (
@@ -11440,12 +11353,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
 "lDl" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Prospector Entrance";
-	req_one_access_txt = "48"
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "prospector1open"
+	},
+/obj/machinery/door/unpowered/securedoor{
+	name = "Prospector Side Entrance";
+	req_one_access_txt = "25"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
@@ -11963,19 +11876,7 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "mkk" = (
-/obj/machinery/door/poddoor/ert{
-	id = "bankvault";
-	layer = 3;
-	name = "Vault Blast Door"
-	},
-/obj/machinery/door/airlock/vault{
-	autoclose = "TRUE";
-	layer = 2;
-	max_integrity = 1000;
-	name = "Bighorn Vault";
-	normal_integrity = 800;
-	req_one_access_txt = "52"
-	},
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "mlD" = (
@@ -11995,18 +11896,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"mmD" = (
-/obj/machinery/autolathe,
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "mna" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
@@ -12448,18 +12337,6 @@
 	dir = 4
 	},
 /area/f13/brotherhood)
-"nhF" = (
-/obj/machinery/button/door{
-	id = "bankvault";
-	name = "bank vault button";
-	pixel_x = 32;
-	req_one_access_txt = "52"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
-	},
-/area/f13/tunnel)
 "nhG" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/side{
@@ -13452,12 +13329,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
-"oUz" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "oUH" = (
 /obj/structure/table/abductor{
 	desc = "After YEARS of research, prototyping, and testing, the brotherhood created the sequel to the table. Advanced flat surface technology at work!";
@@ -13765,7 +13636,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
 "puA" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/machinery/workbench/bottler,
+/obj/structure/railing/wood{
+	layer = 0;
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "pvk" = (
@@ -14002,12 +13877,6 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/tunnel)
-"pMa" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/syringes,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "pMb" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/glass,
@@ -14682,11 +14551,11 @@
 	},
 /area/f13/tunnel)
 "qKh" = (
-/obj/machinery/smartfridge/bottlerack/drug_storage,
 /obj/structure/railing/wood{
 	dir = 8;
 	pixel_x = -3
 	},
+/obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "qKn" = (
@@ -14957,12 +14826,6 @@
 	},
 /turf/open/floor/plating,
 /area/f13/tunnel)
-"rkQ" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/pillbottles,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "rmp" = (
 /obj/machinery/light,
 /obj/machinery/rnd/server/followers{
@@ -15051,7 +14914,7 @@
 	},
 /area/f13/tunnel)
 "rsP" = (
-/obj/machinery/chem_master,
+/obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "rtc" = (
@@ -15274,9 +15137,11 @@
 	},
 /area/f13/followers)
 "rNn" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
+/obj/machinery/smartfridge/bottlerack,
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -3
+	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/khanfort)
 "rNy" = (
@@ -16511,19 +16376,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"tIE" = (
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/obj/structure/rack/shelf_metal,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "tIQ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -18026,14 +17878,6 @@
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/brotherhood)
-"wkC" = (
-/obj/machinery/workbench/bottler,
-/obj/structure/railing/wood{
-	layer = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/building/khanfort)
 "wlv" = (
 /obj/item/bighorn_flag,
 /turf/open/floor/f13/wood,
@@ -21011,14 +20855,14 @@ nuA
 bAC
 rci
 rsP
-bMS
-iXq
-pMa
-ciV
-rkQ
-ftm
-bMS
-bLA
+rsP
+rsP
+rsP
+rsP
+rsP
+rsP
+rsP
+rsP
 rci
 aae
 aaa
@@ -21266,15 +21110,15 @@ aaa
 rci
 kib
 jAs
-tRS
-tRS
-oUz
-tRS
+bre
 tRS
 tRS
 tRS
 tRS
-oUz
+tRS
+tRS
+tRS
+tRS
 tRS
 rci
 aae
@@ -21529,10 +21373,10 @@ tRS
 tRS
 tRS
 tRS
+rsP
+rsP
 tRS
-tRS
-tRS
-tRS
+rsP
 rci
 aaa
 aaa
@@ -21781,15 +21625,15 @@ rci
 tRS
 tRS
 aXt
-ehZ
+tRS
 tRS
 hMi
-tIE
+tRS
 tRS
 qKh
-mmD
+qKh
 tRS
-cqZ
+qKh
 rci
 aaa
 aaa
@@ -22038,14 +21882,14 @@ rci
 wEX
 tRS
 puA
-bre
 tRS
+wEX
 das
-wkC
 tRS
-gaI
-eRH
-tRS
+wEX
+rNn
+rNn
+wEX
 rNn
 rci
 aaa
@@ -34603,7 +34447,7 @@ qWu
 qWu
 qWu
 bCt
-amP
+mkk
 bCt
 bOm
 bOm
@@ -37473,7 +37317,7 @@ abb
 bsC
 oQo
 lBD
-nhF
+lGH
 bCt
 abb
 oNM
@@ -65263,13 +65107,13 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aak
 aaB
@@ -65520,13 +65364,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 nws
 nws
 nws
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -65777,13 +65621,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 iBR
 exy
 vly
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -66034,13 +65878,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 vly
 cvX
 exy
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -66291,13 +66135,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 iBR
 oDA
 vly
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -66543,23 +66387,23 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aak
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 nws
 cfN
 ory
 mix
 nws
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aae
 aae
@@ -66800,7 +66644,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 nws
 nws
@@ -66816,7 +66660,7 @@ nws
 nws
 nws
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -67057,7 +66901,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 rwL
 vNL
@@ -67073,7 +66917,7 @@ mcX
 wIn
 wqv
 nws
-aak
+aaa
 aae
 aae
 aae
@@ -67314,7 +67158,7 @@ aae
 aae
 aae
 aak
-aak
+aaa
 nws
 oVu
 pDI
@@ -67330,7 +67174,7 @@ pjG
 pDI
 bQZ
 nws
-aak
+aaa
 aae
 aae
 aae
@@ -67571,7 +67415,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 nws
 ugV
 fKJ
@@ -67587,7 +67431,7 @@ eOg
 pDI
 bRc
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -67828,7 +67672,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 nws
 ghO
 rEX
@@ -67844,7 +67688,7 @@ lIX
 eOb
 eti
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -68085,7 +67929,7 @@ aae
 aae
 aae
 aak
-aak
+aaa
 nws
 nws
 nws
@@ -68101,7 +67945,7 @@ nws
 nws
 nws
 nws
-aae
+aaa
 aae
 aae
 aak
@@ -68342,7 +68186,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 nws
 uBy
 kSo
@@ -68358,7 +68202,7 @@ uwX
 bSo
 bQI
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -68599,7 +68443,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 nws
 wGI
 pDI
@@ -68615,7 +68459,7 @@ qub
 rCg
 qmt
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -68856,7 +68700,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 dDC
 fdG
@@ -68872,7 +68716,7 @@ pCD
 qom
 kVx
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -69113,7 +68957,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 dpc
 ueb
@@ -69129,7 +68973,7 @@ pua
 vJq
 kmg
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -69370,7 +69214,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 xHi
 uYT
@@ -69386,7 +69230,7 @@ pua
 paX
 iTv
 nws
-aak
+aaa
 aae
 aak
 aae
@@ -69627,7 +69471,7 @@ aak
 aae
 aak
 aae
-aae
+aaa
 nws
 paX
 cmy
@@ -69643,7 +69487,7 @@ pua
 lJk
 fSI
 nws
-aae
+aaa
 aae
 aak
 aae
@@ -69884,7 +69728,7 @@ aae
 aae
 aak
 aae
-aae
+aaa
 nws
 rLW
 eiq
@@ -69900,7 +69744,7 @@ kGg
 nej
 hxQ
 nws
-aae
+aaa
 aae
 aak
 aae
@@ -70141,7 +69985,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 nws
 wiw
 hNr
@@ -70157,7 +70001,7 @@ pua
 dYy
 fNr
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -70398,7 +70242,7 @@ aak
 aae
 aak
 aae
-aae
+aaa
 nws
 lJk
 uYT
@@ -70414,7 +70258,7 @@ pua
 paX
 jrX
 nws
-aae
+aaa
 aak
 aae
 aae
@@ -70655,7 +70499,7 @@ aak
 aae
 aak
 aae
-aae
+aaa
 nws
 pCC
 ueb
@@ -70671,7 +70515,7 @@ pua
 vJq
 tbP
 nws
-aae
+aaa
 aak
 aae
 aae
@@ -70912,7 +70756,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 paX
 uYT
@@ -70928,7 +70772,7 @@ pCD
 xkB
 uYT
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -71169,7 +71013,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 lJb
 rCg
@@ -71185,7 +71029,7 @@ uwX
 nOj
 qmt
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -71426,7 +71270,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 nws
 bQD
 bQS
@@ -71442,7 +71286,7 @@ qub
 iCX
 gEp
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -71683,7 +71527,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 nws
 nws
 nws
@@ -71699,7 +71543,7 @@ pua
 qUT
 pua
 pua
-aak
+aaa
 aae
 aak
 aae
@@ -71940,7 +71784,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 msT
 tnC
@@ -71956,7 +71800,7 @@ xNR
 eHm
 lfB
 pua
-aae
+aaa
 aae
 aae
 aae
@@ -72197,7 +72041,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 qOd
 pDI
@@ -72213,7 +72057,7 @@ vdm
 bWq
 bjZ
 pua
-aae
+aaa
 aae
 aae
 aae
@@ -72454,7 +72298,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 hHy
 pDI
@@ -72470,7 +72314,7 @@ saE
 lfB
 gxz
 pua
-aae
+aaa
 aak
 aae
 aae
@@ -72711,7 +72555,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 eqq
 knm
@@ -72727,7 +72571,7 @@ eCq
 dWL
 cqO
 pua
-aae
+aaa
 aak
 aae
 aae
@@ -72968,7 +72812,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 nws
 nws
@@ -72984,7 +72828,7 @@ pua
 pua
 pua
 pua
-aae
+aaa
 aae
 aae
 aae
@@ -73225,23 +73069,23 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 nws
 paX
 uLz
 bMw
 nws
-aak
-aak
-aak
-aak
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aae
 aae
@@ -73487,13 +73331,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 oaP
 pDI
 uYT
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -73744,13 +73588,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 dbK
 dfI
 uYT
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -74001,13 +73845,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 qet
 bRC
 eWe
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -74258,13 +74102,13 @@ aae
 aae
 aae
 aae
-aae
+aaa
 nws
 nws
 nws
 nws
 nws
-aae
+aaa
 aae
 aae
 aae
@@ -74515,13 +74359,13 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aae
 aae

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -3,7 +3,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "aW" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -17,23 +17,27 @@
 "bo" = (
 /turf/open/indestructible,
 /area/f13/wasteland)
+"bs" = (
+/obj/effect/landmark/start/f13/banker,
+/turf/open/floor/carpet/green,
+/area/f13/city/bighorn)
 "bO" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dk" = (
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ed" = (
 /obj/structure/chair/bench,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "eH" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -44,6 +48,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"eL" = (
+/obj/effect/landmark/start/f13/mayor,
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "fd" = (
 /obj/structure/chair/comfy{
 	color = "#ad0a0a";
@@ -51,12 +59,12 @@
 	pixel_y = 2
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fA" = (
 /obj/structure/table/wood,
 /obj/item/storage/firstaid/ancient,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "hm" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
@@ -64,7 +72,7 @@
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ia" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
@@ -76,27 +84,27 @@
 	color = "#785d49";
 	icon_state = "stagestairs"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "js" = (
 /obj/effect/decal/cleanable/dirt{
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "jt" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kr" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "lh" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -108,7 +116,7 @@
 	layer = 6
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mw" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain/captain{
@@ -117,7 +125,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/carpet/green,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -133,28 +141,25 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "oV" = (
 /turf/open/floor/carpet/royalblack,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "oY" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/carpet/green,
-/area/f13/building/khanfort)
-"qh" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "ql" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sn" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/royalblack,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tL" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -170,7 +175,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uF" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/boxing,
@@ -178,17 +183,17 @@
 /obj/item/clothing/gloves/boxing/green,
 /obj/item/clothing/gloves/boxing/blue,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wa" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	pixel_y = 12
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xc" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -211,7 +216,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xG" = (
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
@@ -223,16 +228,16 @@
 	},
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "yL" = (
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "AG" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "AK" = (
 /obj/structure/fence/wooden{
 	pixel_x = 18
@@ -246,11 +251,11 @@
 	},
 /obj/structure/chair/sofa/right,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Bu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Dh" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
@@ -264,18 +269,18 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Ej" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Ep" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "EY" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/structure/window/spawner,
@@ -284,7 +289,7 @@
 	color = "#845f58"
 	},
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Fj" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
@@ -296,9 +301,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Fs" = (
-/turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
 "Gi" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khanfort)
@@ -310,17 +312,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khanfort)
-"HC" = (
-/obj/item/flag/khan{
-	density = 0;
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
 "HH" = (
 /turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/area/f13/city/bighorn)
 "HP" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -328,7 +322,7 @@
 	termtag = "Secret"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "HT" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -340,24 +334,15 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "IJ" = (
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
-"Ly" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/flag/khan{
-	density = 0;
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "LN" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "LT" = (
 /obj/structure/table/wood,
 /obj/item/melee/onehanded/machete/training,
@@ -365,10 +350,10 @@
 /obj/item/melee/onehanded/machete/training,
 /obj/item/melee/onehanded/machete/training,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Mx" = (
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "MO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -381,7 +366,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Oi" = (
 /obj/structure/chair/sofa,
 /obj/structure/sign/poster/contraband/pinup_couch{
@@ -389,14 +374,14 @@
 	pixel_y = 32
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Os" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 4;
 	pixel_y = 30
 	},
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "OF" = (
 /obj/effect/overlay/junk/curtain,
 /obj/machinery/shower{
@@ -405,17 +390,23 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "OQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "OT" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Pp" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door{
+	name = "Banker Quarters"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "Qh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -428,7 +419,7 @@
 	},
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "RA" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -442,17 +433,10 @@
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
-"RK" = (
-/obj/structure/simple_door/metal{
-	name = "Noyan's Quarters";
-	req_access_txt = "52"
-	},
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
 "RP" = (
 /obj/structure/safe/floor,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Sm" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -464,18 +448,18 @@
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/random,
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "SK" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "SP" = (
 /obj/structure/fence,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "SR" = (
 /obj/structure/chair/bench,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Tf" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -493,22 +477,22 @@
 "TF" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "TH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Ud" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Uy" = (
 /turf/open/floor/carpet/green,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Vi" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Vw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -516,7 +500,7 @@
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "VX" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -526,7 +510,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "WJ" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -534,14 +518,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Xa" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Xy" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -550,35 +534,34 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/khanfort)
 "Yk" = (
-/obj/structure/simple_door/metal{
-	name = "Steward's Quarters";
-	req_access_txt = "52"
+/obj/machinery/door/unpowered/securedoor/sheriff_door{
+	name = "Mayoral Quarters"
 	},
 /turf/open/floor/wood/wood_mosaic,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Yp" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "YA" = (
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "YC" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "YW" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "Zd" = (
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ZU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -586,7 +569,7 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 
 (1,1,1) = {"
 RF
@@ -1324,13 +1307,13 @@ ia
 ia
 ia
 tL
-HC
 Gi
 Gi
 Gi
 Gi
 Gi
-HC
+Gi
+Gi
 Sm
 hm
 hm
@@ -1832,10 +1815,10 @@ ia
 RF
 RF
 RF
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
 ia
 RA
 Gi
@@ -2089,10 +2072,10 @@ ia
 RF
 RF
 ia
-Fs
+HH
 Dj
 OF
-Fs
+HH
 tL
 Gi
 Gi
@@ -2105,7 +2088,7 @@ Gi
 Gi
 Qh
 Gi
-HC
+Gi
 Sm
 hm
 hm
@@ -2346,10 +2329,10 @@ RF
 RF
 ia
 ia
-Fs
+HH
 HT
 dk
-Fs
+HH
 tL
 Gi
 Gi
@@ -2599,14 +2582,14 @@ RF
 RF
 ia
 RF
-Fs
-Fs
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
+HH
+HH
 nT
-Fs
+HH
 tL
 Gi
 GN
@@ -2856,22 +2839,22 @@ ia
 ia
 ia
 RF
-Fs
+HH
 jt
 Wt
 QZ
 Mx
 Mx
 Mx
-Fs
 HH
-qh
-Fs
+HH
+HH
+HH
 Ej
 Ej
 Ej
 Ej
-Fs
+HH
 Tf
 Gi
 Gi
@@ -3113,14 +3096,14 @@ RF
 ia
 ia
 RF
-Fs
+HH
 oV
 oV
 iW
 Mx
 Mx
 mr
-Fs
+HH
 YA
 Yp
 Ej
@@ -3370,14 +3353,14 @@ RF
 ia
 ia
 RF
-Fs
+HH
 sn
 oV
 iW
-Mx
+eL
 fd
 LN
-Fs
+HH
 YA
 yL
 Ej
@@ -3627,14 +3610,14 @@ RF
 ia
 ia
 RF
-Fs
+HH
 oV
 oV
 iW
 Mx
 Mx
 LN
-Fs
+HH
 YA
 ah
 Ej
@@ -3884,14 +3867,14 @@ RF
 ia
 ia
 RF
-Fs
+HH
 Os
 Xa
 EY
 Mx
 Mx
 xw
-RK
+Yk
 YA
 ah
 Ej
@@ -3904,7 +3887,7 @@ Gi
 Gi
 Gi
 Gi
-HC
+Gi
 Sm
 hm
 hm
@@ -4141,14 +4124,14 @@ ia
 ia
 RF
 ia
-Fs
-Fs
-Fs
-Fs
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
+HH
+HH
+HH
+HH
 YA
 yL
 Ej
@@ -4398,14 +4381,14 @@ RF
 ia
 RF
 ia
-Fs
+HH
 RP
 Mx
 HP
 MO
 Ep
 Mx
-Yk
+Pp
 Bu
 YA
 Ej
@@ -4655,22 +4638,22 @@ RF
 ia
 RF
 RF
-Fs
+HH
 Mx
 Uy
 oY
 mw
 tU
 Mx
-Fs
+HH
 Bu
 YA
-Fs
+HH
 SP
 SP
 ql
 SP
-Fs
+HH
 Gi
 Gi
 Sm
@@ -4912,22 +4895,22 @@ RF
 ia
 ia
 ia
-Fs
+HH
 Mx
 Uy
-Uy
+bs
 YW
 tU
 Mx
-Fs
+HH
 YA
 YA
-Fs
+HH
 wA
 Ud
 wa
 kr
-Fs
+HH
 mM
 Gi
 Sm
@@ -5169,22 +5152,22 @@ RF
 ia
 ia
 RF
-Fs
+HH
 SI
 LN
 Mx
 xw
 Mx
 Mx
-Fs
+HH
 YA
 YA
-Fs
+HH
 LT
 wa
 wa
 Vw
-Fs
+HH
 Gi
 Gi
 Sm
@@ -5426,22 +5409,22 @@ ia
 ia
 RF
 RF
-Fs
-Fs
-Fs
+HH
+HH
+HH
 nT
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
 YA
 YA
-Fs
+HH
 fA
 wa
 wa
 ZU
-Fs
+HH
 Gi
 Gi
 Sm
@@ -5684,10 +5667,10 @@ ia
 RF
 ia
 ia
-Fs
+HH
 WJ
 dk
-Fs
+HH
 Yp
 YA
 YA
@@ -5698,7 +5681,7 @@ wa
 wa
 Ud
 Ud
-Fs
+HH
 Gi
 Gi
 xc
@@ -5941,16 +5924,16 @@ ia
 RF
 ia
 ia
-Fs
+HH
 Dj
 OF
-Fs
+HH
 Bu
 Bu
 YA
 Bu
 YA
-Fs
+HH
 uF
 wa
 wa
@@ -5960,7 +5943,7 @@ Gi
 Qh
 Gi
 Qh
-HC
+Gi
 Sm
 hm
 hm
@@ -6198,21 +6181,21 @@ RF
 RF
 ia
 ia
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
 Zd
 Zd
-Fs
+HH
 YA
 Bu
-Fs
+HH
 AT
 wa
 wa
 ed
-Fs
+HH
 Gi
 Gi
 Gi
@@ -6458,18 +6441,18 @@ RF
 ia
 ia
 ia
-Fs
+HH
 Zd
 Zd
-Fs
+HH
 YA
 YA
-Fs
+HH
 Oi
 wa
 Ud
 SR
-Fs
+HH
 xG
 Gi
 Gi
@@ -6715,18 +6698,18 @@ ia
 ia
 RF
 ia
-Fs
-Fs
-Fs
-Fs
+HH
+HH
+HH
+HH
 Vi
 yG
-Fs
+HH
 IJ
 YC
 wa
 SR
-Fs
+HH
 xG
 Gi
 Gi
@@ -6976,14 +6959,14 @@ RF
 RF
 ia
 ia
-Fs
-Fs
-Fs
-Fs
-Fs
-wa
-Fs
-Fs
+HH
+HH
+HH
+HH
+HH
+lh
+HH
+HH
 Tf
 Gi
 Gi
@@ -7759,7 +7742,7 @@ Gi
 Gi
 Gi
 Gi
-HC
+Gi
 Sm
 hm
 hm
@@ -8520,13 +8503,13 @@ hm
 hm
 hm
 Fo
-Ly
+Qh
 Gi
 Gi
 Gi
 Qh
 Qh
-HC
+Gi
 Sm
 hm
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -289,10 +289,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"abb" = (
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "abc" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/bighorn)
@@ -308,35 +305,24 @@
 /area/f13/wasteland)
 "abe" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "abf" = (
 /obj/structure/stairs/west{
 	color = "#624b30"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abh" = (
 /turf/open/floor/plasteel/stairs{
 	color = "#4b3a26"
 	},
-/area/f13/building/khanfort)
-"abi" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abj" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abk" = (
 /obj/machinery/power/terminal{
 	dir = 4;
@@ -369,7 +355,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abo" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
@@ -386,19 +372,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"abq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
 "abs" = (
-/obj/structure/chair/comfy/throne,
-/obj/effect/landmark/start/f13/noyan,
+/obj/structure/chair/comfy/throne{
+	name = "mayoral throne"
+	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"abt" = (
-/turf/closed/wall/f13/sunset/brick_small,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abu" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -407,7 +386,7 @@
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abv" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -417,65 +396,41 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abx" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
 "aby" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"abA" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
-"abB" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/obj/effect/landmark/start/f13/khorchin,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"abC" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/khorchin,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abD" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder/constructed,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abE" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abF" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
-"abG" = (
-/obj/effect/turf_decal/huge/khan,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abH" = (
 /obj/structure/decoration/vent,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -487,14 +442,14 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abJ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abK" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag/towel,
@@ -502,14 +457,14 @@
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abN" = (
 /obj/structure/curtain{
 	color = "#845f58";
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abO" = (
 /obj/structure/closet/locker/fridge,
 /obj/item/storage/box/ingredients/vegetarian,
@@ -521,15 +476,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abP" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
-"abQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "abR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -539,28 +490,26 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/footlocker{
-	anchored = 1;
-	pixel_x = -7
-	},
+/obj/structure/table/wood,
+/obj/item/hand_labeler,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abU" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/pirate,
+/obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abW" = (
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
@@ -568,19 +517,11 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "abX" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"abZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "acb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -588,14 +529,14 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "acc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ace" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -606,14 +547,14 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "acf" = (
 /obj/structure/curtain{
 	color = "#845f58";
 	pixel_y = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "acg" = (
 /obj/structure/closet/crate/footlocker{
 	anchored = 1;
@@ -624,12 +565,13 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ach" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/pirate,
+/obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "aci" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -643,18 +585,18 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "acj" = (
 /obj/structure/chair/bench{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "ack" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "acl" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -664,29 +606,12 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"acm" = (
-/obj/item/flag/khan{
-	density = 0;
-	pixel_y = 20
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
-"acn" = (
-/obj/item/flag/khan{
-	density = 0;
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "aco" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "acp" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4;
@@ -695,13 +620,13 @@
 /turf/open/floor/plasteel/stairs{
 	color = "#4b3a26"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "acq" = (
 /obj/structure/fence/wooden{
 	dir = 4
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
@@ -709,37 +634,37 @@
 "acs" = (
 /obj/structure/campfire/stove,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "act" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acu" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /obj/item/binoculars,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acx" = (
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acy" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -755,46 +680,46 @@
 	id = "prospectorladder2"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acA" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acC" = (
 /obj/structure/simple_door/tent,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acD" = (
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 1;
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acE" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acG" = (
 /obj/structure/barricade/wooden,
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acH" = (
 /obj/structure/fence/wooden{
 	density = 0
@@ -807,7 +732,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acI" = (
 /obj/structure/fence/wooden{
 	density = 0
@@ -820,13 +745,13 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acJ" = (
 /turf/open/floor/plating/wooden{
 	color = "#8d675d";
 	name = "grating"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acK" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -837,20 +762,20 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acN" = (
 /obj/structure/railing/wood{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acO" = (
 /obj/structure/fence/wooden{
 	density = 0;
 	pixel_y = 32
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acP" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -860,56 +785,52 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acQ" = (
 /obj/structure/closet/crate/footchest,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/spear,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acR" = (
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
-"acS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acT" = (
 /obj/structure/closet/crate/footchest,
 /obj/item/twohanded/spear,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acU" = (
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acV" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acW" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/weapon_parts,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acY" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/lighter,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "acZ" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -925,7 +846,7 @@
 /obj/item/binoculars,
 /obj/item/binoculars,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "adf" = (
 /obj/machinery/light/small/broken,
 /obj/effect/overlay/junk/sink{
@@ -1015,7 +936,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "anv" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -1089,7 +1010,7 @@
 /area/f13/building/mall)
 "awp" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "awv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1216,7 +1137,7 @@
 "aIJ" = (
 /obj/structure/railing/wood,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "aJv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -1421,9 +1342,9 @@
 	},
 /area/f13/building/massfusion)
 "beJ" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bfJ" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1506,9 +1427,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/mall)
-"bsJ" = (
-/turf/open/floor/f13/wood,
-/area/f13/tunnel/khanfort)
 "btA" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -1689,7 +1607,7 @@
 "bOg" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bQw" = (
 /obj/structure/sign/poster/prewar/poster75{
 	pixel_y = 32
@@ -2039,7 +1957,7 @@
 "cUT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "cVJ" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder/empty,
@@ -2069,12 +1987,6 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"dan" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
-	},
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "dbl" = (
 /obj/structure/table,
 /obj/structure/junk/small/tv{
@@ -2185,7 +2097,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dnp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2247,7 +2159,7 @@
 /area/f13/city/bighorn)
 "dvF" = (
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/wasteland)
+/area/f13/city/bighorn)
 "dxe" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2335,7 +2247,7 @@
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin/empty,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dNd" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -2450,13 +2362,6 @@
 	icon_state = "bluerusty"
 	},
 /area/f13/building/hospital)
-"edT" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
-	},
-/obj/effect/landmark/start/f13/kheshig,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "egF" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -2503,7 +2408,7 @@
 /obj/item/crafting/abraxo,
 /obj/structure/shelf_wood,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "eoE" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_7"
@@ -2574,7 +2479,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "euX" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -2606,7 +2511,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ezz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -2689,7 +2594,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
+/area/f13/city/bighorn)
 "ePO" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/f13/wood/house,
@@ -2902,7 +2807,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fAM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2917,21 +2822,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"fEr" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/khorchin,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "fEX" = (
 /obj/structure/chair/wood/fancy{
 	dir = 8
 	},
-/obj/effect/landmark/start/f13/steward,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fFj" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -2954,9 +2850,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"fKU" = (
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
 "fNm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_barrels,
@@ -2973,9 +2866,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
-"fQh" = (
-/turf/open/transparent/openspace,
-/area/f13/building/khanfort)
 "fQw" = (
 /obj/structure/railing{
 	dir = 1
@@ -3027,7 +2917,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fVh" = (
 /obj/structure/railing/corner,
 /turf/open/floor/f13{
@@ -3132,8 +3022,8 @@
 "gob" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/caphat/formal/fedcover{
-	name = "security officer's cap";
-	desc = "The latest in fashionable security outfits."
+	desc = "The latest in fashionable security outfits.";
+	name = "security officer's cap"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
@@ -3265,14 +3155,6 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
-"gHU" = (
-/obj/item/flag/khan{
-	density = 0;
-	pixel_x = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/khanfort)
 "gJu" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -3387,7 +3269,7 @@
 	pixel_x = -3
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "gTP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3591,7 +3473,7 @@
 "hsp" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "hsU" = (
 /obj/structure/simple_door/metal/dirtystore{
 	name = "Mall of Wyoming"
@@ -3842,7 +3724,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ibB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3880,7 +3762,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "iir" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-24"
@@ -4006,7 +3888,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ixJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard{
@@ -4199,7 +4081,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "iUG" = (
 /obj/item/storage/bag/trash,
 /turf/open/floor/plasteel/f13{
@@ -4505,7 +4387,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "jRW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4603,7 +4485,7 @@
 /area/f13/building/mall)
 "kaE" = (
 /turf/open/transparent/openspace,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "kbe" = (
 /obj/structure/table,
 /obj/structure/fluff/railing{
@@ -4648,7 +4530,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kfx" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
@@ -4685,6 +4567,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/radiation)
+"kke" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/belt/bandolier,
+/obj/item/storage/belt/bandolier,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "kls" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -4810,7 +4701,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
@@ -4834,10 +4725,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building/hospital)
-"kOc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
 "kOr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4983,7 +4870,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "lhW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -5417,7 +5304,7 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mew" = (
 /obj/structure/railing{
 	dir = 9
@@ -5427,12 +5314,6 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"meA" = (
-/obj/item/flag/khan{
-	pixel_y = 5
-	},
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "mhV" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -5479,7 +5360,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mmp" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5609,7 +5490,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "myu" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -5800,7 +5681,7 @@
 	icon_state = "interior"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mZL" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -6246,7 +6127,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "odC" = (
 /obj/item/chair/stool/retro,
 /turf/open/floor/f13/wood,
@@ -6288,6 +6169,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/mall)
+"oig" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/holster/legholster/police,
+/obj/item/storage/belt/holster/legholster/police,
+/obj/item/storage/belt/holster/legholster/police,
+/obj/item/storage/belt/holster/legholster/police,
+/obj/item/storage/belt/holster/legholster/police,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "ojS" = (
 /turf/closed/wall/f13/store,
 /area/f13/wasteland)
@@ -6322,7 +6212,7 @@
 	name = "Washroom"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "onr" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/f13{
@@ -6358,6 +6248,12 @@
 	layer = 4.1
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
+/area/f13/city/bighorn)
+"oub" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/pirate,
+/obj/effect/landmark/start/f13/sheriff,
+/turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
 "ouA" = (
 /obj/structure/table,
@@ -6578,9 +6474,6 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
-"oVT" = (
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "oWZ" = (
 /turf/open/transparent/openspace,
 /area/f13/caves)
@@ -6763,9 +6656,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"pxI" = (
-/turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
 "pxQ" = (
 /obj/structure/simple_door/house{
 	name = "Sparky Appliances"
@@ -6923,7 +6813,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "pVD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7078,7 +6968,7 @@
 /obj/structure/table/wood/bar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "qmw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7436,7 +7326,7 @@
 "qWS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "qYF" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
@@ -7730,7 +7620,7 @@
 "rOo" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "rPV" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -8078,7 +7968,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sRn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8267,7 +8157,7 @@
 "tjb" = (
 /obj/structure/punching_bag,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tkH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/house{
@@ -8431,7 +8321,7 @@
 "tAr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "tAz" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
@@ -8508,10 +8398,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
-"tLE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel/khanfort)
 "tMJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -8633,7 +8519,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "udt" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -8737,7 +8623,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uoa" = (
 /obj/item/trash/candy{
 	pixel_x = 7;
@@ -8965,10 +8851,8 @@
 /obj/structure/chair/wood/fancy{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/kheshig,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uPm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9050,7 +8934,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "vfp" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -9104,7 +8988,7 @@
 "vlI" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "vol" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -9276,7 +9160,7 @@
 "vKS" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "vLp" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -9469,7 +9353,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wyp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9510,9 +9394,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
 "wDR" = (
-/obj/machinery/mineral/wasteland_vendor/khanchem,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wEu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -9574,7 +9457,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wMt" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
@@ -9701,7 +9584,7 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xfe" = (
 /obj/structure/flora/ausbushes/grassybush{
 	icon_state = "firstbush_1"
@@ -9816,7 +9699,7 @@
 /area/f13/building/massfusion)
 "xuM" = (
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xvZ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
@@ -9935,7 +9818,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xIF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10938,10 +10821,10 @@ abx
 abx
 abx
 abx
-abt
-abt
-abt
-abt
+dvF
+dvF
+dvF
+dvF
 xuM
 xuM
 xuM
@@ -11195,10 +11078,10 @@ xuM
 xuM
 xuM
 vKS
-abt
+dvF
 sPU
-fQh
-abt
+kaE
+dvF
 myk
 abH
 abR
@@ -11452,10 +11335,10 @@ abD
 aci
 kIp
 ucW
-abt
-fQh
-fQh
-abt
+dvF
+kaE
+kaE
+dvF
 lhS
 abI
 ucW
@@ -11710,7 +11593,7 @@ ucW
 ucW
 ucW
 xuM
-pxI
+gkd
 gSV
 xuM
 xuM
@@ -11967,16 +11850,16 @@ ucW
 ocJ
 ucW
 xuM
-pxI
-pxI
+gkd
+gkd
 cUT
 dJh
 abu
 qWS
-oVT
-ach
+kke
+oig
 ixn
-ach
+oub
 xuM
 oez
 oez
@@ -12223,15 +12106,15 @@ abO
 ucW
 unf
 ucW
-abP
-pxI
-pxI
-abP
-oVT
-oVT
-oVT
-oVT
-abT
+beJ
+gkd
+gkd
+beJ
+wDR
+wDR
+wDR
+wDR
+qWS
 qWS
 ace
 hsp
@@ -12481,15 +12364,15 @@ ucW
 ocJ
 ucW
 xuM
-pxI
-kOc
+gkd
+nGj
 xuM
-oVT
-oVT
-oVT
-oVT
-oVT
-oVT
+wDR
+wDR
+wDR
+wDR
+wDR
+wDR
 acf
 hsp
 oez
@@ -12738,15 +12621,15 @@ ucW
 ucW
 ucW
 xuM
-pxI
-kOc
+gkd
+nGj
 xuM
 abU
-oVT
+wDR
 abU
-oVT
+wDR
 abU
-oVT
+wDR
 acg
 hsp
 oez
@@ -12996,12 +12879,12 @@ xbW
 jRs
 xuM
 abw
-pxI
+gkd
 xuM
 abV
 acc
 ach
-oVT
+wDR
 abV
 euz
 ach
@@ -13253,7 +13136,7 @@ xuM
 xuM
 cUT
 xuM
-abP
+beJ
 xuM
 xuM
 xuM
@@ -13512,10 +13395,10 @@ qWS
 abJ
 qWS
 qWS
-oVT
+wDR
 abJ
-oVT
-oVT
+wDR
+wDR
 xuM
 xuM
 xuM
@@ -13764,19 +13647,19 @@ abx
 abv
 abv
 xuM
-oVT
+wDR
 qWS
-abi
 uKN
-abB
-fEr
+uKN
+uKN
+uKN
 aba
 qWS
-oVT
+wDR
 xuM
-abZ
-abQ
-acm
+dnf
+nGj
+aIJ
 oez
 oez
 oez
@@ -14021,17 +13904,17 @@ abv
 abv
 abx
 xuM
-meA
-oVT
+wDR
+wDR
 aby
 aby
 aby
 aby
 qmn
 qWS
-oVT
-oVT
-fKU
+wDR
+beJ
+gkd
 acj
 aco
 oez
@@ -14278,17 +14161,17 @@ abx
 abv
 abx
 abj
-oVT
+wDR
 vlI
 iaD
-oVT
-oVT
-abG
-oVT
-oVT
-oVT
-oVT
-fKU
+wDR
+wDR
+wDR
+wDR
+wDR
+wDR
+beJ
+gkd
 acj
 aIJ
 oez
@@ -14538,15 +14421,15 @@ xuM
 abn
 abs
 aby
-oVT
-oVT
-oVT
-oVT
-oVT
+wDR
+wDR
+abT
+wDR
+wDR
 fUK
 xuM
-fKU
-fKU
+gkd
+gkd
 aIJ
 oez
 oez
@@ -14792,17 +14675,17 @@ abx
 abv
 abx
 abj
-oVT
+wDR
 vlI
 wxI
 qWS
 qWS
-oVT
-oVT
-oVT
-oVT
-oVT
-fKU
+wDR
+wDR
+wDR
+wDR
+beJ
+gkd
 acj
 aIJ
 oez
@@ -15049,17 +14932,17 @@ abx
 abv
 abv
 xuM
-meA
-oVT
+wDR
+wDR
 aby
 aby
 aby
 aby
 aby
-oVT
-oVT
-oVT
-fKU
+wDR
+wDR
+beJ
+gkd
 acj
 aIJ
 oez
@@ -15307,18 +15190,18 @@ abx
 abx
 xuM
 qWS
-oVT
+wDR
 fEX
-edT
-abC
-abC
-dan
-oVT
+fEX
+fEX
+fEX
+fEX
+wDR
 qWS
 xuM
 acb
-abq
-acn
+nel
+aIJ
 oez
 oez
 oez
@@ -15563,15 +15446,15 @@ xuM
 xuM
 xuM
 xuM
-oVT
+wDR
 qWS
 acc
-oVT
-oVT
+wDR
+wDR
 qWS
 acc
 qWS
-oVT
+wDR
 xuM
 xuM
 xuM
@@ -16074,20 +15957,20 @@ abv
 abx
 abx
 xuM
-pxI
+gkd
 acp
 abh
-pxI
+gkd
 xuM
 dnf
-pxI
+gkd
 xuM
 tjb
 abJ
 mls
 qWS
-oVT
-oVT
+wDR
+wDR
 abK
 xuM
 oez
@@ -16336,15 +16219,15 @@ xuM
 xuM
 xuM
 xuM
-pxI
-pxI
-abA
-oVT
-oVT
-oVT
-oVT
+gkd
+gkd
+qqp
+wDR
+wDR
+wDR
+wDR
 abX
-oVT
+wDR
 acl
 hsp
 oez
@@ -16591,17 +16474,17 @@ abx
 abx
 xuM
 emF
-pxI
+gkd
 mZq
-pxI
-pxI
-abA
+gkd
+gkd
+qqp
 wLN
-oVT
+wDR
 wLN
-oVT
-oVT
-oVT
+wDR
+wDR
+wDR
 vfk
 hsp
 oez
@@ -16848,17 +16731,17 @@ csj
 abx
 xuM
 fAx
-pxI
+gkd
 xuM
-pxI
-pxI
-abA
-oVT
-oVT
-oVT
-oVT
+gkd
+gkd
+qqp
+wDR
+wDR
+wDR
+wDR
 bOg
-oVT
+wDR
 acl
 hsp
 oez
@@ -17107,16 +16990,16 @@ xuM
 xuM
 xuM
 xuM
-kOc
-kOc
+nGj
+nGj
 xuM
-wDR
+aby
 qWS
-oVT
-oVT
-oVT
-acc
 wDR
+wDR
+wDR
+acc
+aby
 xuM
 oez
 oez
@@ -17364,12 +17247,12 @@ abv
 abv
 abx
 xuM
-pxI
+gkd
 xHP
 xuM
 xuM
-oVT
-oVT
+wDR
+wDR
 xuM
 rOo
 xuM
@@ -17621,14 +17504,14 @@ abv
 abv
 abx
 dvF
-fQh
-fQh
-abt
+kaE
+kaE
+dvF
 xuM
 abn
-oVT
+wDR
 xuM
-fKU
+gkd
 eOj
 xuM
 abv
@@ -17879,14 +17762,14 @@ abv
 abx
 dvF
 igu
-fQh
-abt
+kaE
+dvF
 xuM
 abN
 pNa
 abP
-fKU
-fKU
+gkd
+gkd
 xuM
 abv
 abx
@@ -18135,15 +18018,15 @@ abx
 abx
 abx
 dvF
-abt
-abt
-abt
+dvF
+dvF
+dvF
 xuM
 hsp
 hsp
 xuM
-gHU
-fKU
+gkd
+gkd
 xuM
 abx
 abv
@@ -18399,8 +18282,8 @@ abx
 oez
 oez
 mWY
-fKU
-fKU
+gkd
+gkd
 wlR
 oez
 oez
@@ -19438,8 +19321,8 @@ abv
 abv
 abv
 abv
-abb
-abb
+xuM
+xuM
 awp
 acH
 kaE
@@ -19447,8 +19330,8 @@ kaE
 kaE
 acO
 tAr
-acS
-acS
+cUT
+cUT
 smZ
 abv
 abv
@@ -19695,7 +19578,7 @@ abv
 abv
 abv
 abv
-abb
+xuM
 acB
 acz
 acG
@@ -19705,7 +19588,7 @@ kaE
 acG
 acQ
 acT
-acS
+cUT
 smZ
 abv
 abv
@@ -20209,17 +20092,17 @@ dtb
 abv
 abv
 abv
-abb
+xuM
 acA
-abb
+xuM
 acG
 acL
 acL
 acL
 acG
-abb
+xuM
 acC
-abb
+xuM
 abv
 abv
 abv
@@ -20469,11 +20352,11 @@ abv
 acq
 abe
 acE
-bsJ
-bsJ
-tLE
-tLE
-bsJ
+gkd
+gkd
+nGj
+nGj
+gkd
 acx
 abe
 awp
@@ -21240,11 +21123,11 @@ abv
 acq
 abe
 acF
-bsJ
-tLE
-bsJ
-bsJ
-tLE
+gkd
+nGj
+gkd
+gkd
+nGj
 acR
 abe
 awp
@@ -21493,19 +21376,19 @@ dtb
 dtb
 abv
 abv
-abb
-abb
+xuM
+xuM
 acC
-abb
+xuM
 acG
 acN
 acN
 acN
 acG
-abb
+xuM
 acC
-abb
-abb
+xuM
+xuM
 abv
 abv
 abv
@@ -22521,8 +22404,8 @@ dtb
 dtb
 abv
 abv
-abb
-abb
+xuM
+xuM
 acD
 abe
 acG
@@ -22532,8 +22415,8 @@ kaE
 acG
 abe
 acU
-abb
-abb
+xuM
+xuM
 abv
 abv
 abv
@@ -23292,8 +23175,8 @@ dtb
 dtb
 abv
 abv
-abb
-abb
+xuM
+xuM
 abe
 abe
 acI
@@ -23303,8 +23186,8 @@ kaE
 acP
 abe
 abe
-abb
-abb
+xuM
+xuM
 abv
 abv
 abv

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -274,7 +274,7 @@
 /area/f13/building/massfusion)
 "aaW" = (
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "aaX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -313,8 +313,11 @@
 "abg" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/overlay/rockfloor_side,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "abh" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/armor/f13/leatherarmor,
@@ -352,6 +355,18 @@
 "abo" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -476,7 +491,7 @@
 "abI" = (
 /obj/effect/overlay/rockfloor_side,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "abJ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/opossum/poppy,
@@ -514,7 +529,7 @@
 "abR" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "abS" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -536,8 +551,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "abW" = (
-/obj/structure/closet/crate/freezer/blood{
-	pixel_y = 20
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -545,12 +561,9 @@
 	},
 /area/f13/building)
 "abX" = (
-/obj/structure/closet{
-	pixel_x = -9;
-	pixel_y = 13
-	},
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath,
+/obj/structure/closet,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -566,13 +579,7 @@
 /area/f13/village)
 "aca" = (
 /obj/structure/table/optable,
-/obj/structure/table/optable,
-/obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/iv_drip{
-	pixel_x = -7;
-	pixel_y = 16
-	},
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -585,7 +592,6 @@
 /turf/open/floor/plating/rust,
 /area/f13/building)
 "acc" = (
-/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13{
@@ -770,6 +776,10 @@
 "acN" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/blood/old,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "acQ" = (
@@ -883,8 +893,8 @@
 /area/f13/building/massfusion)
 "adk" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small/broken,
 /obj/structure/table,
+/obj/item/trash/f13/electronic/toaster/oven,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1139,6 +1149,7 @@
 "aek" = (
 /obj/structure/table,
 /obj/item/flashlight/lantern,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ael" = (
@@ -1420,6 +1431,7 @@
 /area/f13/wasteland)
 "afu" = (
 /obj/structure/chair/stool,
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -1496,13 +1508,13 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
 "afK" = (
-/obj/structure/spider/stickyweb,
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -1671,18 +1683,10 @@
 "ags" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "agt" = (
 /obj/item/stock_parts/cell,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "agv" = (
@@ -2059,7 +2063,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ahT" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -3084,12 +3088,11 @@
 "alE" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
-"alG" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"alG" = (
+/obj/effect/landmark/start/f13/khan_chemist,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "alH" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/ruins{
@@ -3659,10 +3662,9 @@
 	},
 /area/f13/building)
 "aos" = (
-/obj/structure/guillotine,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/bighorn)
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city/bighorn)
 "aot" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/ruins,
@@ -3866,7 +3868,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "aph" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
@@ -3936,9 +3938,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "apu" = (
-/obj/item/flag/khan,
+/obj/item/bighorn_flag,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "apw" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3969,7 +3971,7 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "apC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3985,7 +3987,7 @@
 /obj/structure/stone_tile/surrounding,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "apE" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/wood/wood_common,
@@ -4008,7 +4010,7 @@
 	pixel_y = 14
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "apJ" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
@@ -4037,7 +4039,7 @@
 "apP" = (
 /obj/structure/reagent_dispensers/keg/mead,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "apU" = (
 /obj/structure/simple_door/room{
 	name = "Heaven's Night"
@@ -4098,7 +4100,7 @@
 "aqe" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aqf" = (
 /obj/machinery/smartfridge/bottlerack,
 /obj/effect/decal/cleanable/dirt{
@@ -4116,13 +4118,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
 "aqk" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aqm" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -6258,15 +6255,22 @@
 	},
 /area/f13/tunnel/southwest)
 "axW" = (
-/obj/structure/table/wood/settler,
-/obj/structure/guillotine,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/bighorn)
+/obj/structure/table/wood,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "axX" = (
-/obj/structure/table/wood/settler,
-/obj/structure/closet/crate/wicker,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/bighorn)
+/obj/structure/table/wood,
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/sheet/hay/twenty,
+/obj/item/stack/sheet/cloth/five,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "axY" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/item/storage/box/drinkingglasses,
@@ -6381,21 +6385,33 @@
 	},
 /area/f13/wasteland/west)
 "ayq" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "ayr" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/obj/item/gun/ballistic/automatic/assault_carbine/policerifle,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "ays" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right"
-	},
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/magazine/m5mm,
+/obj/item/ammo_box/magazine/m5mm,
+/obj/item/ammo_box/magazine/m5mm,
+/obj/item/ammo_box/magazine/m5mm,
+/obj/item/ammo_box/magazine/m5mm,
+/obj/item/ammo_box/magazine/m5mm,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "ayt" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -7927,11 +7943,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "aDs" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
-	},
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "aDt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
@@ -9302,8 +9320,10 @@
 /turf/open/floor/carpet,
 /area/f13/building/mall)
 "aHE" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/closed/mineral/random/low_chance,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
 /area/f13/caves)
 "aHF" = (
 /turf/closed/wall/f13/wood,
@@ -9411,7 +9431,7 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aIc" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9886,7 +9906,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel/sub)
 "aJM" = (
-/obj/item/candle/tribal_torch,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
 "aJN" = (
@@ -10011,7 +10031,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aKh" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -10212,9 +10232,6 @@
 "aKP" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
-"aKQ" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
 "aKR" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -12535,7 +12552,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aSk" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/f13/wood,
@@ -12921,7 +12938,7 @@
 	icon_state = "tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aTE" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small/broken{
@@ -13149,14 +13166,15 @@
 	},
 /area/f13/building/nanotrasen)
 "aUo" = (
-/obj/structure/decoration/rag{
-	layer = 2.5;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/obj/item/ammo_box/shotgun/bean,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "aUr" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/farm)
@@ -13317,7 +13335,7 @@
 /obj/structure/table/wood,
 /obj/item/kitchen/knife/butcher,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aUT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13330,7 +13348,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aUU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13428,15 +13446,11 @@
 	},
 /area/f13/building/nanotrasen)
 "aVl" = (
-/obj/structure/decoration/rag{
-	layer = 2.5;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2left"
-	},
-/area/f13/wasteland/bighorn)
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "aVm" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -13511,7 +13525,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aVz" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -13522,11 +13536,11 @@
 /obj/structure/bed/mattress,
 /obj/item/clothing/glasses/f13/biker,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aVC" = (
 /obj/structure/closet/crate,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aVD" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/plate{
@@ -13549,7 +13563,7 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aVG" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -13656,7 +13670,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aVU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13742,7 +13756,7 @@
 	name = "Khan Hut"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWj" = (
 /obj/item/weldingtool,
 /obj/effect/decal/cleanable/dirt,
@@ -13792,7 +13806,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWu" = (
 /obj/machinery/workbench/forge,
 /turf/open/floor/plasteel/f13{
@@ -13804,7 +13818,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWw" = (
 /obj/machinery/blackbox_recorder{
 	name = "data unit"
@@ -13844,13 +13858,12 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWD" = (
-/obj/item/clothing/suit/armor/f13/brahmin_leather_duster,
-/obj/item/clothing/head/helmet/f13/brahmincowboyhat,
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "aWE" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13859,7 +13872,7 @@
 /obj/item/fishy/salmon,
 /obj/item/fishy/salmon,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13896,11 +13909,8 @@
 	},
 /area/f13/building/bighornbunker)
 "aWL" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/effect/landmark/start/f13/khan,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aWM" = (
 /obj/machinery/vending/clothing,
@@ -13924,7 +13934,7 @@
 /obj/item/fishy/shrimp,
 /obj/item/fishy/lobster,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aWP" = (
 /obj/structure/railing{
 	dir = 9
@@ -13999,7 +14009,7 @@
 	},
 /area/f13/building/bighornbunker)
 "aXc" = (
-/obj/effect/decal/remains/human,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -14033,7 +14043,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXh" = (
 /obj/structure/decoration/rag,
 /obj/structure/window/fulltile/wood,
@@ -14044,7 +14054,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXi" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -14086,7 +14096,7 @@
 	name = "Khan Hut"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXn" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -14134,7 +14144,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -14180,12 +14190,12 @@
 	pixel_x = 5
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXB" = (
 /obj/structure/closet/crate/wicker,
 /obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXC" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt{
@@ -14209,7 +14219,7 @@
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXH" = (
 /obj/machinery/power/terminal{
 	dir = 8;
@@ -14291,12 +14301,12 @@
 	name = "Khan Hut"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXV" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aXW" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/bar/heaven)
@@ -14335,11 +14345,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
-"aYe" = (
-/obj/item/flag/khan,
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
 "aYf" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14387,14 +14392,14 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aYn" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 10
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "aYo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -14415,7 +14420,7 @@
 /obj/item/shovel/spade,
 /obj/item/reagent_containers/spray/pestspray,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aYq" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/item/seeds/agave,
@@ -14437,7 +14442,7 @@
 /obj/item/storage/bag/plants,
 /obj/item/storage/bag/plants,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -14450,18 +14455,18 @@
 "aYt" = (
 /obj/structure/legion_extractor,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aYv" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aYw" = (
 /obj/item/storage/fancy/rollingpapers,
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "aYx" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -15075,6 +15080,10 @@
 /area/f13/bar/heaven)
 "baj" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -15089,7 +15098,6 @@
 /area/f13/caves)
 "bap" = (
 /obj/machinery/light,
-/obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrightbottom"
 	},
@@ -16884,7 +16892,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bgj" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/road{
@@ -16894,7 +16902,7 @@
 "bgl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "bgm" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16978,7 +16986,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "bgA" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -17057,7 +17065,7 @@
 	pixel_x = -16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bgR" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
@@ -17253,9 +17261,8 @@
 	},
 /area/f13/wasteland/bighorn)
 "bhG" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/bighorn)
 "bhH" = (
 /obj/structure/simple_door/metal/store,
 /obj/structure/barricade/wooden,
@@ -17559,7 +17566,7 @@
 	},
 /area/f13/building/nanotrasen)
 "biK" = (
-/obj/structure/simple_door/bunker,
+/obj/machinery/door/unpowered/securedoor/khandoor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "biL" = (
@@ -17872,7 +17879,7 @@
 	},
 /area/f13/building/nanotrasen)
 "bjJ" = (
-/obj/item/flag/khan,
+/obj/item/bighorn_flag,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
 	},
@@ -17967,19 +17974,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/bighorn)
-"bkl" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/item/flag/khan,
-/turf/closed/indestructible/riveted/boss{
-	name = "temple wall"
-	},
-/area/f13/tunnel/khanfort)
 "bkm" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -18069,10 +18063,7 @@
 /area/f13/city/bighorn)
 "bku" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/securedoor{
-	name = "First Bank of Bighorn";
-	req_one_access_txt = "52"
-	},
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "bkw" = (
@@ -18102,7 +18093,7 @@
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bkA" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/floor/carpet/green,
@@ -18217,10 +18208,7 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "bkR" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "First Bank of Bighorn";
-	req_one_access_txt = "52"
-	},
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "bkS" = (
@@ -18459,7 +18447,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "blB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/three_barrels,
@@ -18658,7 +18646,7 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "bmt" = (
-/obj/machinery/door/poddoor/gate/preopen{
+/obj/machinery/door/poddoor/gate{
 	id = "exteriorgate"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -18786,10 +18774,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland/bighorn)
-"bmP" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city/bighorn)
 "bmQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
@@ -18815,7 +18799,7 @@
 	pixel_y = -16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bmU" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -18888,13 +18872,13 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnj" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnk" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
@@ -18936,20 +18920,19 @@
 /turf/open/water,
 /area/f13/wasteland/bighorn)
 "bnq" = (
-/obj/effect/turf_decal/huge/khan,
 /obj/structure/stone_tile/block{
 	dir = 1;
 	pixel_x = -16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnr" = (
 /obj/structure/stone_tile/block{
 	dir = 1;
 	pixel_x = 16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bns" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/water,
@@ -18969,7 +18952,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnv" = (
 /obj/effect/decal/riverbank,
 /obj/structure/obstacle/barbedwire/end,
@@ -18978,11 +18961,11 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnD" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "bnF" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -19000,7 +18983,7 @@
 	pixel_x = 5
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "bnI" = (
 /obj/machinery/vending/boozeomat{
 	density = 0;
@@ -19043,7 +19026,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnQ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -19062,7 +19045,7 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnU" = (
 /obj/machinery/computer/terminal{
 	density = 0;
@@ -19072,7 +19055,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnV" = (
 /obj/item/instrument/eguitar{
 	anchored = 1;
@@ -19087,13 +19070,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnY" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bnZ" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/wood/wood_common,
@@ -19237,7 +19220,7 @@
 	obj_integrity = 800
 	},
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "boN" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_x = 3;
@@ -19500,7 +19483,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqc" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -19508,7 +19491,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqd" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -19517,19 +19500,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqe" = (
 /obj/effect/spawner/lootdrop/raiderloot,
 /obj/effect/spawner/lootdrop/raiderloot,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqf" = (
 /obj/effect/spawner/lootdrop/raiderloot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqi" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -19540,10 +19523,7 @@
 	name = "fortress gate"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
-"bqp" = (
-/turf/closed/wall/f13/sunset/brick_small,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqr" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/f13/wood,
@@ -19564,22 +19544,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bqu" = (
-/obj/structure/table/wood,
-/obj/structure/closet/crate/large,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/sheet/hay/twenty,
-/obj/item/stack/sheet/cloth/five,
-/obj/item/grenade/frag,
-/obj/item/grenade/frag,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/stingbangs,
+/obj/item/storage/box/stingbangs,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"bqv" = (
-/obj/structure/table/wood,
-/obj/structure/closet/crate/large,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqw" = (
 /obj/structure/simple_door/metal/store,
 /obj/machinery/door/poddoor/shutters{
@@ -19590,12 +19559,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building/museum)
-"bqx" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/advice_blacksmith,
-/obj/item/twohanded/sledgehammer/simple,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "bqy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/baseball/spiked,
@@ -19606,7 +19569,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/bag/salvage,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqz" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /mob/living/simple_animal/hostile/raider/junker,
@@ -19615,9 +19578,10 @@
 	},
 /area/f13/building/massfusion)
 "bqA" = (
-/obj/machinery/workbench,
+/obj/structure/rack/shelf_metal,
+/obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/ballistic/revolver/hobo/piperifle,
@@ -19629,26 +19593,19 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqD" = (
 /obj/item/sign/bee_warning,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
-"bqE" = (
-/obj/structure/anvil/obtainable/basic,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "bqF" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_color = "#f4e3b0"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_box/shotgun/bean,
@@ -19658,12 +19615,17 @@
 /obj/item/restraints/handcuffs,
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/vest/oasis,
+/obj/item/clothing/suit/armor/vest/oasis,
+/obj/item/clothing/suit/armor/vest/oasis,
+/obj/item/clothing/suit/armor/vest/oasis,
+/obj/item/clothing/suit/armor/vest/oasis,
+/obj/item/clothing/suit/armor/vest/oasis,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bqK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -20200,7 +20162,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/city/bighorn)
 "bvk" = (
-/obj/machinery/door/poddoor/gate/preopen{
+/obj/machinery/door/poddoor/gate{
 	id = "interiorgate"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -20354,7 +20316,7 @@
 	pixel_y = 32
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "bwN" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
@@ -20384,7 +20346,7 @@
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /obj/item/reagent_containers/pill/patch/healpoultice,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "bwY" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -20519,14 +20481,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/east)
 "byd" = (
-/obj/structure/table/wood,
-/obj/structure/decoration/rag{
-	icon_state = "flag_ncr";
-	name = "NCR banner";
-	pixel_x = 32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/turf/open/floor/plating/f13/inside/gravel,
+/area/f13/wasteland/bighorn)
 "bye" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -20685,7 +20641,7 @@
 "byT" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "byU" = (
 /obj/structure/flora/tree/tall{
 	pixel_x = -14;
@@ -20787,7 +20743,7 @@
 	icon_state = "tall_grass_7"
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "bzp" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -20811,11 +20767,9 @@
 	},
 /area/f13/wasteland/bighorn)
 "bzB" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel/khanfort)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city/bighorn)
 "bzD" = (
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
@@ -20941,7 +20895,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "bBa" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/condiment/rice,
@@ -20956,8 +20910,10 @@
 /area/f13/wasteland/bighorn)
 "bBd" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bBe" = (
@@ -21021,7 +20977,7 @@
 	pixel_x = 5
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "bDx" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -21193,6 +21149,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"bIu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bIB" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21398,7 +21359,7 @@
 	name = "BROC"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "bQv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -21494,7 +21455,7 @@
 "bSl" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "bSt" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -21506,7 +21467,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "bSu" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/workboots/mining,
@@ -21541,7 +21502,7 @@
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "bSU" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland/quarry)
@@ -21557,7 +21518,7 @@
 "bTz" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "bTM" = (
 /obj/structure/chair/folding{
 	dir = 8
@@ -21703,7 +21664,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "bVT" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Crimson Caravan Backroom";
@@ -21815,7 +21776,7 @@
 	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "bXh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/wasteland_vendor/crafting{
@@ -22190,7 +22151,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ccb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -22208,7 +22169,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ccm" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -22221,13 +22182,13 @@
 /obj/structure/stone_tile/block,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ccp" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "cct" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22270,16 +22231,16 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "ccK" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ccM" = (
 /obj/structure/stone_tile/slab,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cdj" = (
 /obj/structure/closet/boxinggloves,
 /obj/effect/decal/cleanable/dirt{
@@ -22324,21 +22285,17 @@
 "cdE" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/west)
-"cdJ" = (
-/obj/structure/stone_tile/block,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
 "cdK" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cdM" = (
 /obj/structure/stone_tile/block{
 	dir = 1
 	},
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cdO" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -22358,13 +22315,13 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "cei" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cek" = (
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "cex" = (
 /obj/structure/nest/scorpion{
 	max_mobs = 1
@@ -22400,7 +22357,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cfd" = (
 /obj/effect/decal/cleanable/vomit/old{
 	pixel_y = 15
@@ -22414,7 +22371,7 @@
 /obj/structure/stone_tile/slab/cracked,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cfD" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -22428,7 +22385,7 @@
 	dir = 4
 	},
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cgT" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/red,
@@ -22523,7 +22480,7 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "cje" = (
 /obj/structure/lamp_post,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22610,7 +22567,7 @@
 "ckz" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "ckH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -22837,7 +22794,7 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "cmS" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
@@ -23571,7 +23528,7 @@
 	},
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "ctV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -23604,7 +23561,7 @@
 	pixel_y = -1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "cvl" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23785,9 +23742,13 @@
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
 "cyk" = (
-/obj/structure/junk/small/bed,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/wasteland/bighorn)
 "cym" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -23922,7 +23883,7 @@
 "cCT" = (
 /obj/item/trash/f13/borscht,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "cCW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -23992,7 +23953,7 @@
 	icon_state = "fence_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "cFy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -24073,6 +24034,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/massfusion)
+"cIb" = (
+/obj/machinery/chem_master,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cJm" = (
 /obj/item/stock_parts/scanning_module/triphasic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24205,7 +24170,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomrightcorner,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "cNQ" = (
 /obj/structure/displaycase,
 /obj/effect/decal/cleanable/dirt,
@@ -24309,10 +24274,15 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
+"cRh" = (
+/obj/structure/table/wood/settler,
+/obj/item/grenade/chem_grenade/teargas,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "cRx" = (
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "cRG" = (
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24479,7 +24449,7 @@
 "dag" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "daq" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 1
@@ -24617,7 +24587,7 @@
 	name = "fortress gate"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dfd" = (
 /obj/structure/table/wood,
 /obj/item/wirecutters/crude,
@@ -24631,7 +24601,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dfl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/showcase/horrific_experiment,
@@ -24727,7 +24697,7 @@
 /area/f13/wasteland/east)
 "diz" = (
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "dja" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -24856,9 +24826,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/building/mall)
 "dnR" = (
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "doa" = (
 /obj/structure/filingcabinet{
 	pixel_x = 10
@@ -24967,7 +24936,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "dsI" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13{
@@ -25072,13 +25041,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland/museum)
-"dvV" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/barricade/bars,
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/building/khanfort)
 "dwo" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25111,7 +25073,7 @@
 "dwM" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "dxg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -25189,7 +25151,7 @@
 "dzu" = (
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "dzB" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
@@ -25286,7 +25248,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "dCX" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -25517,6 +25479,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"dLW" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "dMb" = (
 /turf/open/indestructible/ground/outside/road{
@@ -25825,7 +25791,7 @@
 "dYN" = (
 /obj/structure/chair/stool/retro/tan,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "dZs" = (
 /obj/structure/fence{
 	dir = 4
@@ -25868,7 +25834,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "eaC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -25958,13 +25924,6 @@
 	icon_state = "verticalleftborderleft2bottom"
 	},
 /area/f13/wasteland/massfusion)
-"eeU" = (
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
 "eft" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26025,7 +25984,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "ejj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -26422,10 +26381,8 @@
 	},
 /area/f13/wasteland/heaven)
 "exB" = (
-/obj/item/mine/shrapnel,
-/obj/item/trash/chips,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/turf/open/floor/wood/wood_wide,
+/area/f13/caves)
 "exE" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -26492,6 +26449,10 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ezY" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/f13/inside/gravel,
+/area/f13/wasteland/bighorn)
 "eAb" = (
 /obj/structure/fence{
 	dir = 8
@@ -26569,7 +26530,7 @@
 	name = "XANDER"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "eCK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/wasteland,
@@ -26784,10 +26745,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "eLP" = (
-/obj/structure/nest/ghoul{
-	max_mobs = 4
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eMl" = (
 /obj/structure/table/wood/settler,
@@ -26827,7 +26788,6 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
 	},
-/obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
@@ -27126,9 +27086,15 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
 "eWn" = (
-/obj/machinery/workbench/forge,
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/gun/ballistic/shotgun/police,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "eWr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2left"
@@ -27359,7 +27325,7 @@
 "fej" = (
 /obj/effect/decal/riverbank,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "feH" = (
 /obj/item/trash/f13/cram,
 /obj/effect/decal/cleanable/dirt,
@@ -27400,9 +27366,8 @@
 	},
 /area/f13/wasteland/massfusion)
 "ffb" = (
-/obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
-/turf/closed/wall/f13/tentwall,
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "ffF" = (
 /obj/structure/chair{
@@ -27433,10 +27398,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
 "fgf" = (
-/obj/item/flag/khan,
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "fgp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -27510,7 +27474,7 @@
 "fje" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "fjk" = (
 /obj/item/trash/can,
 /obj/effect/decal/cleanable/dirt,
@@ -27520,13 +27484,9 @@
 /area/f13/village)
 "fjD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred{
-	name = "khan barred door";
-	req_access_txt = "125";
-	req_one_access_txt = null
-	},
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fjQ" = (
 /obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters{
@@ -27541,8 +27501,8 @@
 	},
 /area/f13/wasteland/east)
 "fkj" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "fkm" = (
@@ -27555,7 +27515,7 @@
 /obj/structure/table/wood/junk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "fkx" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -27766,7 +27726,7 @@
 /obj/structure/table/wood/junk,
 /obj/item/brahminbrand,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "ftc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -27788,10 +27748,11 @@
 	pixel_y = -2
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "ftF" = (
-/turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/obj/structure/flora/grass/wasteland,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "ftI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27919,7 +27880,7 @@
 "fya" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "fyR" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -28000,9 +27961,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/west)
-"fAo" = (
-/turf/closed/wall/f13/wood,
-/area/f13/tunnel/khanfort)
 "fAr" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/effect/decal/cleanable/dirt,
@@ -28037,6 +27995,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fAV" = (
@@ -28346,8 +28305,11 @@
 	},
 /area/f13/wasteland/bighorn)
 "fMM" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
 /area/f13/wasteland/quarry)
 "fMX" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -28612,7 +28574,7 @@
 "fVL" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "fVO" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -28787,7 +28749,7 @@
 /area/f13/bar/heaven)
 "gdO" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "gdU" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28866,7 +28828,7 @@
 "ggK" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "ghC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -28890,6 +28852,12 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"giN" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/bighorn)
 "gjj" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29224,7 +29192,7 @@
 "gwT" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "gxa" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -29260,6 +29228,10 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"gzv" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "gzE" = (
 /obj/structure/chair/office/dark,
@@ -29508,6 +29480,11 @@
 /obj/structure/sink/deep_water,
 /turf/open/water,
 /area/f13/caves)
+"gJt" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gJU" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -29762,14 +29739,10 @@
 	},
 /area/f13/building)
 "gQy" = (
-/obj/structure/closet{
-	pixel_x = -9;
-	pixel_y = 13
-	},
-/obj/structure/closet{
-	pixel_x = 7;
-	pixel_y = 13
-	},
+/obj/structure/closet,
+/obj/item/bottlecap_mine,
+/obj/item/bottlecap_mine,
+/obj/item/bottlecap_mine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "gRy" = (
@@ -29790,7 +29763,7 @@
 /area/f13/building/hospital)
 "gSC" = (
 /turf/open/indestructible/ground/outside/savannah/topright,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "gSD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -30117,7 +30090,7 @@
 	},
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "hdd" = (
 /obj/structure/closet,
 /obj/item/clothing/under/suit/burgundy,
@@ -30132,7 +30105,7 @@
 "hdX" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "hee" = (
 /obj/structure/punching_bag,
 /obj/effect/decal/cleanable/dirt,
@@ -30178,13 +30151,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "hfD" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_color = "#f4e3b0"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/obj/structure/table/wood,
+/obj/item/ammo_box/shotgun/rubber,
+/obj/item/ammo_box/shotgun/rubber,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "hgS" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_x = 5;
@@ -30275,7 +30246,7 @@
 	pixel_y = -1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "hle" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall/f13/store{
@@ -30309,6 +30280,10 @@
 /obj/structure/table/booth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
+"hmI" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hmT" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -30426,11 +30401,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
-"hrM" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
-/turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "hsc" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/massfusion)
@@ -30446,7 +30417,7 @@
 	pixel_y = 30
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "hul" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -30454,13 +30425,8 @@
 	},
 /area/f13/wasteland/west)
 "hvo" = (
-/obj/structure/table,
-/obj/item/kitchen/fork,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/machinery/door/unpowered/securedoor/khandoor,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hvO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30600,7 +30566,7 @@
 	pixel_x = 3
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "hzN" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -30662,6 +30628,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hBB" = (
@@ -30815,7 +30782,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "hJU" = (
 /obj/structure/rack,
 /obj/item/storage/bag/trash,
@@ -31075,8 +31042,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/massfusion)
 "hTq" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland/quarry)
 "hTr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -31124,6 +31094,7 @@
 	icon_state = "mattress4";
 	pixel_y = -2
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hVj" = (
@@ -31270,13 +31241,9 @@
 	},
 /area/f13/wasteland/heaven)
 "hZD" = (
-/obj/structure/spider/stickyweb,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"hZF" = (
-/obj/structure/furnace,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "hZK" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -31472,14 +31439,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
 "iht" = (
-/obj/item/storage/trash_stack,
-/obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ihO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "iig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -31704,9 +31672,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/massfusion)
 "iqB" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "iqS" = (
 /obj/structure/bookcase,
@@ -31731,7 +31702,7 @@
 "iro" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "irT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -32014,7 +31985,7 @@
 /area/f13/city/bighorn)
 "iAb" = (
 /turf/open/indestructible/ground/outside/savannah/bottomright,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "iAZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32091,7 +32062,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "iCX" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -32291,7 +32262,7 @@
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "iIT" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -32421,7 +32392,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "iMh" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -32509,7 +32480,7 @@
 	},
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "iPb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -32870,7 +32841,7 @@
 "iZd" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "iZj" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -33101,7 +33072,7 @@
 	yieldmod = 1.3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "jgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33203,7 +33174,7 @@
 	pixel_y = 25
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "jjk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomleft"
@@ -33318,7 +33289,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "jlU" = (
 /obj/item/toy/poolnoodle/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -33353,7 +33324,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/jet,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "jne" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -33375,23 +33346,10 @@
 "jns" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/museum)
-"jnG" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/decoration/rag,
-/obj/item/flag/khan,
-/turf/closed/indestructible/riveted/boss{
-	name = "temple wall"
-	},
-/area/f13/tunnel/khanfort)
 "jnX" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "joX" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/fancy/cigarettes/cigpack_pyramid,
@@ -33758,7 +33716,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "jDi" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_ncr_low,
@@ -34073,7 +34031,7 @@
 "jQY" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "jQZ" = (
 /obj/structure/barricade/security,
 /turf/open/indestructible/ground/inside/mountain,
@@ -34135,7 +34093,7 @@
 /area/f13/wasteland/bighorn)
 "jTK" = (
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "jTM" = (
 /obj/structure/decoration/rag,
 /obj/item/restraints/legcuffs/beartrap,
@@ -34417,7 +34375,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kiu" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -34472,7 +34430,11 @@
 /area/f13/wasteland/massfusion)
 "kkw" = (
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
+"kkH" = (
+/obj/machinery/mineral/wasteland_vendor/khanchem,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kkU" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertopright"
@@ -34596,7 +34558,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "kqc" = (
 /obj/item/clothing/shoes/f13/swimfins,
 /obj/structure/table,
@@ -34735,7 +34697,7 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/stack/sheet/cloth/ten,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "kuL" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/indestructible/ground/outside/dirt{
@@ -34784,15 +34746,13 @@
 	id = "prospectorladder2"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "kxh" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/item/stack/sheet/glass/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
+	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kxy" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -34815,7 +34775,7 @@
 /area/f13/building/mall)
 "kyf" = (
 /turf/closed/wall/f13/wood/house/broken,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "kyq" = (
 /obj/structure/fence/corner/wooden{
 	dir = 8
@@ -34824,7 +34784,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "kyv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2"
@@ -34936,13 +34896,8 @@
 /obj/structure/fence/wooden{
 	dir = 4
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	pixel_x = 4;
-	pixel_y = 2
-	},
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "kDp" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -35052,14 +35007,11 @@
 	name = "strong metal bars";
 	obj_integrity = 800
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
 /obj/structure/decoration/rag,
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "kFN" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/decoration/rag,
@@ -35114,10 +35066,16 @@
 	},
 /area/f13/wasteland/west)
 "kHD" = (
-/obj/structure/bed/mattress,
-/obj/item/clothing/under/f13/raiderrags,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	light_color = "#f4e3b0"
+	},
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "kHQ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/desert,
@@ -35191,14 +35149,6 @@
 	icon_state = "topshadowright"
 	},
 /area/f13/wasteland/east)
-"kJX" = (
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/sunset/brick_small,
-/area/f13/building/khanfort)
 "kKf" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -35265,11 +35215,11 @@
 	},
 /obj/structure/table/optable,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kLG" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "kLZ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -35444,7 +35394,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kUn" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -35534,9 +35484,8 @@
 /area/f13/wasteland/west)
 "kWp" = (
 /obj/structure/chair/wood,
-/obj/effect/landmark/start/f13/mangudai,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "kWy" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road,
@@ -35947,7 +35896,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "llA" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -35956,6 +35905,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"llI" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lmK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -35967,13 +35920,9 @@
 	},
 /area/f13/building/mall)
 "lmU" = (
-/obj/structure/simple_door/metal/barred{
-	name = "khan barred door";
-	req_access_txt = "125";
-	req_one_access_txt = null
-	},
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "lnm" = (
 /obj/machinery/light{
 	dir = 1;
@@ -36022,7 +35971,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "lpC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright"
@@ -36128,7 +36077,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "lsP" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -36138,7 +36087,7 @@
 /obj/structure/table/wood,
 /obj/item/lighter,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "lts" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /turf/open/floor/plasteel/f13{
@@ -36211,10 +36160,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
-"lwG" = (
-/obj/effect/landmark/start/f13/mangudai,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "lwS" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -36503,7 +36448,7 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "lHm" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -36608,7 +36553,7 @@
 	pixel_y = -1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "lKl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36623,9 +36568,6 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland/west)
-"lKr" = (
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/building/khanfort)
 "lKy" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2bottom"
@@ -36870,7 +36812,7 @@
 "lRm" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "lRq" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
@@ -36926,7 +36868,7 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "lTa" = (
 /obj/machinery/light{
 	dir = 1;
@@ -36962,6 +36904,12 @@
 	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
+"lUa" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/bighorn)
 "lUl" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -37124,10 +37072,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building/mall)
-"lZl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "lZu" = (
 /obj/structure/rack,
 /obj/item/instrument/glockenspiel,
@@ -37211,7 +37155,7 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mcu" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -37363,7 +37307,7 @@
 	pixel_x = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "mgP" = (
 /obj/item/storage/trash_stack,
 /obj/structure/flora/grass/wasteland{
@@ -37372,7 +37316,7 @@
 	pixel_y = 17
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "mhf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37492,9 +37436,8 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/landmark/start/f13/mangudai,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mmn" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -37548,14 +37491,14 @@
 "mnH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "mnK" = (
 /obj/structure/destructible/tribal_torch/lit{
 	pixel_x = -8;
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "mnN" = (
 /obj/item/stack/sheet/bone,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38038,8 +37981,8 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mFy" = (
@@ -38048,9 +37991,9 @@
 	},
 /area/f13/building/massfusion)
 "mFC" = (
-/obj/structure/destructible/tribal_torch,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "mFG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/onehanded/machete/training,
@@ -38138,11 +38081,11 @@
 /area/f13/caves)
 "mHZ" = (
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "mIl" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/savannah/rightcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "mIw" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13{
@@ -38164,10 +38107,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "mJb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/obj/machinery/workbench,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "mJh" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermainbottom"
@@ -38177,7 +38119,7 @@
 /obj/effect/decal/riverbank,
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "mJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38873,10 +38815,6 @@
 	icon_state = "verticalinnermaintop"
 	},
 /area/f13/wasteland/massfusion)
-"nmT" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
 "nna" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38955,8 +38893,13 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "noQ" = (
-/obj/structure/spider/stickyweb,
-/turf/closed/wall/r_wall/rust,
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/f13/khan,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
 /area/f13/building)
 "npc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39152,7 +39095,7 @@
 /obj/effect/spawner/lootdrop/toolsbasic,
 /obj/item/flashlight,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "nwB" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -39222,7 +39165,7 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "nyF" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39241,8 +39184,8 @@
 	},
 /area/f13/wasteland/massfusion)
 "nzb" = (
-/obj/structure/simple_door/tent,
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor/khandoor,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nzi" = (
@@ -39277,7 +39220,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "nAd" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -39304,10 +39247,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"nAH" = (
-/obj/effect/landmark/start/f13/kipchak,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "nBj" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibdown1"
@@ -39351,7 +39290,7 @@
 /area/f13/wasteland/hospital)
 "nCD" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "nDc" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light/broken{
@@ -39375,9 +39314,6 @@
 /area/f13/building/mall)
 "nEd" = (
 /obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
 /obj/structure/decoration/rag,
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -39387,7 +39323,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "nEf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -39455,10 +39391,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
-"nGu" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
 "nGM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -39575,6 +39507,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nMa" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "nMm" = (
 /obj/structure/closet,
 /obj/item/toy/beach_ball,
@@ -39584,8 +39520,14 @@
 /area/f13/village)
 "nMT" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/gun/ballistic/automatic/smg/mini_uzi,
+/obj/item/gun/ballistic/automatic/smg/mini_uzi,
+/obj/item/gun/ballistic/automatic/smg/mini_uzi,
+/obj/item/gun/ballistic/automatic/smg/mini_uzi,
+/obj/item/ammo_box/magazine/uzim9mm,
+/obj/item/ammo_box/magazine/uzim9mm,
+/obj/item/ammo_box/magazine/uzim9mm,
+/obj/item/ammo_box/magazine/uzim9mm,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nMZ" = (
@@ -39593,7 +39535,7 @@
 	icon_state = "trash_2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "nNe" = (
 /mob/living/simple_animal/hostile/stalker{
 	faction = list("neutral");
@@ -39632,7 +39574,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "nOL" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/road{
@@ -39654,15 +39596,6 @@
 /obj/item/radio/off,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"nPM" = (
-/obj/structure/stone_tile/slab,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
 "nQc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomright"
@@ -39773,7 +39706,7 @@
 "nSe" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "nSf" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2bottom"
@@ -39845,7 +39778,7 @@
 /area/f13/building/hospital)
 "nUK" = (
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "nUM" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13/wood,
@@ -39856,7 +39789,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "nVx" = (
 /obj/machinery/shower{
 	dir = 4
@@ -39944,7 +39877,7 @@
 	},
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "oaa" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -40032,7 +39965,7 @@
 	color = "#624b30"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "odc" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -40106,7 +40039,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "oeL" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -40337,6 +40270,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"olx" = (
+/obj/machinery/door/unpowered/securedoor/khandoor,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "olN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -40581,7 +40518,7 @@
 "osA" = (
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "osB" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innershade"
@@ -40823,10 +40760,7 @@
 /area/f13/village)
 "oDk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/box/lights/bulbs,
+/obj/machinery/base_dispenser/food,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -41204,7 +41138,7 @@
 	icon_state = "post_wood"
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleftcorner,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "oOh" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -41243,7 +41177,7 @@
 	pixel_y = 18
 	},
 /turf/open/indestructible/ground/outside/savannah/topcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "oPA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -41543,7 +41477,7 @@
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
 	},
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "pav" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -41556,9 +41490,8 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/obj/item/flag/khan,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "paG" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -41756,7 +41689,7 @@
 	pixel_y = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "pja" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -41842,6 +41775,10 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
+/area/f13/wasteland/bighorn)
+"pnP" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/bighorn)
 "poc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42071,7 +42008,7 @@
 	name = "CACTUS"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "pwG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rock/pile/largejungle{
@@ -42079,6 +42016,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
+"pwI" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "pwK" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_north_middle"
@@ -42252,7 +42197,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "pAK" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -42354,7 +42299,7 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "pDM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/one_barrel{
@@ -42378,7 +42323,7 @@
 	pixel_y = 25
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "pEs" = (
 /obj/machinery/light{
 	dir = 8
@@ -42447,9 +42392,6 @@
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/east)
-"pGI" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
 "pGQ" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/outside/dirt,
@@ -42543,7 +42485,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "pLY" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -42597,7 +42539,7 @@
 /area/f13/building/hospital)
 "pOc" = (
 /turf/open/indestructible/ground/outside/savannah/topleft,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "pOt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
@@ -42628,13 +42570,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/followers)
-"pPT" = (
-/obj/structure/barricade/bars,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/building/khanfort)
 "pPV" = (
 /obj/structure/sign/poster/prewar/poster61{
 	pixel_x = 30
@@ -42643,12 +42578,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/mangudai,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "pQn" = (
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "pQo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -42817,6 +42751,7 @@
 /area/f13/wasteland/hospital)
 "pXC" = (
 /obj/structure/table,
+/obj/item/storage/keys_set,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pXT" = (
@@ -42987,7 +42922,7 @@
 	pixel_x = 17
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "qfe" = (
 /obj/structure/table_frame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -43002,7 +42937,7 @@
 "qfH" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "qfX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop1"
@@ -43110,7 +43045,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "qiP" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/desert,
@@ -43121,7 +43056,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "qjc" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -43165,13 +43100,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/barred{
-	name = "khan barred door";
-	req_access_txt = "125";
-	req_one_access_txt = null
-	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "qlb" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt{
@@ -43205,7 +43135,7 @@
 "qlH" = (
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "qlO" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -43245,7 +43175,7 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "qmJ" = (
 /obj/item/mop,
 /obj/structure/mopbucket,
@@ -43256,6 +43186,11 @@
 	dir = 4
 	},
 /area/f13/building/mall)
+"qmV" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qmZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
@@ -43289,8 +43224,8 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
 "qof" = (
-/turf/open/floor/plating/f13/inside/gravel,
-/area/f13/building/khanfort)
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland/bighorn)
 "qop" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -43483,12 +43418,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qth" = (
-/mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
 	icon_state = "dirtcorner"
 	},
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "qtn" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -43820,7 +43754,7 @@
 "qGZ" = (
 /obj/structure/barricade/tent,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "qHb" = (
 /obj/item/reagent_containers/syringe,
 /obj/effect/decal/cleanable/dirt{
@@ -43858,12 +43792,10 @@
 	},
 /area/f13/wasteland/east)
 "qIN" = (
-/obj/machinery/light/small,
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 5
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "qJP" = (
 /obj/effect/decal/cleanable/dirt{
@@ -43927,7 +43859,7 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "qLF" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn,
 /turf/open/indestructible/ground/outside/desert{
@@ -44112,7 +44044,7 @@
 "qRL" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/savannah/topleftcorner,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "qSh" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -44155,16 +44087,15 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "qUH" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "qUN" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qVl" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -44248,6 +44179,10 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/west)
+"qYv" = (
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/quarry)
 "qYN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44404,7 +44339,7 @@
 	pixel_y = 11
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "rdV" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -44491,6 +44426,12 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/east)
+"rgK" = (
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rhb" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -44596,7 +44537,7 @@
 "rmx" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "rmy" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -44715,7 +44656,7 @@
 "rpN" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "rpQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44828,9 +44769,8 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/landmark/start/f13/mangudai,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "rtA" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -45039,7 +44979,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "rCA" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -45437,7 +45377,12 @@
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
+"rRq" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland/quarry)
 "rRH" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -45534,6 +45479,14 @@
 /obj/item/brahminsaddle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"rUp" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rUE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -45985,7 +45938,7 @@
 /area/f13/wasteland/east)
 "sjH" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "sjO" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -45997,7 +45950,7 @@
 	pixel_y = 30
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "skt" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/wood_mosaic,
@@ -46024,7 +45977,7 @@
 /obj/structure/table/wood,
 /obj/item/defibrillator/primitive,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sld" = (
 /obj/item/mine/stun,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -46041,10 +45994,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
-"sln" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
 "sls" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -46061,7 +46010,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "slW" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
@@ -46268,7 +46217,7 @@
 /area/f13/wasteland/west)
 "ssK" = (
 /turf/open/indestructible/ground/outside/savannah/toprightcorner,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "stH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -46291,11 +46240,17 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"svL" = (
+/obj/machinery/light/small,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "svU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
+/obj/item/storage/hypospraykit/brute,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "swq" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -46323,7 +46278,7 @@
 	pixel_x = 18
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "swX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46502,7 +46457,7 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "sDH" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -46653,7 +46608,7 @@
 	pixel_y = -2
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sMg" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/backpack/satchel/leather/withwallet,
@@ -46691,7 +46646,7 @@
 "sNx" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "sND" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -46714,6 +46669,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/heaven)
+"sOc" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland/bighorn)
 "sOH" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -46726,9 +46685,8 @@
 	},
 /area/f13/wasteland/bighorn)
 "sOV" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/spider/stickyweb,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sPk" = (
@@ -46830,13 +46788,7 @@
 	color = "#624b30"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
-"sTk" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/sunset/brick_small,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sTP" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -46847,7 +46799,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "sTY" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13/wasteland;
@@ -47119,11 +47071,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/building)
-"tcs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/kipchak,
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "tcy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -47207,7 +47154,7 @@
 	icon_state = "gibbear1"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "tgJ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -47347,7 +47294,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "toc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -47393,7 +47340,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tpH" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -47544,7 +47491,7 @@
 "ttz" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "ttU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -47600,7 +47547,7 @@
 /turf/open/floor/plasteel/stairs{
 	color = "#4b3a26"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tuX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottomright"
@@ -47713,7 +47660,7 @@
 /turf/open/floor/plasteel/stairs{
 	color = "#4b3a26"
 	},
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tyj" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47891,10 +47838,20 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland/museum)
+"tDp" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
+	},
+/area/f13/building)
 "tDv" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "tDx" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
@@ -47963,7 +47920,7 @@
 "tGe" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "tGq" = (
 /obj/structure/showcase/machinery/tv{
 	name = "Pre-war television"
@@ -47998,7 +47955,7 @@
 	pixel_y = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "tGU" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -48161,16 +48118,8 @@
 	},
 /area/f13/building/museum)
 "tMs" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "tMD" = (
 /obj/effect/turf_decal/huge{
 	dir = 4
@@ -48338,7 +48287,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "tSC" = (
 /obj/structure/railing/handrail/blue{
 	pixel_y = -4
@@ -48582,9 +48531,8 @@
 	},
 /area/f13/wasteland/bighorn)
 "uaU" = (
-/mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "ubr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/toolsbasic,
@@ -48661,7 +48609,7 @@
 "ucE" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "ucH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -49062,7 +49010,7 @@
 	},
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "usg" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -49200,7 +49148,7 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uwE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -49351,7 +49299,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uBi" = (
 /obj/structure/fence{
 	dir = 8
@@ -49462,6 +49410,10 @@
 "uFx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
+/area/f13/building)
+"uFF" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uGh" = (
 /obj/structure/table/wood,
@@ -49684,7 +49636,7 @@
 	icon_state = "tall_grass_7"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "uMj" = (
 /obj/item/seeds/xander,
 /turf/open/indestructible/ground/outside/dirt,
@@ -49721,7 +49673,7 @@
 	pixel_y = 33
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "uOw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -50150,12 +50102,28 @@
 "vam" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "van" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/item/seeds/agave,
+/obj/item/seeds/agave,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/mutfruit,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/feracactus,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cotton,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "vao" = (
 /obj/structure/dresser,
@@ -50267,9 +50235,8 @@
 	},
 /area/f13/building)
 "vhp" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/tentwall,
+/obj/item/shovel,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "vhP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -50429,7 +50396,7 @@
 /obj/structure/campfire/barrel,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "vmx" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -50605,9 +50572,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/mall)
-"vtM" = (
-/turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
 "vtR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -50770,7 +50734,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "vzn" = (
 /obj/item/trash/candy{
 	pixel_x = 7;
@@ -50807,14 +50771,8 @@
 	},
 /area/f13/village)
 "vzG" = (
-/obj/machinery/light/small/broken{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vzJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50837,7 +50795,7 @@
 "vAu" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "vAW" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -50900,7 +50858,7 @@
 "vDr" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "vDF" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/table,
@@ -51089,7 +51047,7 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "vMR" = (
 /obj/structure/rack,
 /obj/item/melee/smith/throwingknife,
@@ -51191,6 +51149,13 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/massfusion)
+"vQi" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/obj/item/flag/khan,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/quarry)
 "vQv" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -51204,7 +51169,7 @@
 "vQC" = (
 /obj/machinery/smartfridge/bottlerack/alchemy_rack,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "vQE" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/ten,
@@ -51260,6 +51225,10 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"vSd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "vSj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -51282,7 +51251,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "vSM" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
@@ -51518,6 +51487,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"wbB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wcN" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/f13/store,
@@ -51604,11 +51581,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/east)
 "wfO" = (
-/obj/structure/bed/mattress{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/turf/open/floor/f13/wood,
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "wfZ" = (
 /obj/structure/junk/machinery,
@@ -51681,7 +51655,7 @@
 	pixel_x = -17
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "whT" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -51771,7 +51745,7 @@
 "wjZ" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "wkb" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -51838,7 +51812,7 @@
 	pixel_x = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/quarry)
+/area/f13/caves)
 "wmv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -51971,6 +51945,7 @@
 "wpm" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wpp" = (
@@ -52690,10 +52665,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
-"wQa" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "wQo" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/button/door{
@@ -52735,9 +52706,14 @@
 "wRT" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/wood/wood_wide,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "wSI" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wSN" = (
@@ -52811,7 +52787,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13/wood,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "wUQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -52892,6 +52868,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
+"wXH" = (
+/obj/structure/barricade/bars,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wXL" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52905,7 +52888,7 @@
 	},
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "wXY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -53380,13 +53363,8 @@
 /area/f13/building/mall)
 "xqH" = (
 /obj/structure/stone_tile/block,
-/obj/structure/simple_door/metal/barred{
-	name = "khan barred door";
-	req_access_txt = "125";
-	req_one_access_txt = null
-	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "xrK" = (
 /obj/structure/window{
 	dir = 8
@@ -53573,7 +53551,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "xyC" = (
 /obj/structure/fence{
 	dir = 4
@@ -53703,9 +53681,9 @@
 	},
 /area/f13/building/museum)
 "xCb" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xCC" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -53759,7 +53737,7 @@
 "xDI" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_worn,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "xDJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -53808,7 +53786,7 @@
 "xEP" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "xEU" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland/quarry)
@@ -53859,12 +53837,9 @@
 	},
 /area/f13/wasteland/museum)
 "xFX" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -4;
-	pixel_y = 5
-	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/quarry)
+/area/f13/building)
 "xGe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -53915,9 +53890,8 @@
 	},
 /area/f13/wasteland/firestation)
 "xIY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/khanfort)
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "xJf" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard,
 /turf/closed/wall/f13/tunnel,
@@ -54022,7 +53996,7 @@
 	pixel_y = 24
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel/khanfort)
+/area/f13/city/bighorn)
 "xLG" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -54093,7 +54067,7 @@
 "xOp" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/caves)
 "xOz" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/road{
@@ -54124,7 +54098,7 @@
 	icon_state = "floor2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/khanfort)
+/area/f13/wasteland/bighorn)
 "xPu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -54718,7 +54692,7 @@
 	pixel_y = -2
 	},
 /turf/open/transparent/openspace,
-/area/f13/building/khanfort)
+/area/f13/city/bighorn)
 "yjl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55520,19 +55494,19 @@ aaa
 aae
 aaa
 aaa
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
 aae
 nUK
 nUK
@@ -55777,19 +55751,19 @@ aae
 aae
 aaa
 aaa
-bqp
+tMs
 mHZ
 txZ
 txZ
 mHZ
 mHZ
 sTW
-bqp
+tMs
 dfi
 qmE
 rCa
 dfi
-bqp
+tMs
 nUK
 nUK
 nUK
@@ -56034,19 +56008,19 @@ aaa
 aae
 aaa
 aae
-bqp
+tMs
 ocX
 slQ
 vam
 mHZ
 iro
 mHZ
-pPT
+tMs
 kLA
-vtM
-vtM
+xIY
+xIY
 hqJ
-bqp
+tMs
 nUK
 nUK
 lKi
@@ -56057,13 +56031,13 @@ rdp
 nUK
 nUK
 nUK
-ftF
+wsu
 qGZ
 qGZ
 qGZ
 qGZ
 fje
-diz
+aJN
 fej
 nUK
 nUK
@@ -56291,26 +56265,26 @@ aaa
 aae
 aaa
 aaa
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
 mHZ
 mHZ
-hrM
-vtM
-vtM
-vtM
-vtM
-bqp
+lmU
+xIY
+xIY
+xIY
+xIY
+tMs
 nUK
 aHY
 kyf
 aKg
 kkw
 kkw
-ftF
+wsu
 kCB
 lHc
 aHY
@@ -56318,7 +56292,7 @@ kyf
 aXA
 aXG
 aXV
-ftF
+wsu
 kCB
 mIl
 bXc
@@ -56548,19 +56522,19 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 aaW
 uvY
 iro
-bqp
+tMs
 mHZ
 iro
-pPT
-lZl
-vtM
-vtM
-lZl
-bqp
+tMs
+vSd
+xIY
+xIY
+vSd
+tMs
 nUK
 aqk
 aSj
@@ -56569,8 +56543,8 @@ aKg
 kkw
 aWC
 ccJ
-nmT
-aqk
+qwd
+cyk
 tGe
 aKg
 aKg
@@ -56805,19 +56779,19 @@ aaa
 aae
 aaa
 aae
-bqp
+tMs
 uOl
 fto
 iro
-bqp
+tMs
 mHZ
 mHZ
-pPT
+tMs
 skW
-lZl
-vtM
-vtM
-bqp
+vSd
+xIY
+xIY
+tMs
 nUK
 qGZ
 aUR
@@ -57062,19 +57036,19 @@ aaa
 aae
 aaa
 aae
-bqp
+tMs
 aaW
 yja
 iro
-hrM
+lmU
 mHZ
 iro
-bqp
+tMs
 bwW
-vtM
+xIY
 tnZ
 kUg
-bqp
+tMs
 nUK
 qGZ
 aUT
@@ -57319,22 +57293,22 @@ aaa
 aae
 aaa
 aae
-bqp
+tMs
 aaW
 sLA
 wUP
-bqp
+tMs
 mHZ
 mHZ
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
 nUK
 qGZ
-ftF
+wsu
 aKg
 aKg
 kkw
@@ -57342,7 +57316,7 @@ vMO
 ccp
 tSx
 qGZ
-ftF
+wsu
 aXB
 kkw
 kkw
@@ -57576,34 +57550,34 @@ aaa
 aae
 aae
 aae
-bqp
+tMs
 aaW
 qiY
 piC
-bqp
+tMs
 mHZ
 bqb
-hrM
+lmU
 mHZ
 kir
 sTW
 svU
-bqp
+tMs
 nUK
 nUK
 nAb
-ftF
+wsu
 aWh
-ftF
-ftF
-aYe
+wsu
+wsu
+nSe
 diz
-cyk
+nub
 nAb
-ftF
+wsu
 aXU
-ftF
-ftF
+wsu
+wsu
 paB
 bzo
 oPm
@@ -57832,33 +57806,33 @@ aae
 aaa
 aae
 aae
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
 lmU
-bqp
-bqp
+tMs
+tMs
 oeK
 mHZ
 iro
 jQY
-sTk
+tMs
 nUK
 nUK
 nSe
 wXN
-lKr
+qof
 nwv
 xPf
 iIO
-ihO
+sUG
 diz
 uMa
 ceh
-lKr
+qof
 vAu
 nVn
 iOU
@@ -58090,37 +58064,37 @@ aaa
 aaa
 aae
 tMs
-vtM
+xIY
 mlW
 jlL
 mlW
-lZl
-nAH
-lZl
-bqp
+vSd
+xIY
+vSd
+tMs
 lSY
 qLy
 mHZ
 mcq
-sTk
+tMs
 nUK
 nUK
-ihO
+sUG
 hkZ
-lKr
+qof
 diz
 qfH
 tSx
 tGQ
 tDv
-nmT
+qwd
 diz
-lKr
+qof
 tSx
 nVn
 jnX
-diz
-diz
+aJN
+aJN
 swL
 nUK
 nUK
@@ -58346,25 +58320,25 @@ aaa
 aaa
 aaa
 aaa
-kJX
+tMs
 kWp
 xDI
-vtM
+xIY
 nOI
-vtM
-vtM
-lZl
-bqp
-bqp
+xIY
+xIY
+vSd
+tMs
+tMs
 tpm
 tpm
-bqp
+tMs
 tMs
 nUK
 nUK
 qUE
 uMa
-lKr
+qof
 diz
 diz
 diz
@@ -58372,12 +58346,12 @@ diz
 qUE
 diz
 qUE
-lKr
+qof
 diz
 cNM
 ssK
 ihO
-diz
+aJN
 mnK
 pEm
 nUK
@@ -58604,24 +58578,24 @@ aaa
 aae
 aaa
 tMs
-vtM
-vtM
-nAH
-vtM
-nAH
-vtM
-nAH
-kJX
+xIY
+xIY
+xIY
+xIY
+xIY
+xIY
+xIY
+tMs
 bgh
 bmT
 bnj
-bqp
+tMs
 bnv
 bnD
 bnH
 diz
 vmp
-qof
+byd
 tDv
 diz
 uMa
@@ -58629,7 +58603,7 @@ diz
 diz
 diz
 diz
-qof
+byd
 diz
 oOd
 qRL
@@ -58743,7 +58717,7 @@ jbR
 aAf
 aAf
 aAf
-aWD
+hhC
 cWF
 vQI
 aae
@@ -58861,32 +58835,32 @@ aaa
 aae
 aaa
 tMs
-lwG
+xIY
 jmJ
 xDI
 nOI
-vtM
-vtM
-vtM
+xIY
+xIY
+xIY
 bqk
 bgQ
-aKQ
+sjH
 bnq
 deE
 mHZ
-mHZ
-mHZ
+bhG
+bhG
 qof
 qof
-lKr
-lKr
-lKr
 qof
-lKr
-lKr
-lKr
+sOc
 qof
-lKr
+qof
+qof
+qof
+qof
+qof
+qof
 diz
 nVn
 xOp
@@ -58999,9 +58973,9 @@ hhC
 hhC
 hhC
 hhC
-exB
 hhC
-wQa
+hhC
+oUj
 aaQ
 aae
 aae
@@ -59117,36 +59091,36 @@ aaa
 aaa
 aae
 aae
-kJX
+tMs
 pLU
 xDI
 apu
 xDI
-vtM
-vtM
-vtM
-aKQ
-aKQ
-aKQ
-aKQ
-aKQ
+xIY
+xIY
+xIY
+sjH
+sjH
+sjH
+sjH
+sjH
 mHZ
-mHZ
-mHZ
-lKr
-lKr
-lKr
-lKr
+bhG
+bhG
+qof
+qof
+sOc
+sOc
 qof
 qof
 qof
-lKr
-lKr
+qof
+qof
 qof
 qof
 diz
 cFl
-diz
+aJN
 nCD
 bSl
 jTK
@@ -59375,35 +59349,35 @@ aaa
 aae
 aaa
 tMs
-lwG
+xIY
 lte
 xDI
 nOI
-vtM
-vtM
-lZl
-aKQ
+xIY
+xIY
+vSd
+sjH
 bkz
-aKQ
+sjH
 bnr
-aKQ
+sjH
 mHZ
-mHZ
-mHZ
-qof
-qof
-qof
-qof
-lKr
-lKr
-lKr
-qof
-qof
-lKr
-qof
+bhG
+bhG
+byd
+byd
+byd
+byd
+byd
+byd
+byd
+byd
+byd
+byd
+byd
 cCT
 nVn
-diz
+aJN
 eao
 pQn
 jTK
@@ -59631,19 +59605,19 @@ aae
 aaa
 aae
 aaa
-kJX
-vtM
-vtM
-nAH
-vtM
-nAH
-lZl
-tcs
-kJX
+tMs
+xIY
+xIY
+xIY
+xIY
+xIY
+vSd
+xIY
+tMs
 blA
 bni
 bnu
-bqp
+tMs
 bnv
 bnD
 bnH
@@ -59652,12 +59626,12 @@ diz
 qUE
 qfH
 diz
-ihO
+sUG
 vDr
 fsG
-lKr
-lKr
-lKr
+qof
+qof
+qof
 diz
 nVn
 iZd
@@ -59747,7 +59721,7 @@ pak
 wEd
 xOD
 aaQ
-byd
+cmY
 cmY
 aaQ
 hhC
@@ -59891,16 +59865,16 @@ aaa
 tMs
 kWp
 nOI
-vtM
+xIY
 xDI
-vtM
-lZl
-lZl
-bqp
-bqp
-bqp
-bqp
-bqp
+xIY
+vSd
+vSd
+tMs
+tMs
+tMs
+tMs
+tMs
 tMs
 nUK
 nUK
@@ -59912,9 +59886,9 @@ uMa
 diz
 dwM
 dYN
-lKr
-lKr
 qof
+qof
+byd
 mgP
 kyq
 cRx
@@ -60150,18 +60124,18 @@ apP
 pPV
 tnZ
 rsI
-lZl
-nAH
-vtM
-bqp
+vSd
+xIY
+xIY
+tMs
 bqu
 bqy
 bqC
 bqG
-sTk
+tMs
 nUK
 nUK
-ihO
+sUG
 tSx
 diz
 diz
@@ -60169,9 +60143,9 @@ qfH
 diz
 diz
 qUE
+byd
+byd
 qof
-qof
-lKr
 qUE
 nVn
 dag
@@ -60402,39 +60376,39 @@ aae
 aaa
 aae
 aaa
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
 fjD
-bqp
-bqp
-bqv
-vtM
-vtM
-vtM
-sTk
+tMs
+tMs
+xIY
+xIY
+xIY
+xIY
+tMs
 nUK
 nUK
 iCR
 cuU
 xEP
 bCT
-nmT
+qwd
 diz
 diz
 sDn
-lKr
-lKr
 qof
+qof
+byd
 diz
 nVn
-diz
-diz
-diz
-diz
+aJN
+aJN
+aJN
+aJN
 mnK
 mJD
 aaa
@@ -60660,40 +60634,40 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 bnP
 ahS
 bqc
-bqp
+tMs
 mHZ
 sTW
-bqp
-hZF
-vtM
-vtM
+tMs
+xIY
+axW
+ayr
 eWn
-bqp
+tMs
 nUK
 nUK
-ftF
-ftF
+wsu
+wsu
 boM
-ftF
-ftF
+wsu
+wsu
 fgf
 diz
 diz
+byd
 qof
-lKr
-lKr
+qof
 diz
 cFl
-diz
+aJN
 aTC
-diz
-diz
-diz
-diz
+aJN
+aJN
+aJN
+aJN
 aaa
 "}
 (24,1,1) = {"
@@ -60917,40 +60891,40 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 bnS
-vtM
+xIY
 bqd
-bqp
+tMs
 iro
 mHZ
 xCb
-vtM
-vtM
-vtM
-vtM
-bqp
+xIY
+axX
+ays
+aUo
+tMs
 nUK
 aHY
 kyf
 aVC
 aWt
 aWv
-ftF
+wsu
 kCB
 diz
 diz
+byd
+byd
 qof
-qof
-lKr
-ihO
+sUG
 nVn
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 aaa
 "}
 (25,1,1) = {"
@@ -61174,19 +61148,19 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 bnU
-vtM
-vtM
+xIY
+xIY
 xCb
 iro
 iro
-pPT
-vtM
-lZl
-bqE
+tMs
+xIY
+xIY
+xIY
 kxh
-bqp
+tMs
 nUK
 aqk
 aVy
@@ -61197,17 +61171,17 @@ ttz
 ccJ
 diz
 diz
-lKr
-lKr
 qof
+qof
+byd
 diz
 nVn
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 aaa
 "}
 (26,1,1) = {"
@@ -61431,19 +61405,19 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 bnW
-vtM
+xIY
 bqe
-bqp
+tMs
 mHZ
 mHZ
-pPT
-vtM
-vtM
-vtM
-vtM
-bqp
+tMs
+xIY
+ayq
+aDs
+aVl
+tMs
 nUK
 qGZ
 wjZ
@@ -61452,19 +61426,19 @@ aVT
 aKg
 kkw
 aXm
-lKr
-lKr
-lKr
 qof
-lKr
+qof
+qof
+ezY
+qof
 tDv
 nVn
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 aaa
 "}
 (27,1,1) = {"
@@ -61688,19 +61662,19 @@ aaa
 aae
 aaa
 aaa
-bqp
+tMs
 bnY
 uAN
 bqf
-bqp
+tMs
 iro
 mHZ
-bqp
-bqx
+tMs
+xIY
 bqA
 bqF
 bqH
-bqp
+tMs
 nUK
 qGZ
 aVB
@@ -61711,15 +61685,15 @@ aXg
 hdX
 bSt
 qUE
-lKr
-qof
-qof
+sOc
+ezY
+byd
 diz
 nVn
 jgS
-diz
+aJN
 jgS
-qfH
+ftF
 jgS
 eCn
 aaa
@@ -61945,22 +61919,22 @@ aae
 aae
 aaa
 aaa
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
 mHZ
 mHZ
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+xIY
+xIY
+xIY
+xIY
+tMs
 nUK
 qGZ
-ftF
+wsu
 aVF
 kkw
 kkw
@@ -61968,15 +61942,15 @@ vMO
 ccp
 nMZ
 diz
+byd
 qof
-lKr
-qof
+byd
 diz
 nVn
 jgS
-diz
+aJN
 jgS
-diz
+aJN
 jgS
 bQa
 aaa
@@ -62202,19 +62176,19 @@ ygj
 ygj
 ygj
 ygj
-bqp
+tMs
 sSI
 lkW
 fya
 mHZ
 mHZ
 mHZ
-nGu
+tMs
 xIY
-aKQ
 xIY
-sln
-bqp
+xIY
+xIY
+tMs
 aaa
 aaa
 nAb
@@ -62226,15 +62200,15 @@ iLR
 diz
 xyt
 bAI
-qof
+byd
 pAJ
 xyt
 nVn
-diz
-diz
+aJN
+aJN
 aTC
-diz
-diz
+aJN
+aJN
 pwp
 aaa
 "}
@@ -62459,19 +62433,19 @@ ygj
 fMs
 kwJ
 ygj
-bqp
+tMs
 mHZ
 tuu
 tuu
 mHZ
 mHZ
 dsz
-dvV
+tMs
 hfD
 mJb
 kHD
-xIY
-bqp
+aWD
+tMs
 aaa
 aae
 aae
@@ -62488,9 +62462,9 @@ bVO
 nEd
 asS
 lpt
-kkw
-kkw
-kkw
+exB
+exB
+exB
 aYv
 aYw
 aaa
@@ -62716,19 +62690,19 @@ ygj
 hGN
 xdz
 ygj
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
-bqp
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
+tMs
 aae
 aae
 aae
@@ -62738,18 +62712,18 @@ aae
 aae
 aae
 aae
-bkl
+nEd
 rRi
 qlH
 bVO
-bkl
+nEd
 asS
 bgl
 aYp
 aYq
 aYt
-ftF
-ftF
+ahz
+ahz
 aaa
 "}
 (32,1,1) = {"
@@ -62996,16 +62970,16 @@ aae
 aae
 aae
 bgz
-cdJ
+xqH
 ccM
 bVO
 bwK
 asS
 bgl
-ftF
-ftF
-bhG
-ftF
+ahz
+ahz
+afn
+ahz
 aae
 aaa
 "}
@@ -63510,9 +63484,9 @@ aae
 aae
 aae
 bgz
-cdJ
+xqH
 osA
-eeU
+qkH
 bwK
 asS
 asS
@@ -63767,7 +63741,7 @@ aae
 aae
 aae
 apg
-cdJ
+xqH
 osA
 apH
 apg
@@ -64021,10 +63995,10 @@ aae
 aae
 aae
 gdO
-fAo
+bji
 gdO
 bgz
-cdJ
+xqH
 jDf
 qiH
 bwK
@@ -64281,7 +64255,7 @@ bSP
 lsO
 kwZ
 apg
-cdJ
+xqH
 cfz
 bVO
 apg
@@ -64791,9 +64765,9 @@ ygj
 ygj
 aae
 aae
-fAo
+bji
 ccK
-fAo
+bji
 pat
 xLC
 osA
@@ -65309,7 +65283,7 @@ cfT
 sjH
 mnH
 lRm
-cdJ
+xqH
 osA
 bVO
 gdO
@@ -65562,7 +65536,7 @@ swr
 ygj
 aae
 aae
-bzB
+bry
 fkm
 cdK
 cci
@@ -65819,11 +65793,11 @@ swr
 ygj
 aae
 aae
-fAo
-fAo
+bji
+bji
 sNx
 cbZ
-cdJ
+xqH
 osA
 bVO
 bwK
@@ -66076,9 +66050,9 @@ swr
 ygj
 aae
 aae
-aae
-fAo
-fAo
+gdO
+bji
+bji
 pat
 apz
 osA
@@ -66337,9 +66311,9 @@ aae
 aae
 aae
 bgz
-cdJ
+xqH
 qlH
-eeU
+qkH
 bwK
 aae
 aae
@@ -66594,7 +66568,7 @@ aae
 aae
 aae
 apg
-cdJ
+xqH
 osA
 bVO
 apg
@@ -67108,7 +67082,7 @@ aae
 aae
 aae
 apg
-cdJ
+xqH
 osA
 bVO
 apg
@@ -67365,7 +67339,7 @@ aae
 aae
 aae
 bgz
-cdJ
+xqH
 osA
 bVO
 bwK
@@ -67879,7 +67853,7 @@ aae
 aae
 aae
 bgz
-cdJ
+xqH
 byT
 bVO
 bwK
@@ -68080,9 +68054,9 @@ aae
 aae
 wEd
 dQd
-xtI
-xtI
-ePI
+dQd
+dQd
+dQd
 tpP
 frQ
 mHp
@@ -68135,11 +68109,11 @@ aae
 aae
 aae
 aae
-jnG
-cdJ
+kFK
+xqH
 osA
-eeU
-jnG
+qkH
+kFK
 aae
 aae
 aae
@@ -68338,11 +68312,11 @@ wEd
 wEd
 dQd
 heG
-ayq
-ayq
+dQd
+dQd
 tpP
-ayr
-aUo
+frQ
+mHp
 abS
 nWT
 cVt
@@ -68388,13 +68362,13 @@ bji
 bji
 bZR
 bZP
-abV
-abV
-abV
-abV
+bzB
+bzB
+bzB
+bzB
 kFK
 xqH
-nPM
+osA
 qkH
 kFK
 aae
@@ -68594,12 +68568,12 @@ wEd
 wEd
 wEd
 dQd
-xtI
-aos
-ayq
+dQd
+dQd
+dQd
 tpP
-ays
-aUo
+frQ
+mHp
 abS
 ayn
 ara
@@ -68851,12 +68825,12 @@ sEB
 wEd
 wEd
 dQd
-xtI
-ayq
-ayq
+dQd
+dQd
+dQd
 tpP
-ayr
-aUo
+frQ
+mHp
 nWT
 aeC
 tqb
@@ -69108,12 +69082,12 @@ wEd
 wEd
 wEd
 dQd
-xtI
-ayq
-ayq
+dQd
+dQd
+dQd
 tpP
-ayr
-aUo
+frQ
+mHp
 rWE
 ayn
 fdU
@@ -69125,8 +69099,8 @@ fdU
 bMM
 bmu
 bMM
-bMM
-dtk
+lUa
+pnP
 dtk
 dtk
 bTO
@@ -69366,11 +69340,11 @@ flC
 wEd
 aXF
 dQd
-ayq
-ayq
+dQd
+dQd
 tpP
-ayr
-aUo
+frQ
+mHp
 bgu
 aer
 nhQ
@@ -69382,7 +69356,7 @@ fdU
 fdU
 bmu
 bMM
-fdU
+giN
 jZx
 bMM
 dtk
@@ -69623,11 +69597,11 @@ wEd
 wEd
 dQd
 dQd
-axW
-ayq
+dQd
+dQd
 tpP
-ayr
-aUo
+frQ
+mHp
 abS
 igF
 gIE
@@ -69880,11 +69854,11 @@ wEd
 wEd
 dQd
 dQd
-axX
-ayq
+dQd
+dQd
 tpP
-aDs
-aVl
+frQ
+mHp
 abS
 igF
 pPr
@@ -70141,7 +70115,7 @@ dQd
 dQd
 tpP
 eoi
-ojS
+mHp
 abS
 igF
 pPr
@@ -70666,7 +70640,7 @@ aTw
 bjq
 bjq
 bjq
-bmP
+aos
 bjq
 bjq
 ydE
@@ -70920,7 +70894,7 @@ jYk
 ygj
 aTw
 akX
-akX
+aos
 akX
 bxu
 akX
@@ -71176,7 +71150,7 @@ pPr
 jYk
 ygj
 aTw
-bmP
+akX
 aTw
 brF
 akX
@@ -74835,17 +74809,17 @@ aaa
 aaa
 aaa
 aaa
-aae
-aaa
-aae
-aae
-aae
-aae
-aae
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aae
 aae
@@ -75099,21 +75073,21 @@ aae
 aaa
 aaa
 aaa
-aae
-aaa
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aae
+aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aab
@@ -75619,7 +75593,7 @@ aaa
 aae
 aae
 aae
-aak
+aaa
 aak
 aae
 aak
@@ -75876,7 +75850,7 @@ aak
 aaa
 aaa
 aaa
-aak
+aaa
 aaa
 aae
 aaa
@@ -76390,7 +76364,7 @@ aae
 aak
 aak
 aak
-aak
+aaa
 aak
 aae
 aae
@@ -76647,7 +76621,7 @@ aak
 aak
 aak
 aaa
-aak
+aaa
 aaa
 aae
 aae
@@ -76904,7 +76878,7 @@ aak
 aak
 aak
 aak
-aae
+aaa
 aaa
 aaa
 aae
@@ -77161,7 +77135,7 @@ aak
 aak
 aak
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -77418,7 +77392,7 @@ aak
 aak
 aak
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -77675,7 +77649,7 @@ aak
 aak
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -77932,7 +77906,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -78189,7 +78163,7 @@ aak
 aae
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -78446,7 +78420,7 @@ aae
 aak
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -78703,7 +78677,7 @@ aae
 aak
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -78960,7 +78934,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -79217,7 +79191,7 @@ aak
 aak
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -79474,7 +79448,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -79731,7 +79705,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -79988,7 +79962,7 @@ aae
 aak
 aak
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -80245,7 +80219,7 @@ aae
 aae
 aae
 aak
-aak
+aaa
 aae
 aae
 aae
@@ -80502,7 +80476,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -80759,7 +80733,7 @@ aak
 aak
 aae
 aae
-aak
+aaa
 aae
 aae
 aae
@@ -81016,7 +80990,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -81273,7 +81247,7 @@ aak
 aak
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -81530,7 +81504,7 @@ aak
 aak
 aak
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -81787,7 +81761,7 @@ aak
 aae
 aak
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -82044,7 +82018,7 @@ aak
 aae
 aak
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -82301,7 +82275,7 @@ aae
 aae
 aak
 aak
-aae
+aaa
 aae
 aak
 aae
@@ -82558,14 +82532,14 @@ aak
 aak
 aae
 aae
-aak
-aae
-aae
-aak
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 eWB
 sCC
@@ -82822,7 +82796,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 aae
 eWB
 agN
@@ -83079,7 +83053,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 jgz
 eWB
@@ -83336,7 +83310,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 jgz
@@ -83593,7 +83567,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 uRS
@@ -83850,7 +83824,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -84107,7 +84081,7 @@ aae
 aak
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -84364,7 +84338,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -84621,7 +84595,7 @@ aae
 aae
 aak
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -84849,7 +84823,7 @@ wEd
 aae
 aaa
 aaa
-aaB
+gDj
 aaa
 aae
 aaa
@@ -84878,7 +84852,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -85135,7 +85109,7 @@ aak
 aae
 aae
 aae
-aae
+aaa
 aak
 aae
 aae
@@ -85392,7 +85366,7 @@ aae
 aae
 aae
 aae
-aak
+aaa
 aak
 aae
 aae
@@ -85649,7 +85623,7 @@ aae
 aae
 aae
 aak
-aae
+aaa
 aae
 aae
 aae
@@ -85906,7 +85880,7 @@ aae
 aae
 aae
 aae
-aae
+aaa
 aae
 aae
 aae
@@ -86161,9 +86135,9 @@ aae
 aae
 aae
 aae
-aak
 aae
 aae
+aaa
 aae
 aak
 aae
@@ -86410,7 +86384,7 @@ bjo
 aaB
 aaB
 abV
-eLP
+aaB
 aaB
 aaB
 aaB
@@ -86420,7 +86394,7 @@ ajF
 ajF
 ajF
 ajF
-aae
+aaa
 aae
 aae
 aak
@@ -86674,10 +86648,10 @@ abV
 abV
 ajF
 srd
-adO
+iht
 drp
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -86926,7 +86900,7 @@ aev
 aae
 aae
 aae
-aaA
+ajF
 aaB
 aaB
 ajF
@@ -86934,7 +86908,7 @@ srd
 adO
 nMT
 ajF
-aae
+aaa
 aae
 aak
 aae
@@ -87183,7 +87157,7 @@ aae
 aae
 aae
 aae
-aaA
+ajF
 aaB
 aaB
 ajF
@@ -87191,7 +87165,7 @@ sxE
 adO
 heQ
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -87448,7 +87422,7 @@ heQ
 adO
 ovv
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -87705,7 +87679,7 @@ gQy
 adO
 adO
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -87962,7 +87936,7 @@ ajF
 ajF
 biK
 ajF
-aae
+aaa
 aae
 aak
 aae
@@ -88212,14 +88186,14 @@ abW
 acC
 aXc
 ajF
-iqB
-kVQ
+xyU
+bIu
 ajF
-sOV
+kkH
 xyU
 xyU
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -88468,15 +88442,15 @@ abB
 acC
 acC
 acC
-bcG
+hvo
 xyU
 xyU
-bcG
+hvo
 xyU
 xyU
 wpm
 ajF
-aae
+aaa
 aae
 aak
 aae
@@ -88723,19 +88697,19 @@ aca
 acC
 abB
 acC
-vzG
+pwI
 abo
 ajF
 xyU
 xyU
 ajF
 rRH
-aKR
+xyU
 afb
 ajF
-aae
-aae
-aae
+aaa
+aaa
+aaa
 aae
 aak
 aae
@@ -88992,7 +88966,7 @@ ajF
 ajF
 ajF
 ajF
-aae
+aaa
 aae
 aae
 aae
@@ -89249,7 +89223,7 @@ acC
 afu
 afu
 ajF
-aae
+aaa
 aak
 aae
 aae
@@ -89499,14 +89473,14 @@ meG
 ajF
 adO
 adO
-wSI
+wbB
 ajF
 baj
 acC
 afc
-hvo
+afc
 ajF
-aae
+aaa
 aak
 aae
 aaB
@@ -89748,11 +89722,11 @@ aae
 aae
 aae
 ajF
-abY
+wXH
 abY
 abY
 adO
-adO
+hZD
 oiZ
 adO
 adO
@@ -89763,7 +89737,7 @@ aXj
 afv
 afv
 ajF
-aae
+aaa
 aak
 aae
 aaB
@@ -90010,7 +89984,7 @@ adO
 agr
 adO
 adO
-aex
+biK
 adO
 adO
 juz
@@ -90018,9 +89992,9 @@ aex
 acC
 aXj
 afu
-afu
+noQ
 ajF
-aae
+aaa
 aak
 aae
 aae
@@ -90272,12 +90246,12 @@ adO
 adO
 ilS
 ajF
-aWL
-aXc
+tDp
+acC
 acC
 adk
 ajF
-aae
+aaa
 aae
 aae
 aak
@@ -90522,14 +90496,14 @@ ajF
 ajF
 ajF
 ajF
-van
+adO
 acN
 ajF
 adO
 adO
 aek
 ajF
-aXj
+iqB
 acC
 acC
 afI
@@ -90779,7 +90753,7 @@ aae
 aae
 ajF
 ajF
-aex
+biK
 ajF
 ajF
 ceR
@@ -90791,7 +90765,7 @@ cxd
 iYZ
 vpZ
 ajF
-aae
+aaa
 aaa
 aaa
 aae
@@ -91036,19 +91010,19 @@ aae
 aae
 ajF
 acs
-hZD
+adO
 acs
 ajF
 boC
 xjM
 ajF
 ajF
-noQ
+ajF
 krf
 ajF
 ajF
 ajF
-aae
+aaa
 aae
 aae
 aaa
@@ -91305,7 +91279,7 @@ cxd
 aXj
 afK
 ajF
-aae
+aaa
 aaa
 aae
 aae
@@ -91562,7 +91536,7 @@ irT
 oDk
 afJ
 ajF
-aae
+aaa
 aae
 aae
 aaa
@@ -91808,8 +91782,8 @@ aae
 ajF
 ajF
 ajF
-aae
-aae
+fMM
+ndo
 kZn
 xjM
 prR
@@ -91819,7 +91793,7 @@ ajF
 ajF
 ajF
 ajF
-aae
+aaa
 aaa
 aaa
 aae
@@ -92064,21 +92038,21 @@ aae
 aae
 aae
 pzs
-iht
+pzs
 urA
 nrn
 xjM
 xjM
 eMW
-cpq
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aJM
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aaa
+aaa
 aaa
 aae
 aaa
@@ -92332,11 +92306,11 @@ rkl
 rkl
 rkl
 xFX
-xFX
-aae
-aae
-aae
-aae
+van
+aiL
+aiL
+aiL
+aaa
 aaa
 aae
 aae
@@ -92570,7 +92544,7 @@ aae
 aae
 rkl
 rkl
-rkl
+acl
 rkl
 aae
 aae
@@ -92588,11 +92562,11 @@ rkl
 hBx
 hUJ
 rkl
-vNj
-cpq
-cpq
-urA
-aae
+qIN
+vhp
+dLW
+gzv
+aiL
 aaa
 aae
 aae
@@ -92846,10 +92820,10 @@ mbr
 aUy
 rkl
 nyy
-rqE
-rqE
-rqE
-aae
+ixZ
+ixZ
+ixZ
+aiL
 aaa
 aae
 xEU
@@ -93089,7 +93063,7 @@ rkl
 aae
 aae
 aae
-rkl
+acl
 jsp
 xyU
 vRx
@@ -93101,12 +93075,12 @@ kcz
 rkl
 xyU
 aUz
-vhp
-nrn
-xjM
-xjM
-aKb
-aae
+acl
+aaF
+vzG
+wfO
+vzG
+aiL
 aaa
 aae
 aae
@@ -93348,7 +93322,7 @@ rkl
 aae
 rkl
 mRs
-gXC
+aWL
 dHr
 dAO
 ndo
@@ -93359,12 +93333,12 @@ rkl
 mFo
 fAT
 rkl
-nrn
-xjM
-xjM
-xjM
-aae
-aae
+aaF
+vzG
+aaT
+vzG
+aiL
+aaa
 aaa
 aae
 cpq
@@ -93616,12 +93590,12 @@ hwj
 rkl
 rkl
 vsR
-nrn
-xjM
-boC
-xjM
-aae
-aae
+aaF
+aaT
+uFF
+aaT
+aiL
+aaa
 aaa
 aae
 ken
@@ -93854,7 +93828,7 @@ aaa
 aae
 aae
 rkl
-pgO
+sOV
 xzB
 xyU
 xyU
@@ -93873,12 +93847,12 @@ puj
 cpq
 qGu
 hIS
-nrn
-xjM
-xjM
+aaF
+wfO
+aaT
 abR
-aae
-aae
+aiL
+aaa
 aaa
 aae
 cpq
@@ -94112,12 +94086,12 @@ aae
 aae
 rkl
 xyU
-pgO
+sOV
 nIo
 xyU
 ffb
 abg
-pGI
+uaU
 whS
 rqE
 rqE
@@ -94130,12 +94104,12 @@ cpq
 cpq
 cpq
 rmx
-nrn
-xjM
-xjM
-xjM
-aae
-aae
+aaF
+aaT
+aaT
+aaT
+aiL
+aaa
 aaa
 aae
 aae
@@ -94374,8 +94348,8 @@ lxR
 xyU
 nzb
 abI
-pGI
-pGI
+uaU
+uaU
 oJW
 xjM
 xjM
@@ -94391,8 +94365,8 @@ vsR
 rkl
 rkl
 rkl
-aae
-aHE
+aiL
+aaa
 aaa
 aae
 aae
@@ -94625,11 +94599,11 @@ aaa
 aae
 aae
 rkl
+alG
+qmV
 xyU
-pgO
-sYZ
 xyU
-ral
+ffb
 abI
 uaU
 qeT
@@ -94643,13 +94617,13 @@ eXx
 cpq
 cCA
 dim
-fAT
-xyU
-wfO
-xyU
+cRh
+qUN
+rUp
+llI
 rkl
-aae
-aae
+aiL
+aaa
 aaa
 aae
 aae
@@ -94886,7 +94860,7 @@ mqy
 xyU
 mbr
 xyU
-ral
+ffb
 afn
 abu
 rkl
@@ -94900,13 +94874,13 @@ eXx
 cpq
 cpq
 ral
+hmI
 xyU
-xyU
-xyU
-qIN
-rkl
-aae
-aae
+rgK
+svL
+acl
+aiL
+aaa
 aae
 aaa
 aae
@@ -95153,17 +95127,17 @@ ehL
 nrn
 xjM
 xjM
-fpS
+hTq
 puj
 urA
 qcV
 xyU
 xyU
-mbr
-xyU
+gJt
+cIb
 rkl
-aae
-aae
+aiL
+aaa
 aae
 aae
 aaa
@@ -95419,8 +95393,8 @@ rkl
 rkl
 rkl
 rkl
-aae
-aae
+aiL
+aaa
 aae
 aae
 aaa
@@ -95659,7 +95633,7 @@ aae
 aae
 aae
 aae
-uFx
+abu
 qvQ
 acE
 mjc
@@ -95673,11 +95647,11 @@ rqE
 iQb
 xjM
 dqx
-aae
-aae
-aae
-aae
-aae
+aiL
+aiL
+aiL
+aiL
+aaa
 aae
 aae
 aae
@@ -95932,9 +95906,9 @@ xjM
 prR
 vNj
 pzs
-aae
-aae
-aae
+aiL
+aiL
+aaa
 aaa
 aae
 aae
@@ -96189,9 +96163,9 @@ kZn
 prR
 cpq
 cpq
-aae
-aae
-aae
+aiL
+aiL
+aaa
 aae
 aaa
 aaa
@@ -96446,9 +96420,9 @@ xjM
 prR
 puj
 cpq
-cpq
-aae
-aae
+mFC
+aiL
+aaa
 aae
 aae
 aae
@@ -96688,10 +96662,10 @@ aae
 aae
 aae
 aae
-crm
-txT
-cpq
-cpq
+aHE
+qth
+dnR
+dnR
 puj
 pFr
 eDQ
@@ -96703,10 +96677,10 @@ xjM
 prR
 cpq
 cpq
-mFC
-hIS
-cpq
-urA
+coX
+acl
+acl
+vQi
 pmC
 pmC
 cpq
@@ -96724,9 +96698,9 @@ aae
 aae
 aae
 ank
-cpq
-cpq
-cpq
+rRq
+rRq
+rRq
 ank
 aae
 aae
@@ -96944,12 +96918,12 @@ aae
 aae
 aae
 aae
-xjM
+aJN
 kLG
-crm
+aHE
 qth
-cpq
-cpq
+dnR
+dnR
 cpq
 nTn
 urA
@@ -96960,9 +96934,9 @@ xjM
 iTv
 oGj
 rqE
-rqE
-rqE
-rqE
+ixZ
+acl
+ixZ
 rqE
 rqE
 oGj
@@ -97199,15 +97173,15 @@ aae
 aae
 aae
 aae
-fMM
+ihO
 mgu
-xjM
-kFs
-xjM
-prR
-cpq
-cpq
-cCA
+aJN
+ckz
+aJN
+eLP
+dnR
+dnR
+dnR
 cpq
 cpq
 cpq
@@ -97217,9 +97191,9 @@ xjM
 xjM
 kFs
 xjM
-xjM
-xjM
-xjM
+aaT
+olx
+aaT
 xjM
 xjM
 kFs
@@ -97459,12 +97433,12 @@ aae
 ejf
 tgs
 wmc
-kFs
-xjM
-prR
-cpq
-cpq
-aae
+ckz
+aJN
+eLP
+dnR
+dnR
+aiL
 cpq
 cpq
 cpq
@@ -97474,9 +97448,9 @@ dAO
 dAO
 fqn
 dAO
-dAO
-dAO
-dAO
+aaU
+acl
+aaU
 dAO
 fqn
 fqn
@@ -97715,25 +97689,25 @@ aae
 aae
 mgu
 dzu
-xjM
-kFs
-xjM
-prR
-cpq
-aae
-aae
-aae
-aae
+aJN
+ckz
+aJN
+eLP
+dnR
+aiL
+aiL
+aiL
+aiL
 lNy
 cpq
 cpq
-dnR
+cpq
 cpq
 pmC
 cpq
 mFC
-hIS
-cpq
+acl
+acl
 puj
 cpq
 cpq
@@ -97963,35 +97937,35 @@ aaa
 "}
 (169,1,1) = {"
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aiL
+aiL
+aiL
+nMa
+nMa
+aiL
+aiL
+aiL
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-alG
-qUN
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-hTq
-cpq
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+aiL
+acl
+qYv
 cpq
 cpq
 nrn
@@ -98226,28 +98200,28 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
 aaB
 sls
 ccF
 aaB
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aae
 cpq

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -120,6 +120,10 @@
 #define F13SHOPKEEPER	(1<<1)
 #define F13BARKEEP		(1<<2)
 #define F13PREACHER		(1<<3)
+#define F13SHERIFF		(1<<4)
+#define F13MAYOR		(1<<5)
+#define F13BANKER		(1<<6)
+#define F13DEPUTY		(1<<7)
 
 #define VAULT			(1<<7)
 
@@ -153,13 +157,16 @@
 #define F13FOLLOWERVOLUNTEER	(1<<3)
 
 #define KHAN		(1<<12)
-
+/*
 #define F13NOYAN (1<<0)
 #define F13STEWARD (1<<1)
 #define F13KHESHIG (1<<2)
 #define F13KHORCHIN (1<<3)
 #define F13KIPCHAK (1<<4)
 #define F13MANGUDAI (1<<5)
+*/
+#define F13KHAN (1<<0)
+#define F13KHANCHEMIST (1<<1)
 
 #define JOB_AVAILABLE 0
 #define JOB_UNAVAILABLE_GENERIC 1

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -60,6 +60,10 @@
 	name = "khan door"
 	req_access_txt = "125"
 
+//bdoor
+/obj/machinery/door/unpowered/securedoor/sheriff_door
+	name = "secure door"
+	req_access_txt = "62"
 
 // ------------------------------------
 // NCR SECURE REINFORCED DOOR - tough airlock replacement

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -752,11 +752,11 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "Lawyer"
 
 /obj/effect/landmark/start/f13/sheriff
-	name = "Chief of Police"
+	name = "Sheriff"
 	icon_state = "Chief of Police"
 
 /obj/effect/landmark/start/f13/deputy
-	name = "Officer"
+	name = "Deputy"
 	icon_state = "Officer"
 
 /obj/effect/landmark/start/f13/farmer
@@ -916,26 +916,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/start/f13/followersscientist
 	name = "Followers Scientist"
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+//Khans
+// OLD KHAN STUFF
 /obj/effect/landmark/start/f13/noyan
 	name = "Noyan"
 	icon_state = "Pusher"
@@ -958,4 +940,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 
 /obj/effect/landmark/start/f13/mangudai
 	name = "Mangudai"
+	icon_state = "Pusher"
+
+// Proper Khans
+/obj/effect/landmark/start/f13/khan
+	name = "Khan Enforcer"
+	icon_state = "Pusher"
+
+/obj/effect/landmark/start/f13/khan_chemist
+	name = "Khan Chemist"
 	icon_state = "Pusher"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1239,7 +1239,7 @@
 
 /obj/item/card/id/silver/mayor
 	name = "Mayor's mayoral permit"
-	desc = "A silver encrusted identification permit reserved for the Mayor of Oasis."
+	desc = "A silver encrusted identification permit reserved for the Mayor of Bighorn."
 	icon_state = "silver"
 	item_state = "silver_id"
 	assignment = "mayoral permit"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -873,11 +873,11 @@
 	crafting_recipe_types = list(/datum/crafting_recipe/set_vrboard/den)
 
 /obj/item/book/granter/crafting_recipe/ODF
-	name = "Weapons of Yuma and the Oasis Defense Force"
+	name = "Weapons of Yuma and the Bighorn Defense Force"
 	desc = "a book detailing weapons used in the region and by the local town, it has lithiographed pictures of hand-drawn schematics for each weapon type"
 	oneuse = TRUE
 	crafting_recipe_types = list(/datum/crafting_recipe/policepistol, /datum/crafting_recipe/durathread_vest, /datum/crafting_recipe/policerifle, /datum/crafting_recipe/steelbib/heavy, /datum/crafting_recipe/armyhelmetheavy, /datum/crafting_recipe/huntingshotgun)
-	remarks = list("Looks like Oasis hand-crafts replicas from a pre-war police armory", "Some of these weapons are more than 200 years old....", "Duct tape really can hold it together!", "So that is how you laminate armor sheets together", "Looks like you can beat metal into just the right shape to replace the bits")
+	remarks = list("Looks like Bighorn hand-crafts replicas from a pre-war police armory", "Some of these weapons are more than 200 years old....", "Duct tape really can hold it together!", "So that is how you laminate armor sheets together", "Looks like you can beat metal into just the right shape to replace the bits")
 
 
 /obj/item/book/granter/trait/tagger

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1162,7 +1162,7 @@
 	new /obj/item/stock_parts/matter_bin/bluespace(src)
 	new /obj/item/stock_parts/matter_bin/bluespace(src)
 	new /obj/item/stock_parts/matter_bin/bluespace(src)
-	
+
 /obj/item/storage/box/sparelimbs
 	name = "box of prosthethic limbs"
 	desc = "Contains superior prosthethic limbs, one of each type."
@@ -1174,7 +1174,7 @@
 	new /obj/item/bodypart/r_arm/robot(src)
 	new /obj/item/bodypart/l_leg/robot(src)
 	new /obj/item/bodypart/r_leg/robot(src)
-	
+
 //Colored boxes.
 /obj/item/storage/box/green
 	icon_state = "box_green"
@@ -1402,7 +1402,7 @@
 
 /obj/item/storage/box/citizenship_permits
 	name = "box of citizenship permits"
-	desc = "A box containing spare citizenship permits for Oasis. Use a mayor's ID on a citizenship permit to assign its owner."
+	desc = "A box containing spare citizenship permits for Bighorn. Use a mayor's ID on a citizenship permit to assign its owner."
 	illustration = "id"
 
 /obj/item/storage/box/citizenship_permits/PopulateContents()
@@ -1437,7 +1437,7 @@ list(/obj/item/stack/sheet/metal = 20,
 /obj/item/storage/box/shopkeeper
 	name = "Shopkeeper's blueprints"
 	desc = "a box of the shopkeeper's blueprints"
-	
+
 
 /obj/item/storage/box/shopkeeper/PopulateContents()
 	for(var/i in 1 to 4)
@@ -1453,6 +1453,6 @@ list(/obj/item/stack/sheet/metal = 20,
 							/obj/item/book/granter/crafting_recipe/blueprint/brushgun,
 							)
 		new randomgun(src)
-	
+
 
 

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -717,8 +717,8 @@
 	slowdown = 0.12
 
 /obj/item/clothing/suit/armor/f13/town/chief
-	name = "OPD Chief's jacket"
-	desc = "A navy-blue jacket with blue shoulder designations, '/OPD/' stitched into one of the chest pockets, and hidden ceramic trauma plates. It has a small compartment for a holdout pistol."
+	name = "BPD Chief's jacket"
+	desc = "A navy-blue jacket with blue shoulder designations, '/BPD/' stitched into one of the chest pockets, and hidden ceramic trauma plates. It has a small compartment for a holdout pistol."
 	icon = 'icons/fallout/clothing/suits_cosmetic.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_cosmetic.dmi'
 	icon_state = "police_chief"
@@ -739,7 +739,7 @@
 	slowdown = 0.08 //combat armor but less slowdown
 
 /obj/item/clothing/suit/armor/vest/oasis
-	name = "OPD vest"
+	name = "BPD vest"
 	desc = "a lightweight ballistic vest that combines protection and comfort. This one has pockets sewn into the front and a badge pinned on it."
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets
 	armor = list("melee" = 15, "bullet" = 45, "laser" = 15,  "energy" = 30, "bomb" = 40, "bio" = 40, "rad" = 40, "fire" = 50, "acid" = 10, "wound" = 50)
@@ -749,7 +749,7 @@
 
 /obj/item/clothing/suit/armor/f13/metalarmor/steelbib/oasis
 	name = "heavy steel breastplate"
-	desc = "a steel breastplate, inspired by a pre-war design. Looks like oasis citizens added an additional layer of metal on the front face."
+	desc = "a steel breastplate, inspired by a pre-war design. Looks like Bighorn citizens added an additional layer of metal on the front face."
 	icon_state = "steel_bib"
 	item_state = "steel_bib"
 	armor = list( "melee" = 30, "bullet" = 50, "laser" = 30, "energy" = 15, "bomb" = 20, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0, "wound" = 45)

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -312,7 +312,7 @@
 	armor = list("melee" = 25, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 20, "acid" = 5)
 
 /obj/item/clothing/suit/armored/light/town/vest
-	name = "Oasis flak vest"
+	name = "Bighorn flak vest"
 	desc = "A refurbished flak vest, repaired by the Oasis Police Department. The ballistic nylon has a much tougher weave, but it still will not take acid or most high-powered rounds."
 	icon_state = "vest_flak"
 	item_state = "vest_flak"

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -382,7 +382,7 @@
 
 /obj/item/clothing/suit/armored/medium/steelbib/town
 	name = "steel breastplate"
-	desc = "A steel breastplate inspired by a pre-war design, this one was made locally in Oasis. It uses a stronger steel alloy in it's construction, still heavy though"
+	desc = "A steel breastplate inspired by a pre-war design, this one was made locally in Bighorn. It uses a stronger steel alloy in it's construction, still heavy though"
 	armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = -10)
 	slowdown = 0.11
 

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -1327,7 +1327,7 @@
 
 /obj/item/clothing/under/f13/combat/militia
 	name = "ODF fatigues"
-	desc = "An olive-green combat uniform, issued to members of the Oasis Defense Force."
+	desc = "An olive-green combat uniform, issued to members of the Bighorn Defense Force."
 
 /obj/item/clothing/under/f13/enclave_officer
 	name = "officer uniform"
@@ -1355,7 +1355,7 @@
 
 /obj/item/clothing/under/f13/general/oasis
 	name = "dictator's overcoat"
-	desc = "A grim looking overcoat - preferable standard for the ruler of oasis.<br>It's decorated with golden stars, each one adorned with a tree."
+	desc = "A grim looking overcoat - preferable standard for the ruler of Bighorn.<br>It's decorated with golden stars, each one adorned with a tree."
 
 /obj/item/clothing/under/f13/recon
 	name = "recon armor"

--- a/code/modules/jobs/job_types/bighorn.dm
+++ b/code/modules/jobs/job_types/bighorn.dm
@@ -10,14 +10,218 @@ Detective : 4 ACCESS_FORENSICS_LOCKERS
 here's a tip, go search DEFINES/access.dm
 */
 
-/*
-Mayor
-*/
-
 /datum/job/bighorn
 	exp_type = EXP_TYPE_BIGHORN
 	faction = FACTION_BIGHORN
 
+/*
+Mayor
+*/
+/datum/job/bighorn/f13mayor
+	title = "Mayor"
+	flag = F13MAYOR
+	department_flag = DEP_BIGHORN
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "Yourself"
+	description = "You are the benevolent tyrant of Bighorn, chosen by the people to represent and lead them. Pass laws to protect your citizens, distribute town funds and make deals with the powers present within the Region to better the people, and yourself, of course."
+	selection_color = "#d7b088"
+	exp_requirements = 1500
+	outfit = /datum/outfit/job/bighorn/f13mayor
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+
+/datum/outfit/job/bighorn/f13mayor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
+	ADD_TRAIT(H, TRAIT_GENERIC, src)
+
+/datum/outfit/job/bighorn/f13mayor
+	name = "Mayor"
+	jobtype = 	/datum/job/bighorn/f13mayor
+	ears =		/obj/item/radio/headset/headset_town
+	id =		/obj/item/card/id/silver/mayor
+	backpack = 	/obj/item/storage/backpack/satchel/explorer
+	satchel = 	/obj/item/storage/backpack/satchel/explorer
+	l_pocket = 	/obj/item/storage/bag/money/small/settler
+	r_pocket = 	/obj/item/flashlight/flare
+	belt = 		/obj/item/gun/ballistic/revolver/colt357
+	shoes = 	/obj/item/clothing/shoes/laceup
+	uniform = 	/obj/item/clothing/under/suit/checkered
+	suit = 		/obj/item/clothing/suit/armor/f13/kit
+	head = 		/obj/item/clothing/head/fedora
+	backpack_contents = list(
+		/obj/item/clothing/head/f13/town/big = 1, \
+		/obj/item/storage/box/citizenship_permits = 1, \
+		/obj/item/ammo_box/a357=2, \
+		/obj/item/pen/fountain/captain = 1)
+/*--------------------------------------------------------------*/
+/datum/job/bighorn/f13sheriff
+	title = "Sheriff"
+	flag = F13SHERIFF
+	department_flag = DEP_BIGHORN
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the mayor"
+	description = "As the chief law enforcer of the Town, your job is to keep the peace, settle local disputes, and keep your townsfolk safe and alive. Unfortunately, with the NCR and Legion closing in on the region, the Town is caught between a rock and a hard place, as with the war brings with it unsavory elements like the Khans and Outlaws. Sometimes the people you handle inside the town will be alive in cuffs, or dead on the street. Other times, they'll escape the limits of the town, to which you can put a bounty on their head for their capture, or have your deputies capture them. However, you must remember these three critical things: never leave the town undefended, keep the townsfolk alive and safe, and most importantly - keep your hand on your gun and don't you trust anyone."
+	selection_color = "#d7b088"
+	exp_requirements = 1500
+	outfit = /datum/outfit/job/bighorn/f13sheriff
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+
+/datum/outfit/job/bighorn/f13sheriff
+	name = "Sheriff"
+	jobtype = /datum/job/bighorn/f13sheriff
+	id = /obj/item/card/id/dogtag/sheriff
+	belt = null
+	backpack = /obj/item/storage/backpack/satchel/explorer
+	satchel = /obj/item/storage/backpack/satchel/explorer
+
+	ears = 			/obj/item/radio/headset/headset_town
+	uniform =  		/obj/item/clothing/under/f13/sheriff
+	neck =			/obj/item/storage/belt/holster
+	shoes = 		/obj/item/clothing/shoes/f13/cowboy
+	suit = 			/obj/item/clothing/suit/armor/f13/town/chief
+	head = 			/obj/item/clothing/head/f13/town/sheriff
+	glasses =		/obj/item/clothing/glasses/sunglasses
+	l_hand = 		/obj/item/gun/ballistic/rifle/repeater/brush
+	l_pocket =		/obj/item/storage/bag/money/small/bighorn
+
+	backpack_contents = list(
+		/obj/item/storage/box/deputy_badges=1, \
+		/obj/item/ammo_box/tube/c4570=3, \
+		/obj/item/ammo_box/m44=2, \
+		/obj/item/restraints/handcuffs=1, \
+		/obj/item/melee/classic_baton=1,
+		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/book/granter/crafting_recipe/ODF = 1)
+	r_pocket = /obj/item/flashlight/flare
+
+/datum/outfit/job/bighorn/f13sheriff/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
+	ADD_TRAIT(H, TRAIT_SELF_AWARE, src)
+/*--------------------------------------------------------------*/
+/datum/job/bighorn/f13deputy
+	title = "Deputy"
+	flag = F13DEPUTY
+	department_flag = DEP_BIGHORN
+	total_positions = 4
+	spawn_positions = 4
+	supervisors = "the sheriff and the mayor"
+	description = "Working alongside the Sheriff you've known them for a while, having worked with them under the previous Sheriff - you bagged many a bandit and raider together on the road. These days you patrol the areas outside of town, tracking down bounties on the run and keeping the settlers safe from harm."
+	selection_color = "#dcba97"
+	exp_requirements = 620
+	outfit = /datum/outfit/job/bighorn/f13deputy
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+
+/datum/outfit/job/bighorn/f13deputy
+	name = "Deputy"
+	jobtype = /datum/job/bighorn/f13deputy
+	ears = 			/obj/item/radio/headset/headset_town
+	id =            /obj/item/card/id/dogtag/deputy
+	backpack = /obj/item/storage/backpack/satchel/explorer
+	satchel = /obj/item/storage/backpack/satchel/explorer
+	l_pocket = /obj/item/storage/bag/money/small/settler
+	r_pocket = /obj/item/flashlight/flare
+	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
+	suit = 			/obj/item/clothing/suit/armor/vest/oasis
+	head =	/obj/item/clothing/head/f13/town/deputy
+	belt = /obj/item/gun/ballistic/revolver/colt357
+	shoes = 		/obj/item/clothing/shoes/f13/explorer
+	uniform = /obj/item/clothing/under/f13/cowboyb
+	backpack_contents = list(
+		/obj/item/ammo_box/a357=2, \
+		/obj/item/ammo_box/tube/m44=2, \
+		/obj/item/restraints/handcuffs=1,
+		/obj/item/melee/onehanded/knife/survival = 1,
+		/obj/item/book/granter/crafting_recipe/ODF = 1)
+
+/datum/outfit/job/bighorn/f13deputy/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+/*--------------------------------------------------------------*/
+/datum/job/den/f13banker
+	title = "Banker"
+	flag = F13BANKER
+	department_flag = DEP_BIGHORN
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the mayor"
+	description = "No matter where society lurks, profit and fortune are there to be made! It is up to you to distribute caps and earn interest while safekeeping items of value for the wastelands denizens! Ensure you make a profit and make your money back no matter the cost. You are to work alongside the Town, and should not be attempting to harm the residents of Bighorn."
+	selection_color = "#dcba97"
+	exp_requirements = 1500
+	enforces = "You are in a Job meant for encouraging roleplay with others, do not abandon your post or hoard money unless absolutely necessary. Do not use the caps provided for yourself."
+	outfit = /datum/outfit/job/den/f13banker
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	loadout_options = list(
+	/datum/outfit/loadout/classy,
+	/datum/outfit/loadout/loanshark,
+	/datum/outfit/loadout/investor,
+	)
+
+/datum/outfit/job/den/f13banker
+	name = "Banker"
+	jobtype = /datum/job/den/f13banker
+	uniform = /obj/item/clothing/under/lawyer/blacksuit
+	id = /obj/item/card/id/silver
+	ears = /obj/item/radio/headset/headset_town
+	shoes = /obj/item/clothing/shoes/f13/fancy
+	backpack = /obj/item/storage/backpack/satchel/leather
+	satchel = /obj/item/storage/backpack/satchel/leather
+	backpack_contents = list(
+		/obj/item/storage/bag/money/small/banker)
+
+/datum/outfit/loadout/classy
+	name = "Classy"
+	head = /obj/item/clothing/head/collectable/tophat
+	glasses = /obj/item/clothing/glasses/monocle
+	uniform = /obj/item/clothing/under/suit_jacket/charcoal
+	suit = /obj/item/clothing/suit/f13/banker
+	gloves = /obj/item/clothing/gloves/color/white
+	shoes = /obj/item/clothing/shoes/laceup
+	backpack_contents = list(
+	/obj/item/cane=1,
+	/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+	/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass=1
+	)
+
+/datum/outfit/loadout/loanshark
+	name = "Loanshark"
+	glasses = /obj/item/clothing/glasses/orange
+	mask = /obj/item/clothing/mask/cigarette/cigar
+	suit = /obj/item/clothing/suit/f13/vest
+	uniform = /obj/item/clothing/under/f13/sleazeball
+	shoes = /obj/item/clothing/shoes/sandal
+	backpack_contents = list(
+	/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+	/obj/item/storage/box/matches=1,
+	/obj/item/gun/ballistic/automatic/smg/mini_uzi=1
+	)
+
+/datum/outfit/loadout/investor
+	name = "Investor"
+	glasses = /obj/item/clothing/glasses/sunglasses
+	suit = /obj/item/clothing/suit/toggle/lawyer/black
+	uniform = /obj/item/clothing/under/f13/bennys
+	gloves = /obj/item/clothing/gloves/fingerless
+	shoes = /obj/item/clothing/shoes/laceup
+	backpack_contents = list(
+		/obj/item/gun/ballistic/revolver/colt357=1,
+		/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+		/obj/item/storage/box/matches=1
+		)
 /*--------------------------------------------------------------*/
 /datum/job/bighorn/f13barkeep
 	title = "Barkeep"
@@ -30,7 +234,7 @@ Mayor
 	enforces = "While you have dominion over your private business, your premium status as a citizen may be revoked if you are considered a danger to the populace or anger those in control of the town."
 	selection_color = "#dcba97"
 
-	outfit = /datum/outfit/job/den/f13barkeep
+	outfit = /datum/outfit/job/bighorn/f13barkeep
 
 	loadout_options = list(
 	/datum/outfit/loadout/rugged,
@@ -50,7 +254,7 @@ Mayor
 	)
 
 
-/datum/outfit/job/den/f13barkeep
+/datum/outfit/job/bighorn/f13barkeep
 	name = "Barkeep"
 	jobtype = /datum/job/bighorn/f13barkeep
 
@@ -116,7 +320,7 @@ Mayor
 	selection_color = "#dcba97"
 	exp_requirements = 300
 
-	outfit = /datum/outfit/job/den/f13shopkeeper
+	outfit = /datum/outfit/job/bighorn/f13shopkeeper
 	access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
 	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
 	matchmaking_allowed = list(
@@ -128,7 +332,7 @@ Mayor
 		),
 	)
 
-/datum/outfit/job/den/f13shopkeeper
+/datum/outfit/job/bighorn/f13shopkeeper
 	name = "Shopkeeper"
 	jobtype = /datum/job/bighorn/f13shopkeeper
 
@@ -139,12 +343,12 @@ Mayor
 	satchel = /obj/item/storage/backpack/satchel
 	duffelbag = /obj/item/storage/backpack/duffelbag
 	gloves = /obj/item/clothing/gloves/fingerless
-	l_pocket = /obj/item/storage/bag/money/small/den
+	l_pocket = /obj/item/storage/bag/money/small/bighorn
 	r_pocket = /obj/item/flashlight/glowstick
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	backpack_contents = list(/obj/item/storage/box/shopkeeper = 1)
 
-/datum/outfit/job/den/f13shopkeeper/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/bighorn/f13shopkeeper/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
@@ -167,7 +371,7 @@ Mayor
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/explosive/shrapnelmine)
 
-/datum/outfit/job/den/f13shopkeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/bighorn/f13shopkeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
@@ -184,7 +388,7 @@ Mayor
 	enforces = "Your premium status as a citizen may be revoked if you are considered a danger to the populace or anger those in control of the town."
 	selection_color = "#dcba97"
 
-	outfit = /datum/outfit/job/den/f13settler
+	outfit = /datum/outfit/job/bighorn/f13settler
 
 	loadout_options = list(
 		/datum/outfit/loadout/provisioner,
@@ -392,7 +596,7 @@ Mayor
 		/obj/item/storage/bag/money/small/settler)
 //end preacher
 
-/datum/outfit/job/den/f13settler
+/datum/outfit/job/bighorn/f13settler
 	name = "Citizen"
 	jobtype = /datum/job/bighorn/f13settler
 	ears = /obj/item/radio/headset/headset_town
@@ -408,7 +612,7 @@ Mayor
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		)
 
-/datum/outfit/job/den/f13settler/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/bighorn/f13settler/pre_equip(mob/living/carbon/human/H)
 	..()
 	uniform = pick(
 		/obj/item/clothing/under/f13/settler, \

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -69,6 +69,7 @@ Administrator
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 	ADD_TRAIT(H, TRAIT_RESEARCHER, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST_EXPERT, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 /datum/outfit/job/followers/f13leadpractitioner
 	name =	"Followers Administrator"
@@ -139,6 +140,7 @@ Practitioner
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
+	ADD_TRAIT(H, TRAIT_POOR_AIM, src)
 
 	//the follower practitioner doesn't need access because it's already set in the /datum/job/follower
 	//personally, I don't think a practitioner should have more access than a volunteer.

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -3,20 +3,10 @@
 	selection_color = "#ff915e"
 	faction = FACTION_KHAN
 	exp_type = EXP_TYPE_KHAN
-	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_MINING, ACCESS_GATEWAY)
-	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_MINING, ACCESS_GATEWAY)
-	forbids = "THE KHANATE DISCOURAGES: Dishonorable actions, Weakness, Abuse of power or status, sabotaging other Khans."
-	enforces = "THE KHANATE ENCOURAGES: Bravery, Honor, Displays of strenght, Brotherhood."
-
-/datum/job/khanleader //do NOT use this for anything, it's just to store faction datums
-	department_flag = KHAN
-	selection_color = "#ff915e"
-	faction = FACTION_KHAN
-	exp_type = EXP_TYPE_KHAN
-	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
-	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
-	forbids = "THE KHANATE DISCOURAGES: Dishonorable actions, Weakness, Abuse of power or status, sabotaging other Khans."
-	enforces = "THE KHANATE ENCOURAGES: Bravery, Honor, Displays of strenght, Brotherhood."
+	access = list(ACCESS_KHAN)
+	minimal_access = list(ACCESS_KHAN)
+	forbids = "THE KHANS DISCOURAGES: Weakness, Sabotaging other Khans."
+	enforces = "THE KHANS ENCOURAGES: Displays of Strength. Assisting the 'Trade'."
 
 /datum/outfit/job/khan
 	name = "Khan"
@@ -50,295 +40,52 @@
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
 
-/datum/outfit/job/khan/mangudai
-	jobtype = /datum/job/khan/mangudai
+/datum/outfit/job/khan/chemist
+	jobtype = /datum/job/khan/chemist
 
-/datum/outfit/job/khan/kipchak
-	jobtype = /datum/job/khan/kipchak
+/datum/job/khan/enforcer
+	title = "Khan Enforcer"
+	flag = F13KHAN
+	faction = FACTION_KHAN
+	total_positions = 6
+	spawn_positions = 6
+	description = "You are a Khan, a member of the local band that the Chief has sent to scout these lands. Listen to the Chemist, and assure you've a steady supply of caps for the Chief."
+	supervisors = "the Chemist"
+	selection_color = "#ff915e"
+	exp_requirements = 240
+	exp_type = EXP_TYPE_WASTELAND
+	outfit = /datum/outfit/job/khan
 
-/datum/outfit/job/khan/khorchin
-	jobtype = /datum/job/khan/khorchin
-
-/datum/outfit/job/khan/kheshig
-	jobtype = /datum/job/khan/kheshig
-
-/datum/outfit/job/khanleader/steward
-	jobtype = /datum/job/khanleader/steward
-
-/datum/outfit/job/khanleader/noyan
-	jobtype = /datum/job/khanleader/noyan
-
-/datum/outfit/job/khanleader
-	name = "Khan"
-	jobtype = /datum/job/khanleader
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
-	id = /obj/item/card/id/khanleadertattoo
-	ears = /obj/item/radio/headset/headset_khans
-	head = /obj/item/clothing/head/helmet/f13/khan/bandana
-	shoes = /obj/item/clothing/shoes/f13/military/khan
-	backpack =	/obj/item/storage/backpack/satchel/explorer
-	satchel = 	/obj/item/storage/backpack/satchel/old
-	uniform = /obj/item/clothing/under/f13/khan
-	r_hand = /obj/item/book/granter/trait/selection
-	r_pocket = /obj/item/flashlight/flare
-	l_pocket = /obj/item/storage/survivalkit_khan
-	gloves = /obj/item/melee/unarmed/brass/spiked
-	box = null
-	backpack_contents = list(
-		/obj/item/storage/bag/money/small/khan = 1
+	loadout_options = list(
+		/datum/outfit/loadout/soldier
 		)
 
-/datum/outfit/job/khanleader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/combatrifle)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
-
-/datum/job/khanleader/noyan
-	title = "Noyan"
-	flag = F13NOYAN
-	head_announce = list("Security")
+/datum/job/khan/chemist
+	title = "Khan Chemist"
+	flag = F13KHANCHEMIST
 	faction = FACTION_KHAN
 	total_positions = 1
 	spawn_positions = 1
-	description = "You are a Noyan, a ranking officer of the Khanate in charge of the local territory. You serve with the authority of the Khan themselves, and answer only to them - every Khan within the region is under your command. Maintain control of Bighorn from your mighty Khan Fortress. Work closely with the Steward if present - an invaluable financial and political adviser."
-	enforces = "While you command great respect, you are nevertheless expected to keep the interests of the Khanate central. Put down dissent, but expect rapid and justified rebellion amongst your Khans if you begin unnecessarily endangering the interests of the Khanate. Mangudai and Kipchaks make good guards and scouts: Khorchins and Kheshigs are a more formidable military garrison."
-	supervisors = "the Khan and Khanate"
+	description = "You are a Chemist, one of the few Khans present in this camp that can produce those sweet, sweet chems. Keep them flowing and assure a supply of caps, so you can send them back to the Chief."
+	enforces = "You have control over the lab, a valuable asset in generating profit."
+	supervisors = "the Chief"
 	selection_color = "#ff915e"
 	req_admin_notify = 1
-	exp_requirements = 1000
-	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khanleader/noyan
-
-	loadout_options = list(
-		/datum/outfit/loadout/ironfist,
-		/datum/outfit/loadout/peopleleader,
-		/datum/outfit/loadout/pacifier,
-		/datum/outfit/loadout/bigboss,
-		)
-
-/datum/job/khanleader/steward
-	title = "Steward"
-	flag = F13STEWARD
-	head_announce = list("Security")
-	faction = FACTION_KHAN
-	total_positions = 1
-	spawn_positions = 1
-	description = "You are a Steward, a veteran of the Great Khans now serving its interests through negotiations and book-keeping. While dialogue and paperwork may be less exciting than the battlefield, you are instrumental in securing the financial and political wellbeing of the Khanate in this region. You are expected to lead in the absence of a Noyan."
-	enforces = "You have control over the First Bank of Bighorn, a valuable asset in generating profit. Some ideas - distributing loans, handling the collection of tribute, establishing a chem distribution ring, and working with another faction - perhaps against another. But don't unnecessarily endanger the Khanate, and listen to the Noyan!"
-	supervisors = "the Noyan and Khanate"
-	selection_color = "#ff915e"
 	exp_requirements = 750
 	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khanleader/steward
+	outfit = /datum/outfit/job/khan/chemist
 
 	loadout_options = list(
-		/datum/outfit/loadout/taxcollector,
-		/datum/outfit/loadout/privileged,
-		)
-
-/datum/job/khan/kheshig
-	title = "Kheshig"
-	flag = F13KHESHIG
-	faction = FACTION_KHAN
-	total_positions = 2
-	spawn_positions = 2
-	description = "You are a Kheshig, a veteran Khorchin of the Great Khans who has displayed a degree of combat mastery in service to the Khanate. You receive access to a far greater arsenal, but with this comes greater expectations - expect to be given duties befitting of a true loyalist of the Khan such as leading dangerous expeditions alongside Knorchin, Bighorn prospectors and Followers."
-	supervisors = "the Noyan and Khanate"
-	selection_color = "#ff915e"
-	exp_requirements = 500
-	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khan/kheshig
-
-	loadout_options = list(
-		/datum/outfit/loadout/veteran,
-		/datum/outfit/loadout/sprayer,
-		/datum/outfit/loadout/pusher,
-		)
-
-/datum/job/khan/khorchin
-	title = "Khorchin"
-	flag = F13KHORCHIN
-	faction = FACTION_KHAN
-	total_positions = 4
-	spawn_positions = 4
-	description = "You are a Khorchin, an experienced warrior of the Great Khans who has proven their worth to the Khanate several times over. Your lamellar armor was forged for your person, and you shall find ample instruments of warfare at your disposal. Duties of greater prestige shall be given to you, from protecting Bighorn from lawbreakers to serving on diplomatic missions and expeditions."
-	supervisors = "the Noyan and Khanate"
-	selection_color = "#ff915e"
-	exp_requirements = 150
-	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khan/khorchin
-
-	loadout_options = list(
-		/datum/outfit/loadout/fighter,
-		/datum/outfit/loadout/guard,
-		/datum/outfit/loadout/protector,
-		)
-
-/datum/job/khan/kipchak
-	title = "Kipchak"
-	flag = F13KIPCHAK
-	faction = FACTION_KHAN
-	total_positions = 4
-	spawn_positions = 4
-	description = "You are a Kipchak, a warrior of the Great Khans who has demonstrated prowess beyond the domain of a Mangudai. While you remain a humble soldier, greater duties may be entrusted upon you - such as leadership of small scouting parties or the collection of tribute. Your additional duties may involve hunting, prospecting and mining."
-	supervisors = "the Noyan and Khanate"
-	selection_color = "#ff915e"
-	exp_requirements = 60
-	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khan/kipchak
-
-	loadout_options = list(
-		/datum/outfit/loadout/miner,
-		/datum/outfit/loadout/prospector,
-		/datum/outfit/loadout/hunter,
-		)
-
-/datum/job/khan/mangudai
-	title = "Mangudai"
-	flag = F13MANGUDAI
-	faction = FACTION_KHAN
-	total_positions = 4
-	spawn_positions = 4
-	description = "You are a Mangudai, a warrior of the Great Khans who has passed the Trial of Position within the arena and earned their place. While your combat skills are to be respected, remember your position as a soldier - protect the Khan Fortress and Bighorn, show loyalty, and you may find chances yet to prove your greater worth."
-	supervisors = "the Noyan and Khanate"
-	selection_color = "#ff915e"
-	exp_type = EXP_TYPE_KHAN
-	outfit = /datum/outfit/job/khan/mangudai
-
-	loadout_options = list(
-		/datum/outfit/loadout/enforcer,
-		/datum/outfit/loadout/khanskirmisher,
-		/datum/outfit/loadout/khandrug,
+		/datum/outfit/loadout/chemist,
+		/datum/outfit/loadout/quack,
 		)
 
 //=========================================================== LOADOUT DATUMS ===========================================================
 
-//KIPCHAK =================================================================
+//KHAN =================================================================
 
-/datum/outfit/loadout/miner
-	name = "Miner"
-	r_hand = /obj/item/pickaxe
-	l_hand = /obj/item/flashlight/lantern
-	belt = /obj/item/storage/bag/ore
-	backpack_contents = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/shovel = 1)
-
-/datum/outfit/loadout/prospector
-	name = "Prospector"
-	r_hand = /obj/item/gun/ballistic/automatic/pistol/m1911/custom
-	l_hand = /obj/item/weldingtool/largetank
-	belt = /obj/item/storage/belt
-	mask = /obj/item/clothing/mask/gas/welding
-	backpack_contents = list(
-		/obj/item/wrench = 1,
-		/obj/item/ammo_box/magazine/m45 = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/techno = 1)
-
-/datum/outfit/loadout/hunter
-	name = "Hunter"
-	r_hand = /obj/item/gun/ballistic/rifle/hunting
-	belt = /obj/item/storage/belt/bandolier
-	backpack_contents = list(
-		/obj/item/ammo_box/a308  = 3,
-		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
-
-//MANGUDAI =================================================================
-
-/datum/outfit/loadout/enforcer
-	name = "Enforcer"
-	r_hand = /obj/item/twohanded/baseball/spiked
-	belt = /obj/item/storage/belt/bandolier
-	backpack_contents = list(
-		/obj/item/restraints/legcuffs/bola/tactical = 1,
-		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
-
-/datum/outfit/loadout/khanskirmisher
-	name = "Skirmisher"
-	r_hand = /obj/item/gun/ballistic/automatic/smg/mini_uzi
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/uzim9mm = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
-		/obj/item/storage/belt/holster = 1)
-
-/datum/outfit/loadout/khandrug
-	name = "Drug Pusher"
-	belt = /obj/item/storage/belt/bandolier
-	backpack_contents = list(
-		/obj/item/book/granter/trait/midsurgery = 1,
-		/obj/item/book/granter/trait/chemistry = 1,
-		/obj/item/reagent_containers/pill/patch/turbo = 2)
-
-//KHORCHIN =================================================================
-
-/datum/outfit/loadout/fighter
-	name = "Fighter"
-	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
-	belt = /obj/item/storage/belt/bandolier
-	head = /obj/item/clothing/head/helmet/f13/khan
-	backpack_contents = list(
-		/obj/item/ammo_box/tube/m44 = 3,
-		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
-
-/datum/outfit/loadout/guard
-	name = "Guard"
-	r_hand = /obj/item/gun/ballistic/shotgun/trench
-	belt = /obj/item/storage/belt/bandolier
-	head = /obj/item/clothing/head/helmet/f13/khan
-	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck = 2,
-		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
-
-/datum/outfit/loadout/protector
-	name = "protector"
-	r_hand = /obj/item/gun/ballistic/automatic/pistol/n99
-	l_hand = /obj/item/shield/riot/scrapshield
-	belt = /obj/item/storage/belt/bandolier
-	head = /obj/item/clothing/head/helmet/f13/khan
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
-		/obj/item/melee/onehanded/machete/scrapsabre = 1,
-		/obj/item/book/granter/trait/bigleagues = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
-
-//KESHIG ===================================================================
-
-/datum/outfit/loadout/veteran
-	name = "Veteran Fighter"
-	belt = /obj/item/storage/belt/bandolier
-	r_hand = /obj/item/gun/ballistic/automatic/m1garand
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
-	head = /obj/item/clothing/head/helmet/f13/khan
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/garand308 = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
-
-/datum/outfit/loadout/sprayer
-	name = "Sprayer"
-	belt = /obj/item/storage/belt/bandolier
-	r_hand = /obj/item/gun/ballistic/automatic/smg/smg10mm
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
-	head = /obj/item/clothing/head/helmet/f13/khan
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m10mm_adv/ext = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
-
-/datum/outfit/loadout/pusher
-	name = "Pusher"
+/datum/outfit/loadout/soldier
+	name = "Soldier"
 	belt = /obj/item/storage/backpack/spearquiver
 	l_hand = /obj/item/shield/riot/tower
 	r_hand = /obj/item/melee/onehanded/machete/scrapsabre
@@ -348,83 +95,24 @@
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
 		/obj/item/book/granter/trait/bigleagues = 1)
 
-//STEWARD ==================================================================
 
-/datum/outfit/loadout/privileged
-	name = "Privileged"
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat/goji
-	glasses = /obj/item/clothing/glasses/wraith_spectacles
-	head = /obj/item/clothing/head/collectable/petehat/gang
-	r_hand = /obj/item/gun/ballistic/revolver/colt357/lucky
-	l_hand = /obj/item/twohanded/baseball/louisville
-	neck = /obj/item/storage/belt/holster
-	backpack_contents = list(
-		/obj/item/ammo_box/a357 = 3,
-		/obj/item/clipboard = 1,
-		/obj/item/pen = 1,
-		/obj/item/folder = 1)
+//CHEMIST =================================================================
 
-/datum/outfit/loadout/taxcollector
-	name = "Tax Collector"
-	glasses = /obj/item/clothing/glasses/sunglasses
-	r_hand = /obj/item/gun/ballistic/revolver/hunting
-	neck = /obj/item/storage/belt/holster
-	backpack_contents = list(
-		/obj/item/ammo_box/c4570 = 3,
-		/obj/item/twohanded/baseball = 1,
-		/obj/item/clipboard = 1,
-		/obj/item/pen = 1,
-		/obj/item/folder = 1)
-
-//NOYAN ====================================================================
-
-/datum/outfit/loadout/bigboss
-	name = "Big Boss"
-	belt =/obj/item/storage/belt/bandolier
-	r_hand = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
-	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
-	glasses = /obj/item/clothing/glasses/sunglasses
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m14mm = 3,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
-
-/datum/outfit/loadout/ironfist
-	name = "Iron Fist"
-	gloves = /obj/item/melee/powerfist/f13
+/datum/outfit/loadout/chemist
+	name = "Chemist"
+	suit = /obj/item/clothing/suit/toggle/labcoat
 	belt = /obj/item/storage/belt/bandolier
-	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
-	glasses = /obj/item/clothing/glasses/sunglasses
 	backpack_contents = list(
-		/obj/item/restraints/legcuffs/bola/tactical = 1,
-		/obj/item/book/granter/trait/iron_fist  = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/book/granter/trait/lowsurgery =1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
 
-/datum/outfit/loadout/peopleleader
-	name = "People's leader"
-	r_hand = /obj/item/gun/ballistic/revolver/revolver45
-	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+/datum/outfit/loadout/quack
+	name = "Quack Chemist"
+	suit = /obj/item/clothing/suit/jacket/leather/overcoat
 	glasses = /obj/item/clothing/glasses/sunglasses
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/bandolier
 	backpack_contents = list(
-		/obj/item/ammo_box/c45rev = 3,
-		/obj/item/restraints/legcuffs/bola/tactical = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
-
-/datum/outfit/loadout/pacifier
-	name = "Pacifier"
-	r_hand = /obj/item/gun/ballistic/automatic/shotgun/riot
-	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
-	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
-	glasses = /obj/item/clothing/glasses/sunglasses
-	backpack_contents = list(
-		/obj/item/ammo_box/magazine/d12g = 2,
-		/obj/item/ammo_box/shotgun/buck = 2,
-		/obj/item/restraints/legcuffs/bola/tactical = 1,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
-		/obj/item/book/granter/trait/bigleagues = 1)
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/book/granter/trait/explosives =1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)

--- a/code/modules/jobs/job_types/khan_OLD.dm
+++ b/code/modules/jobs/job_types/khan_OLD.dm
@@ -1,0 +1,436 @@
+/*
+This entire file is deprecated. It remains for the  purpose of archiving and potential return, should we wish to revert the change that did this.
+Please do not reference datums within this file, or utilise it in any capacity.
+*/
+
+
+/datum/job/khan //do NOT use this for anything, it's just to store faction datums
+	department_flag = KHAN
+	selection_color = "#ff915e"
+	faction = FACTION_KHAN
+	exp_type = EXP_TYPE_KHAN
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_MINING, ACCESS_GATEWAY)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_MINING, ACCESS_GATEWAY)
+	forbids = "THE KHANATE DISCOURAGES: Dishonorable actions, Weakness, Abuse of power or status, sabotaging other Khans."
+	enforces = "THE KHANATE ENCOURAGES: Bravery, Honor, Displays of strenght, Brotherhood."
+
+/datum/job/khanleader //do NOT use this for anything, it's just to store faction datums
+	department_flag = KHAN
+	selection_color = "#ff915e"
+	faction = FACTION_KHAN
+	exp_type = EXP_TYPE_KHAN
+	access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	minimal_access = list(ACCESS_KHAN, ACCESS_BAR, ACCESS_CLINIC, ACCESS_GATEWAY, ACCESS_MINT_VAULT, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS, ACCESS_CLONING)
+	forbids = "THE KHANATE DISCOURAGES: Dishonorable actions, Weakness, Abuse of power or status, sabotaging other Khans."
+	enforces = "THE KHANATE ENCOURAGES: Bravery, Honor, Displays of strenght, Brotherhood."
+
+/datum/outfit/job/khan
+	name = "Khan"
+	jobtype = /datum/job/khan
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
+	id = /obj/item/card/id/khantattoo
+	ears = /obj/item/radio/headset/headset_khans
+	head = /obj/item/clothing/head/helmet/f13/khan/bandana
+	shoes = /obj/item/clothing/shoes/f13/military/khan
+	backpack =	/obj/item/storage/backpack/satchel/explorer
+	satchel = 	/obj/item/storage/backpack/satchel/old
+	uniform = /obj/item/clothing/under/f13/khan
+	r_hand = /obj/item/book/granter/trait/selection
+	r_pocket = /obj/item/flashlight/flare
+	l_pocket = /obj/item/storage/survivalkit_khan
+	gloves = /obj/item/melee/unarmed/brass/spiked
+	box = null
+	backpack_contents = list(
+		/obj/item/storage/bag/money/small/khan = 1
+		)
+
+/datum/outfit/job/khan/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/combatrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
+
+/datum/outfit/job/khan/mangudai
+	jobtype = /datum/job/khan/mangudai
+
+/datum/outfit/job/khan/kipchak
+	jobtype = /datum/job/khan/kipchak
+
+/datum/outfit/job/khan/khorchin
+	jobtype = /datum/job/khan/khorchin
+
+/datum/outfit/job/khan/kheshig
+	jobtype = /datum/job/khan/kheshig
+
+/datum/outfit/job/khanleader/steward
+	jobtype = /datum/job/khanleader/steward
+
+/datum/outfit/job/khanleader/noyan
+	jobtype = /datum/job/khanleader/noyan
+
+/datum/outfit/job/khanleader
+	name = "Khan"
+	jobtype = /datum/job/khanleader
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket
+	id = /obj/item/card/id/khanleadertattoo
+	ears = /obj/item/radio/headset/headset_khans
+	head = /obj/item/clothing/head/helmet/f13/khan/bandana
+	shoes = /obj/item/clothing/shoes/f13/military/khan
+	backpack =	/obj/item/storage/backpack/satchel/explorer
+	satchel = 	/obj/item/storage/backpack/satchel/old
+	uniform = /obj/item/clothing/under/f13/khan
+	r_hand = /obj/item/book/granter/trait/selection
+	r_pocket = /obj/item/flashlight/flare
+	l_pocket = /obj/item/storage/survivalkit_khan
+	gloves = /obj/item/melee/unarmed/brass/spiked
+	box = null
+	backpack_contents = list(
+		/obj/item/storage/bag/money/small/khan = 1
+		)
+
+/datum/outfit/job/khanleader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/set_vrboard/den)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/combatrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/gate_khanate)
+
+/datum/job/khanleader/noyan
+	title = "Noyan"
+	flag = F13NOYAN
+	head_announce = list("Security")
+	faction = FACTION_KHAN
+	total_positions = 1
+	spawn_positions = 1
+	description = "You are a Noyan, a ranking officer of the Khanate in charge of the local territory. You serve with the authority of the Khan themselves, and answer only to them - every Khan within the region is under your command. Maintain control of Bighorn from your mighty Khan Fortress. Work closely with the Steward if present - an invaluable financial and political adviser."
+	enforces = "While you command great respect, you are nevertheless expected to keep the interests of the Khanate central. Put down dissent, but expect rapid and justified rebellion amongst your Khans if you begin unnecessarily endangering the interests of the Khanate. Mangudai and Kipchaks make good guards and scouts: Khorchins and Kheshigs are a more formidable military garrison."
+	supervisors = "the Khan and Khanate"
+	selection_color = "#ff915e"
+	req_admin_notify = 1
+	exp_requirements = 1000
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khanleader/noyan
+
+	loadout_options = list(
+		/datum/outfit/loadout/ironfist,
+		/datum/outfit/loadout/peopleleader,
+		/datum/outfit/loadout/pacifier,
+		/datum/outfit/loadout/bigboss,
+		)
+
+/datum/job/khanleader/steward
+	title = "Steward"
+	flag = F13STEWARD
+	head_announce = list("Security")
+	faction = FACTION_KHAN
+	total_positions = 1
+	spawn_positions = 1
+	description = "You are a Steward, a veteran of the Great Khans now serving its interests through negotiations and book-keeping. While dialogue and paperwork may be less exciting than the battlefield, you are instrumental in securing the financial and political wellbeing of the Khanate in this region. You are expected to lead in the absence of a Noyan."
+	enforces = "You have control over the First Bank of Bighorn, a valuable asset in generating profit. Some ideas - distributing loans, handling the collection of tribute, establishing a chem distribution ring, and working with another faction - perhaps against another. But don't unnecessarily endanger the Khanate, and listen to the Noyan!"
+	supervisors = "the Noyan and Khanate"
+	selection_color = "#ff915e"
+	exp_requirements = 750
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khanleader/steward
+
+	loadout_options = list(
+		/datum/outfit/loadout/taxcollector,
+		/datum/outfit/loadout/privileged,
+		)
+
+/datum/job/khan/kheshig
+	title = "Kheshig"
+	flag = F13KHESHIG
+	faction = FACTION_KHAN
+	total_positions = 2
+	spawn_positions = 2
+	description = "You are a Kheshig, a veteran Khorchin of the Great Khans who has displayed a degree of combat mastery in service to the Khanate. You receive access to a far greater arsenal, but with this comes greater expectations - expect to be given duties befitting of a true loyalist of the Khan such as leading dangerous expeditions alongside Knorchin, Bighorn prospectors and Followers."
+	supervisors = "the Noyan and Khanate"
+	selection_color = "#ff915e"
+	exp_requirements = 500
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khan/kheshig
+
+	loadout_options = list(
+		/datum/outfit/loadout/veteran,
+		/datum/outfit/loadout/sprayer,
+		/datum/outfit/loadout/pusher,
+		)
+
+/datum/job/khan/khorchin
+	title = "Khorchin"
+	flag = F13KHORCHIN
+	faction = FACTION_KHAN
+	total_positions = 4
+	spawn_positions = 4
+	description = "You are a Khorchin, an experienced warrior of the Great Khans who has proven their worth to the Khanate several times over. Your lamellar armor was forged for your person, and you shall find ample instruments of warfare at your disposal. Duties of greater prestige shall be given to you, from protecting Bighorn from lawbreakers to serving on diplomatic missions and expeditions."
+	supervisors = "the Noyan and Khanate"
+	selection_color = "#ff915e"
+	exp_requirements = 150
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khan/khorchin
+
+	loadout_options = list(
+		/datum/outfit/loadout/fighter,
+		/datum/outfit/loadout/guard,
+		/datum/outfit/loadout/protector,
+		)
+
+/datum/job/khan/kipchak
+	title = "Kipchak"
+	flag = F13KIPCHAK
+	faction = FACTION_KHAN
+	total_positions = 4
+	spawn_positions = 4
+	description = "You are a Kipchak, a warrior of the Great Khans who has demonstrated prowess beyond the domain of a Mangudai. While you remain a humble soldier, greater duties may be entrusted upon you - such as leadership of small scouting parties or the collection of tribute. Your additional duties may involve hunting, prospecting and mining."
+	supervisors = "the Noyan and Khanate"
+	selection_color = "#ff915e"
+	exp_requirements = 60
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khan/kipchak
+
+	loadout_options = list(
+		/datum/outfit/loadout/miner,
+		/datum/outfit/loadout/prospector,
+		/datum/outfit/loadout/hunter,
+		)
+
+/datum/job/khan/mangudai
+	title = "Mangudai"
+	flag = F13MANGUDAI
+	faction = FACTION_KHAN
+	total_positions = 4
+	spawn_positions = 4
+	description = "You are a Mangudai, a warrior of the Great Khans who has passed the Trial of Position within the arena and earned their place. While your combat skills are to be respected, remember your position as a soldier - protect the Khan Fortress and Bighorn, show loyalty, and you may find chances yet to prove your greater worth."
+	supervisors = "the Noyan and Khanate"
+	selection_color = "#ff915e"
+	exp_type = EXP_TYPE_KHAN
+	outfit = /datum/outfit/job/khan/mangudai
+
+	loadout_options = list(
+		/datum/outfit/loadout/enforcer,
+		/datum/outfit/loadout/khanskirmisher,
+		/datum/outfit/loadout/khandrug,
+		)
+
+//=========================================================== LOADOUT DATUMS ===========================================================
+
+//KIPCHAK =================================================================
+
+/datum/outfit/loadout/miner
+	name = "Miner"
+	r_hand = /obj/item/pickaxe
+	l_hand = /obj/item/flashlight/lantern
+	belt = /obj/item/storage/bag/ore
+	backpack_contents = list(
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/shovel = 1)
+
+/datum/outfit/loadout/prospector
+	name = "Prospector"
+	r_hand = /obj/item/gun/ballistic/automatic/pistol/m1911/custom
+	l_hand = /obj/item/weldingtool/largetank
+	belt = /obj/item/storage/belt
+	mask = /obj/item/clothing/mask/gas/welding
+	backpack_contents = list(
+		/obj/item/wrench = 1,
+		/obj/item/ammo_box/magazine/m45 = 3,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/techno = 1)
+
+/datum/outfit/loadout/hunter
+	name = "Hunter"
+	r_hand = /obj/item/gun/ballistic/rifle/hunting
+	belt = /obj/item/storage/belt/bandolier
+	backpack_contents = list(
+		/obj/item/ammo_box/a308  = 3,
+		/obj/item/melee/onehanded/knife/hunting = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
+
+//MANGUDAI =================================================================
+
+/datum/outfit/loadout/enforcer
+	name = "Enforcer"
+	r_hand = /obj/item/twohanded/baseball/spiked
+	belt = /obj/item/storage/belt/bandolier
+	backpack_contents = list(
+		/obj/item/restraints/legcuffs/bola/tactical = 1,
+		/obj/item/book/granter/trait/bigleagues = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
+
+/datum/outfit/loadout/khanskirmisher
+	name = "Skirmisher"
+	r_hand = /obj/item/gun/ballistic/automatic/smg/mini_uzi
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/uzim9mm = 3,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/storage/belt/holster = 1)
+
+/datum/outfit/loadout/khandrug
+	name = "Drug Pusher"
+	belt = /obj/item/storage/belt/bandolier
+	backpack_contents = list(
+		/obj/item/book/granter/trait/midsurgery = 1,
+		/obj/item/book/granter/trait/chemistry = 1,
+		/obj/item/reagent_containers/pill/patch/turbo = 2)
+
+//KHORCHIN =================================================================
+
+/datum/outfit/loadout/fighter
+	name = "Fighter"
+	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
+	belt = /obj/item/storage/belt/bandolier
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/ammo_box/tube/m44 = 3,
+		/obj/item/book/granter/trait/bigleagues = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
+
+/datum/outfit/loadout/guard
+	name = "Guard"
+	r_hand = /obj/item/gun/ballistic/shotgun/trench
+	belt = /obj/item/storage/belt/bandolier
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/book/granter/trait/bigleagues = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
+
+/datum/outfit/loadout/protector
+	name = "protector"
+	r_hand = /obj/item/gun/ballistic/automatic/pistol/n99
+	l_hand = /obj/item/shield/riot/scrapshield
+	belt = /obj/item/storage/belt/bandolier
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m10mm_adv/simple = 3,
+		/obj/item/melee/onehanded/machete/scrapsabre = 1,
+		/obj/item/book/granter/trait/bigleagues = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3)
+
+//KESHIG ===================================================================
+
+/datum/outfit/loadout/veteran
+	name = "Veteran Fighter"
+	belt = /obj/item/storage/belt/bandolier
+	r_hand = /obj/item/gun/ballistic/automatic/m1garand
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/garand308 = 3,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+/datum/outfit/loadout/sprayer
+	name = "Sprayer"
+	belt = /obj/item/storage/belt/bandolier
+	r_hand = /obj/item/gun/ballistic/automatic/smg/smg10mm
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m10mm_adv/ext = 3,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+/datum/outfit/loadout/pusher
+	name = "Pusher"
+	belt = /obj/item/storage/backpack/spearquiver
+	l_hand = /obj/item/shield/riot/tower
+	r_hand = /obj/item/melee/onehanded/machete/scrapsabre
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	head = /obj/item/clothing/head/helmet/f13/khan
+	backpack_contents = list(
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+//STEWARD ==================================================================
+
+/datum/outfit/loadout/privileged
+	name = "Privileged"
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat/goji
+	glasses = /obj/item/clothing/glasses/wraith_spectacles
+	head = /obj/item/clothing/head/collectable/petehat/gang
+	r_hand = /obj/item/gun/ballistic/revolver/colt357/lucky
+	l_hand = /obj/item/twohanded/baseball/louisville
+	neck = /obj/item/storage/belt/holster
+	backpack_contents = list(
+		/obj/item/ammo_box/a357 = 3,
+		/obj/item/clipboard = 1,
+		/obj/item/pen = 1,
+		/obj/item/folder = 1)
+
+/datum/outfit/loadout/taxcollector
+	name = "Tax Collector"
+	glasses = /obj/item/clothing/glasses/sunglasses
+	r_hand = /obj/item/gun/ballistic/revolver/hunting
+	neck = /obj/item/storage/belt/holster
+	backpack_contents = list(
+		/obj/item/ammo_box/c4570 = 3,
+		/obj/item/twohanded/baseball = 1,
+		/obj/item/clipboard = 1,
+		/obj/item/pen = 1,
+		/obj/item/folder = 1)
+
+//NOYAN ====================================================================
+
+/datum/outfit/loadout/bigboss
+	name = "Big Boss"
+	belt =/obj/item/storage/belt/bandolier
+	r_hand = /obj/item/gun/ballistic/automatic/pistol/deagle/elcapitan
+	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/m14mm = 3,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+/datum/outfit/loadout/ironfist
+	name = "Iron Fist"
+	gloves = /obj/item/melee/powerfist/f13
+	belt = /obj/item/storage/belt/bandolier
+	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	backpack_contents = list(
+		/obj/item/restraints/legcuffs/bola/tactical = 1,
+		/obj/item/book/granter/trait/iron_fist  = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+/datum/outfit/loadout/peopleleader
+	name = "People's leader"
+	r_hand = /obj/item/gun/ballistic/revolver/revolver45
+	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	neck = /obj/item/storage/belt/holster
+	backpack_contents = list(
+		/obj/item/ammo_box/c45rev = 3,
+		/obj/item/restraints/legcuffs/bola/tactical = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)
+
+/datum/outfit/loadout/pacifier
+	name = "Pacifier"
+	r_hand = /obj/item/gun/ballistic/automatic/shotgun/riot
+	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket/coat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	backpack_contents = list(
+		/obj/item/ammo_box/magazine/d12g = 2,
+		/obj/item/ammo_box/shotgun/buck = 2,
+		/obj/item/restraints/legcuffs/bola/tactical = 1,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/book/granter/trait/bigleagues = 1)

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1122,6 +1122,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	r_pocket = /obj/item/flashlight/lantern
 	backpack_contents = list(
 		/obj/item/reagent_containers/pill/patch/healingpowder = 2,
+		/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus = 1,
 		/obj/item/warpaint_bowl
 		)
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -58,12 +58,14 @@ GLOBAL_LIST_INIT(command_positions, list(
 
 	"Legion Centurion",
 
-	"Chief of Police",
+	"Sheriff",
+	"Banker",
+	"Mayor",
 
 	"Enclave Lieutenant",
 
-	"Noyan",
-	"Steward",
+//	"Noyan",
+//	"Steward",
 	))
 
 GLOBAL_LIST_INIT(silicon_whitelist_positions, list(
@@ -138,6 +140,10 @@ GLOBAL_LIST_INIT(brotherhood_positions, list(
 
 GLOBAL_LIST_INIT(bighorn_positions, list(
 	"Shopkeeper",
+	"Sheriff",
+	"Mayor",
+	"Deputy",
+	"Banker",
 	"Barkeep",
 	"Preacher",
 	"Citizen",
@@ -205,7 +211,7 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
 	"Tribal",
 	"Wastelander",
 ))
-
+/*
 GLOBAL_LIST_INIT(khan_positions, list(
 	"Noyan",
 	"Steward",
@@ -213,6 +219,11 @@ GLOBAL_LIST_INIT(khan_positions, list(
 	"Khorchin",
 	"Kipchak",
 	"Mangudai",
+))
+*/
+GLOBAL_LIST_INIT(khan_positions, list(
+	"Khan Enforcer",
+	"Khan Chemist",
 ))
 
 GLOBAL_LIST_INIT(enclave_positions, list(

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -832,7 +832,7 @@
 //Police rifle			Keywords: OASIS, 5.56mm, Semi-auto, 20 (10-50) round magazine
 /obj/item/gun/ballistic/automatic/marksman/policerifle
 	name = "Police Rifle"
-	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Oasis Police Department. Held together by duct tape and prayers, it somehow still shoots."
+	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Bighorn Police Department. Held together by duct tape and prayers, it somehow still shoots."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -881,7 +881,7 @@
 
 /obj/item/gun/ballistic/automatic/marksman/policerifle
 	name = "Police Rifle"
-	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Oasis Police Department. Held together by duct tape and prayers, it somehow still shoots. This one has been re-chambered to 5.56"
+	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Bighorn Police Department. Held together by duct tape and prayers, it somehow still shoots. This one has been re-chambered to 5.56"
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -1290,7 +1290,7 @@
 	//Police rifle			Keywords: OASIS, 5mm, Semi-auto, 30 round magazine
 /obj/item/gun/ballistic/automatic/assault_carbine/policerifle
 	name = "Police Rifle"
-	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Oasis Police Department. Held together by duct tape and prayers, it somehow still shoots."
+	desc = "A pre-war Rifle that has been constantly repaired and rebuilt by the Bighorn Police Department. Held together by duct tape and prayers, it somehow still shoots."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'

--- a/code/modules/shuttle/f13.dm
+++ b/code/modules/shuttle/f13.dm
@@ -96,7 +96,7 @@
 
 /obj/machinery/computer/shuttle/vault113elevator
 	name = "vault 113 elevator controls"
-	desc = "Controls the elevator between the Vault and Oasis."
+	desc = "Controls the elevator between the Vault and Bighorn."
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"
 	light_color = LIGHT_COLOR_CYAN

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -426,9 +426,9 @@
 	path = /obj/item/clothing/head/helmet/blueshirt
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
 	cost = 3
-	restricted_desc = "Oasis PD, Oasis officials"
-	restricted_roles = list("Chief of Police",
-							"Officer",
+	restricted_desc = "Bighorn PD, Bighorn officials"
+	restricted_roles = list("Sheriff",
+							"Deputy",
 							"Mayor",
 							"Detective",
 							"Secretary",

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -194,13 +194,13 @@
 							)
 
 /datum/gear/suit/deputyvest
-	name = "OPD armor vest"
+	name = "BPD armor vest"
 	path = /obj/item/clothing/suit/armor/vest/oasis
 	subcategory = LOADOUT_SUBCATEGORY_SUIT_FACTIONS
 	cost = 4
-	restricted_desc = "Oasis Police, Oasis Officials"
-	restricted_roles = list("Chief of Police",
-							"Officer",
+	restricted_desc = "Bighorn Police, Bighorn Officials"
+	restricted_roles = list("Sheriff",
+							"Deputy",
 							"Mayor",
 							"Detective",
 							"Secretary",

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -150,7 +150,7 @@
 	name = "torn rags"
 	path = /obj/item/clothing/under/f13/rag
 
-//suits 
+//suits
 
 /datum/gear/uniform/suit
 	name = "black suit"
@@ -671,10 +671,10 @@
 	restricted_desc = "Oasis"
 	restricted_roles = list("Mayor",
 							"Secretary",
-							"Chief of Police",
+							"Sheriff",
 							"Doctor",
 							"Citizen",
-							"Officer",
+							"Deputy",
 							"Shopkeeper",
 							"Farmer",
 							"Prospector",
@@ -682,7 +682,7 @@
 							"Barkeep",
 							)
 
-//Khans 
+//Khans
 
 /datum/gear/uniform/khans
 	name = "great khans jorts"


### PR DESCRIPTION
- - -
The primary purpose of this PR is to devalue the roles of the Khans, that being inflated, and returning the Town to being an RP hub. This doesn't remove the Khans, just returns them to chem pushers. From the nonsense names to the replacement of Townie roles, it was a nightmare that this PR correct.
Their stated goal is to gather caps, for a nondescript 'Chief', assuredly the one that was previously in Bighorn. No more hugging it out in the temple of Pax.
- - - 
Balance:
 - Auxilia given one ambrosia deus.
 - Followers (DOCTORS) provided poor aim, to discourage combat-medic behaviour. Or actively seeking conflict. You know why this was done.
 - Bighorns' set of gates now begin closed. View additions for _why_.
 - Bank Vault door replaced by a standard command door, accessible by the returned roles.
 - MF's basement walls are surrounded by dense rock, so you can't skip the dungeon and deprive other players of loot without effort.
 - Guillotines removed from the front of Bighorn. Why is this a balance change? No clue.
 - Khans moved to the mining quarry west of MF. Adjustments made as necessary.
- - -
Additions:
 - Return of the Mayor, Sheriff, Banker and Deputy roles for the town, alongside their respective access and quarters. This retrofits the Khan building for this purpose.
- - -
Other notes:
 - All of the returned roles have all access, town wise, for the purpose of Roleplay, both law keeping and otherwise.
- - -
