### PR TITLE
Tables & NML

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -10,9 +10,9 @@
 "aab" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -2585,13 +2585,12 @@
 	},
 /area/f13/bunker)
 "aBy" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
+/mob/living/simple_animal/hostile/handy/assaultron{
+	color = "#75705a";
+	health = 600;
+	name = "assaultron dominator"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "aBL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2849,9 +2848,9 @@
 /area/f13/underground/cave)
 "aTE" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -3528,6 +3527,9 @@
 	light_color = "#ad1b1b"
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/robobrain{
+	name = "Conscripted Engineer"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "bNo" = (
@@ -3587,11 +3589,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/underground/cave)
 "bQv" = (
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "bRc" = (
 /obj/structure/car/rubbish2,
@@ -4445,10 +4447,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -4553,10 +4554,6 @@
 	light_color = "#ad1b1b"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "cXM" = (
@@ -5391,13 +5388,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
 "dNR" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
-/area/f13/bunker)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/city)
 "dNU" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -5919,7 +5913,9 @@
 	},
 /area/f13/bunker/bighornbunker)
 "epH" = (
-/mob/living/simple_animal/hostile/handy/robobrain,
+/mob/living/simple_animal/hostile/handy/robobrain{
+	name = "Conscripted Engineer"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
 "eqm" = (
@@ -6470,13 +6466,9 @@
 	},
 /area/f13/vault)
 "eZl" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eZL" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -6631,8 +6623,8 @@
 	},
 /area/f13/bunker/bighornbunker)
 "fjH" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bighornbunker)
 "fkd" = (
@@ -7032,7 +7024,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/f13,
 /area/f13/city)
 "fHH" = (
@@ -8249,11 +8241,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
 "hjh" = (
-/obj/item/stack/sheet/mineral/sandbags,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/shrapnel,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
+/obj/structure/bed/mattress/pregame,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "hji" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /obj/effect/decal/cleanable/dirt,
@@ -10631,14 +10622,10 @@
 	},
 /area/f13/underground/cave)
 "kal" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/f13,
+/area/f13/city)
 "kbB" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -12573,12 +12560,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
-"mll" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/shrapnel,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "mlU" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -14295,11 +14276,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"oeJ" = (
-/obj/structure/table/rolling,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "ofW" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
@@ -17552,6 +17528,10 @@
 "rPb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
 	},
@@ -17779,8 +17759,8 @@
 /area/f13/bunker)
 "seY" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/f13,
 /area/f13/city)
 "sfc" = (
@@ -18790,14 +18770,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"tri" = (
-/mob/living/simple_animal/hostile/handy/assaultron{
-	color = "#75705a";
-	health = 600;
-	name = "assaultron dominator"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bunker)
 "trH" = (
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
@@ -19053,16 +19025,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"tHt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/bunker)
 "tIh" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2left"
@@ -19755,6 +19717,10 @@
 	},
 /obj/effect/overlay/junk/oldpipes{
 	dir = 9
+	},
+/mob/living/simple_animal/hostile/handy/protectron{
+	health = 260;
+	name = "protectron guardian"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
@@ -22827,15 +22793,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/underground/cave)
-"ycZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/securitron{
-	health = 250;
-	name = "securitron mk.2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker)
 "ydW" = (
 /obj/item/flashlight/seclite,
 /obj/item/clothing/head/ushanka,
@@ -24709,7 +24666,7 @@ lix
 shC
 aTA
 aTA
-eld
+eZl
 bVH
 bVH
 bVH
@@ -33467,7 +33424,7 @@ szp
 lPS
 szp
 sfc
-trH
+hjh
 uLm
 tGX
 tGX
@@ -33750,7 +33707,7 @@ oFc
 sQz
 jdd
 uba
-xwj
+kal
 jdd
 huP
 sQz
@@ -38548,7 +38505,7 @@ uRL
 akh
 akh
 xrg
-bxU
+dNR
 xrg
 xrg
 nnl
@@ -53847,7 +53804,7 @@ wOd
 cDz
 oqm
 sye
-cDz
+aBy
 oqm
 uJZ
 cDz
@@ -54876,7 +54833,7 @@ pfW
 bNh
 cDz
 pfW
-tri
+cDz
 qzI
 cDz
 dtz
@@ -58987,8 +58944,8 @@ oqm
 aOJ
 kyn
 oqm
+xPT
 pcV
-dNR
 pcV
 qZq
 oqm
@@ -60018,7 +59975,7 @@ oqm
 ujN
 jLV
 hCz
-dNR
+xPT
 oqm
 aSH
 kqq
@@ -60269,7 +60226,7 @@ shC
 shC
 shC
 pIE
-mgq
+aab
 jcd
 oqm
 ujN
@@ -60526,7 +60483,7 @@ shC
 shC
 shC
 oqm
-aTE
+fFC
 ngb
 lyZ
 ujN
@@ -60784,7 +60741,7 @@ shC
 shC
 vpm
 mnO
-kal
+aOJ
 oqm
 pcV
 oZm
@@ -61305,7 +61262,7 @@ oqm
 oqm
 oqm
 oqm
-cRm
+rcQ
 cWE
 oqm
 shC
@@ -62848,7 +62805,7 @@ bgL
 mmR
 oqm
 aOJ
-mxg
+cRm
 oqm
 shC
 shC
@@ -63354,7 +63311,7 @@ oqm
 qKi
 oqm
 fxR
-aOJ
+vfQ
 oqm
 fpS
 viG
@@ -63867,7 +63824,7 @@ lWc
 bxz
 bwm
 mNJ
-hjh
+dQk
 nLW
 oqm
 tUD
@@ -64112,10 +64069,10 @@ shC
 shC
 oqm
 dPd
-ycZ
-aBy
-eZl
-eZl
+mzc
+dwQ
+wKJ
+wKJ
 dvm
 oqm
 myz
@@ -64124,7 +64081,7 @@ aaa
 oqm
 oqm
 oqm
-fFC
+aTE
 fFC
 oqm
 oqm
@@ -64382,7 +64339,7 @@ oqm
 shC
 oqm
 fFC
-oeJ
+fFC
 oqm
 shC
 shC
@@ -65401,7 +65358,7 @@ oqm
 nlM
 fFC
 fFC
-aSH
+pwG
 oqm
 shC
 shC
@@ -65418,7 +65375,7 @@ shC
 shC
 oqm
 aOJ
-tHt
+mxg
 oqm
 czy
 cAP
@@ -65918,13 +65875,13 @@ aOJ
 aOJ
 jnK
 skf
-bQv
+aSH
 mxf
 fFC
 fFC
 umF
 dJU
-mll
+qrZ
 umF
 aSH
 mfn
@@ -66173,7 +66130,7 @@ iAy
 aOJ
 fFC
 poU
-bQv
+aSH
 fFC
 uiV
 fFC
@@ -67466,7 +67423,7 @@ shC
 shC
 pIE
 vYb
-aab
+mgq
 bEj
 hZK
 hCD
@@ -67725,7 +67682,7 @@ oqm
 rcQ
 aOJ
 cDz
-cDz
+bQv
 bUQ
 hrp
 oqm
@@ -68493,7 +68450,7 @@ shC
 shC
 shC
 oqm
-bQv
+aSH
 aSH
 aOJ
 aSH

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -16052,6 +16052,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"urR" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "utC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17280,9 +17284,7 @@
 	},
 /area/f13/followers)
 "wBd" = (
-/obj/machinery/radioterminal/bos{
-	density = 1
-	},
+/obj/machinery/radioterminal/bos,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
@@ -33612,7 +33614,7 @@ qWu
 qWu
 qWu
 bCt
-dFQ
+urR
 bCt
 bOm
 bOm
@@ -36738,7 +36740,7 @@ bPR
 abb
 bCt
 bCt
-dFQ
+urR
 bCt
 bCt
 abb

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -343,6 +343,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
+"LQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city/bighorn)
 "LT" = (
 /obj/structure/table/wood,
 /obj/item/melee/onehanded/machete/training,
@@ -5929,7 +5937,7 @@ Dj
 OF
 HH
 Bu
-Bu
+LQ
 YA
 Bu
 YA

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1048,9 +1048,9 @@
 /area/f13/building/mall)
 "ayb" = (
 /obj/machinery/chem_dispenser/drinks{
+	density = 0;
 	dir = 1;
-	pixel_y = -15;
-	density = 0
+	pixel_y = -15
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
@@ -1633,8 +1633,8 @@
 	pixel_y = 11
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 6;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 6
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
@@ -1895,12 +1895,12 @@
 "csE" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles{
-	pixel_y = 14;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 14
 	},
 /obj/item/storage/box/gloves{
-	pixel_y = 4;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
@@ -2141,8 +2141,8 @@
 "dcv" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
-	pixel_y = 14;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 14
 	},
 /obj/item/storage/box/beakers{
 	pixel_x = -6;
@@ -5107,8 +5107,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 8;
-	termtag = "Private";
-	pixel_y = 5
+	pixel_y = 5;
+	termtag = "Private"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
@@ -5434,9 +5434,9 @@
 /area/f13/followers)
 "lzz" = (
 /obj/machinery/chem_dispenser/drinks/beer{
+	density = 0;
 	dir = 1;
-	pixel_y = -15;
-	density = 0
+	pixel_y = -15
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
@@ -6201,6 +6201,10 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"ngO" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "nhp" = (
 /turf/closed/wall,
 /area/f13/building/mall)
@@ -7346,6 +7350,14 @@
 	},
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
+"pQw" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/window/spawner/north,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "pQE" = (
 /obj/structure/mirror,
 /turf/closed/wall/f13/store,
@@ -7379,6 +7391,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
+"pXF" = (
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "pXR" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/door/window/right{
@@ -7933,6 +7952,13 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/city/bighorn)
+"reF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/window/spawner/north,
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "reH" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -8331,7 +8357,6 @@
 "slA" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/door/window/right{
-	dir = 2;
 	req_one_access_txt = "120"
 	},
 /turf/open/floor/f13{
@@ -9518,8 +9543,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 4;
-	termtag = "Business";
-	pixel_y = 5
+	pixel_y = 5;
+	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood)
@@ -9528,6 +9553,13 @@
 /obj/item/book/manual/wiki/grenades,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"uFI" = (
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -3
+	},
+/turf/open/floor/f13/wood,
+/area/f13/brotherhood)
 "uFO" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -10497,6 +10529,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"xuH" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/f13/wood,
+/area/f13/city/bighorn)
 "xuM" = (
 /turf/closed/wall/f13/wood,
 /area/f13/city/bighorn)
@@ -12911,10 +12947,10 @@ abO
 ucW
 unf
 ucW
-wDR
+ngO
 gkd
 gkd
-wDR
+ngO
 wDR
 wDR
 wDR
@@ -13941,12 +13977,12 @@ xuM
 xuM
 cUT
 xuM
-wDR
+ngO
 xuM
 xuM
 xuM
 xuM
-wDR
+ngO
 cUT
 cUT
 xuM
@@ -14718,7 +14754,7 @@ aby
 qmn
 qWS
 wDR
-wDR
+ngO
 gkd
 acj
 aco
@@ -14975,7 +15011,7 @@ wDR
 wDR
 wDR
 wDR
-wDR
+ngO
 gkd
 acj
 aIJ
@@ -15489,7 +15525,7 @@ wDR
 wDR
 wDR
 wDR
-wDR
+ngO
 gkd
 acj
 aIJ
@@ -15746,7 +15782,7 @@ aby
 aby
 wDR
 wDR
-wDR
+ngO
 gkd
 acj
 aIJ
@@ -16508,15 +16544,15 @@ xuM
 abf
 xuM
 xuM
-gkd
+xuH
 xuM
 xuM
-gkd
+xuH
 xuM
 xuM
 xuM
 xuM
-wDR
+ngO
 xuM
 meo
 ack
@@ -18572,7 +18608,7 @@ dvF
 xuM
 abN
 pNa
-gkd
+xuH
 gkd
 gkd
 xuM
@@ -66611,7 +66647,7 @@ abv
 abv
 abv
 abv
-abv
+jNF
 jNF
 jNF
 jNF
@@ -66868,10 +66904,10 @@ abv
 abv
 abv
 abv
-abv
 jNF
+cED
 hqd
-xtN
+reF
 cED
 cED
 cED
@@ -67125,9 +67161,9 @@ abv
 abv
 abv
 abv
-abv
 jNF
 cED
+uFI
 cED
 cED
 cED
@@ -70209,9 +70245,9 @@ abv
 abv
 abv
 abv
-abv
 jNF
 cED
+pXF
 cED
 cED
 cED
@@ -70466,10 +70502,10 @@ abv
 abv
 abv
 abv
-abv
 jNF
+cED
 hqd
-aiR
+pQw
 cED
 cED
 cED
@@ -70723,7 +70759,7 @@ abv
 abv
 abv
 abv
-abv
+jNF
 jNF
 jNF
 jNF

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -713,6 +713,7 @@
 /area/f13/building/bighornbunker)
 "acE" = (
 /obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -3121,7 +3122,7 @@
 /area/f13/caves)
 "alO" = (
 /obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "alP" = (
@@ -3708,7 +3709,10 @@
 /obj/structure/decoration/rag{
 	layer = 8
 	},
-/obj/structure/simple_door/metal/fence,
+/obj/structure/simple_door/metal/fence{
+	req_access_txt = "62";
+	req_one_access_txt = "62"
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
 	icon_state = "outerpavement"
@@ -4437,13 +4441,14 @@
 	},
 /area/f13/tunnel/northwest)
 "aru" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/tunnel/southeast)
+/obj/effect/landmark/start/f13/khan_chemist,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "arx" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "ary" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -4483,6 +4488,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "arJ" = (
@@ -4665,7 +4671,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "asu" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13{
@@ -4684,7 +4690,7 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "asB" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/desert,
@@ -4916,8 +4922,9 @@
 	},
 /area/f13/brotherhood)
 "atv" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/tunnel/southeast)
+/obj/effect/landmark/start/f13/khan,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aty" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -5085,7 +5092,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "aue" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/ruins,
@@ -5153,7 +5160,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "aut" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
@@ -5197,7 +5204,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "auB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5686,7 +5693,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "awg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -5962,7 +5969,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "awW" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel/southwest)
@@ -10167,8 +10174,8 @@
 /area/f13/bar/heaven)
 "aKD" = (
 /obj/structure/ladder/unbreakable{
-	name = "Secret Hatch";
-	id = "Bos Bunker"
+	id = "Bos Bunker";
+	name = "Secret Hatch"
 	},
 /turf/open/floor/f13{
 	color = "#818181";
@@ -14360,12 +14367,10 @@
 	},
 /area/f13/wasteland/east)
 "aYh" = (
-/obj/structure/beebox/premade/random,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland/west)
+/obj/machinery/light/small,
+/obj/effect/landmark/start/f13/khan,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "aYj" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/barber{
@@ -18611,7 +18616,7 @@
 /area/f13/tunnel/northwest)
 "bmi" = (
 /turf/closed/indestructible/rock,
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "bmj" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -19613,9 +19618,9 @@
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
 "bqD" = (
-/obj/item/sign/bee_warning,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/west)
+/obj/effect/landmark/start/f13/khan,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "bqF" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/suit/armor/bulletproof,
@@ -20177,6 +20182,11 @@
 	icon_state = "floordirty"
 	},
 /area/f13/brotherhood)
+"bvf" = (
+/obj/structure/chair,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "bvh" = (
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/floor/wood/wood_mosaic,
@@ -21400,6 +21410,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"bOT" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/f13/wood,
+/area/f13/city/bighorn)
 "bPg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21463,8 +21477,8 @@
 "bRl" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -23786,8 +23800,8 @@
 /area/f13/wasteland/east)
 "cwm" = (
 /obj/structure/closet/crate/bin{
-	pixel_y = 27;
-	density = 0
+	density = 0;
+	pixel_y = 27
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -23894,17 +23908,6 @@
 /obj/item/radio/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/museum)
-"cyT" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bosgateoutside"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "cyZ" = (
 /obj/structure/fence{
 	dir = 4
@@ -24103,8 +24106,8 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_y = 29;
-	density = 0
+	density = 0;
+	pixel_y = 29
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -24438,11 +24441,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "cRy" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/landmark/start/f13/khan,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood)
+/area/f13/building)
 "cRG" = (
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24672,13 +24676,18 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/mall)
+"dbM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dcd" = (
 /turf/closed/indestructible/f13/matrix/transition{
 	destination_x = 2;
 	destination_y = 40;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "dce" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -25526,6 +25535,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/east)
+"dFZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "dGa" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -25672,6 +25689,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/massfusion)
+"dKt" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2"
+	},
+/area/f13/wasteland/west)
 "dKw" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -26092,6 +26115,10 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ebu" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/wood/wood_worn,
+/area/f13/city/bighorn)
 "ebC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -26154,8 +26181,9 @@
 	},
 /area/f13/wasteland/museum)
 "eeF" = (
-/turf/closed/wall/r_wall,
-/area/f13/wasteland/valley)
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/quarry)
 "eeK" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -26316,7 +26344,10 @@
 /area/f13/building)
 "elW" = (
 /mob/living/simple_animal/hostile/bear/yaoguai{
-	health = 600
+	armour_penetration = 0.5;
+	desc = "A mutated American black bear, sporting razor sharp teeth, claws, and a nasty temper. This one appears to be criminally underfed.";
+	health = 600;
+	name = "famished yao guai"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -27338,7 +27369,7 @@
 	destination_y = 33;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "eUK" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -27789,13 +27820,9 @@
 	},
 /area/f13/building/massfusion)
 "fij" = (
-/obj/structure/fence/wooden{
-	pixel_x = -14
-	},
-/turf/open/indestructible/ground/outside/savannah{
-	icon_state = "savannah8"
-	},
-/area/f13/brotherhood)
+/obj/effect/spawner/lootdrop/f13/bomb/tier3,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "fiO" = (
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/supermart,
@@ -27833,6 +27860,7 @@
 /area/f13/wasteland/east)
 "fkj" = (
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "fkm" = (
@@ -28247,7 +28275,7 @@
 	destination_y = 36;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "fyX" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
@@ -28332,6 +28360,7 @@
 "fAr" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "fAw" = (
@@ -28363,6 +28392,7 @@
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fAV" = (
@@ -29432,6 +29462,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"gpD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "gpG" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 10;
@@ -29650,8 +29685,9 @@
 	},
 /area/f13/wasteland/firestation)
 "gzp" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -3
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -30208,7 +30244,7 @@
 	destination_y = 32;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "gQp" = (
 /obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
@@ -30676,6 +30712,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"heN" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "heQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -30831,6 +30872,7 @@
 /area/f13/tunnel)
 "hmI" = (
 /obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hmT" = (
@@ -31168,6 +31210,11 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
+"hAy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/f13/wood,
+/area/f13/city/bighorn)
 "hAB" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/item/reagent_containers/glass/bucket,
@@ -31200,6 +31247,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hBB" = (
@@ -31351,6 +31399,7 @@
 /obj/structure/sign/poster/contraband/pinup_claw1{
 	pixel_y = 32
 	},
+/obj/item/twohanded/spear/bonespear/deathclaw,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "hIS" = (
@@ -31486,7 +31535,7 @@
 	destination_y = 38;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "hOC" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -31679,6 +31728,7 @@
 	icon_state = "mattress4";
 	pixel_y = -2
 	},
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hVj" = (
@@ -33696,6 +33746,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
+"jfz" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jfH" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2top"
@@ -34869,6 +34923,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"jUU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/radiation{
+	pixel_y = -32
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jVs" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/desert,
@@ -34905,6 +34966,11 @@
 	icon_state = "savannah4"
 	},
 /area/f13/wasteland/valley)
+"jWz" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "jXr" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34926,6 +34992,14 @@
 /obj/item/shovel/spade,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
+"jYW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "jZx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -35324,6 +35398,12 @@
 /obj/item/clothing/under/f13/cowboyt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
+"kqw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "kqy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35911,6 +35991,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "kJP" = (
@@ -36966,6 +37047,10 @@
 /area/f13/wasteland/heaven)
 "luu" = (
 /obj/structure/simple_door/metal/store,
+/obj/machinery/door/poddoor/shutters{
+	id = "mus1";
+	layer = 11
+	},
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
 	},
@@ -37290,10 +37375,9 @@
 	},
 /area/f13/wasteland/west)
 "lGE" = (
-/turf/open/floor/plasteel/stairs{
-	color = "#4b3a26"
-	},
-/area/f13/brotherhood)
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lGG" = (
 /obj/structure/tires/two,
 /obj/effect/decal/cleanable/dirt,
@@ -37849,7 +37933,17 @@
 	},
 /area/f13/building/massfusion)
 "lVz" = (
-/obj/machinery/light,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bosgateoutside"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lVG" = (
@@ -38528,7 +38622,7 @@
 /area/f13/wasteland/east)
 "mrI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "msu" = (
@@ -38596,8 +38690,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mvu" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bosgateoutside"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -38814,8 +38913,8 @@
 "mBw" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -38897,6 +38996,7 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/start/f13/khan,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mFy" = (
@@ -39015,6 +39115,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mIF" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/west)
 "mIK" = (
 /obj/structure/table/glass,
 /obj/machinery/light/broken,
@@ -39208,6 +39312,12 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/heaven)
+"mQN" = (
+/obj/structure/sign/warning/radiation{
+	pixel_x = 32
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland/museum)
 "mQV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -39560,6 +39670,10 @@
 	icon_state = "blueyellowfull"
 	},
 /area/f13/building/mall)
+"ndT" = (
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "nec" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -41277,17 +41391,9 @@
 	},
 /area/f13/building/bighornbunker)
 "omh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bosgateoutside"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "omt" = (
@@ -41603,8 +41709,8 @@
 /area/f13/wasteland/museum)
 "ovr" = (
 /obj/machinery/vending/dinnerware{
-	pixel_y = -7;
-	density = 0
+	density = 0;
+	pixel_y = -7
 	},
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood)
@@ -41659,6 +41765,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/firestation)
+"oxR" = (
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building/museum)
 "oyh" = (
 /obj/machinery/light{
 	dir = 4
@@ -42223,7 +42335,7 @@
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
 	},
-/area/f13/wasteland/valley)
+/area/f13/caves)
 "oOU" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -42311,6 +42423,16 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/valley)
+"oQI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/machinery/door/unpowered/secure_bos,
+/obj/machinery/door/poddoor/shutters{
+	id = "bosgateoutside"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oQP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -42937,11 +43059,12 @@
 	},
 /area/f13/building/massfusion)
 "poN" = (
-/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13{
-	icon_state = "floordirty"
+	icon_state = "bar"
 	},
-/area/f13/building/museum)
+/area/f13/building)
 "ppc" = (
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
@@ -42962,6 +43085,7 @@
 /area/f13/building/museum)
 "ppV" = (
 /obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "pqO" = (
@@ -43452,6 +43576,11 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland/museum)
+"pEe" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pEm" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -43593,7 +43722,7 @@
 	destination_y = 35;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "pJY" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -43608,7 +43737,7 @@
 "pKA" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/closed/wall/r_wall,
-/area/f13/wasteland/valley)
+/area/f13/caves)
 "pKL" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43867,7 +43996,7 @@
 	destination_y = 37;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "pVH" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt{
@@ -44534,15 +44663,12 @@
 	},
 /area/f13/village)
 "qrs" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/door/unpowered/secure_bos,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosgateoutside"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13,
+/area/f13/building)
 "qrv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/random,
@@ -45491,7 +45617,7 @@
 	destination_y = 39;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "rbE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -45726,7 +45852,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/machinery/door/unpowered/secure_bos,
 /turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland/valley)
+/area/f13/caves)
 "rjo" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8
@@ -45917,13 +46043,10 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "roK" = (
-/obj/structure/nest/securitron{
-	max_mobs = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building/museum)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13,
+/area/f13/building)
 "rpj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -47178,7 +47301,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/mall)
 "sgo" = (
-/mob/living/simple_animal/hostile/deathclaw/playable,
+/obj/item/stack/sheet/animalhide/deathclaw,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "sgp" = (
@@ -47468,8 +47591,9 @@
 	},
 /area/f13/building/hospital)
 "sqg" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
 	},
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood)
@@ -47662,6 +47786,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"sxL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "syG" = (
 /obj/machinery/computer/operating,
 /obj/machinery/light,
@@ -47787,7 +47916,7 @@
 	destination_y = 34;
 	destination_z = 9
 	},
-/area/f13/tunnel/southeast)
+/area/f13/tunnel)
 "sCs" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaltop"
@@ -48581,6 +48710,16 @@
 	dir = 6
 	},
 /area/f13/building/hospital)
+"thC" = (
+/obj/structure/nest/protectron{
+	layer = 3;
+	max_mobs = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building/museum)
 "thI" = (
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
@@ -50349,7 +50488,8 @@
 "uno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "uod" = (
@@ -51760,6 +51900,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vdV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/radiation{
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "veD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright2bottom"
@@ -53770,12 +53917,9 @@
 	},
 /area/f13/wasteland/east)
 "wzH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/machinery/door/unpowered/securedoor/sheriff_door,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/city/bighorn)
 "wzN" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -53805,6 +53949,11 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
+"wAK" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/wood/wood_wide,
+/area/f13/caves)
 "wBe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -55624,7 +55773,7 @@
 	},
 /area/f13/wasteland/east)
 "xHo" = (
-/obj/structure/nest/securitron,
+/obj/structure/nest/protectron,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "xHG" = (
@@ -56051,8 +56200,8 @@
 /area/f13/wasteland/bighorn)
 "xVT" = (
 /obj/machinery/button/door{
-	pixel_y = 10;
-	id = "BoS Inside"
+	id = "BoS Inside";
+	pixel_y = 10
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
@@ -57654,7 +57803,7 @@ wEd
 wEd
 wEd
 wEd
-bqD
+wEd
 wEd
 wEd
 wEd
@@ -58057,7 +58206,7 @@ tMs
 tMs
 mHZ
 mHZ
-mHZ
+bOT
 xIY
 xIY
 xIY
@@ -58825,7 +58974,7 @@ tMs
 aaW
 yja
 iro
-mHZ
+bOT
 mHZ
 iro
 tMs
@@ -58960,7 +59109,7 @@ vOV
 aXp
 vOV
 iUD
-aYh
+iKu
 wEd
 aae
 aae
@@ -59342,7 +59491,7 @@ piC
 tMs
 mHZ
 bqb
-mHZ
+bOT
 mHZ
 kir
 sTW
@@ -59597,7 +59746,7 @@ tMs
 tMs
 tMs
 tMs
-mHZ
+bOT
 tMs
 tMs
 oeK
@@ -61273,7 +61422,7 @@ brV
 aCL
 aEG
 aAf
-oUj
+fij
 hhC
 aJx
 aae
@@ -62167,7 +62316,7 @@ tMs
 tMs
 tMs
 tMs
-iro
+hAy
 tMs
 tMs
 xIY
@@ -62292,7 +62441,7 @@ vOV
 vOV
 vOV
 pUh
-bqD
+wEd
 wEd
 wEd
 wEd
@@ -62683,7 +62832,7 @@ bqd
 tMs
 iro
 mHZ
-xIY
+ebu
 xIY
 axX
 ays
@@ -62799,7 +62948,7 @@ qzv
 aHF
 aHF
 pUh
-bqD
+wEd
 wEd
 xOD
 cvl
@@ -62937,7 +63086,7 @@ tMs
 bnU
 xIY
 xIY
-xIY
+ebu
 iro
 iro
 tMs
@@ -64242,7 +64391,7 @@ aae
 aae
 nEd
 ccn
-osA
+pat
 bVO
 nEd
 asS
@@ -70153,7 +70302,7 @@ bzB
 bzB
 kFK
 xqH
-osA
+pat
 qkH
 kFK
 aae
@@ -72425,7 +72574,7 @@ aTw
 bjq
 bjq
 bjq
-akX
+wzH
 bjq
 bjq
 ydE
@@ -72679,7 +72828,7 @@ jYk
 ygj
 aTw
 akX
-akX
+wzH
 akX
 bxu
 akX
@@ -75539,10 +75688,10 @@ yjm
 ydE
 bjq
 bjq
-blj
+gpD
 bjq
 bjq
-lUX
+ndT
 bjq
 bjq
 bar
@@ -78080,7 +78229,7 @@ lKy
 daa
 bGu
 nzp
-uRS
+mIF
 ygj
 aTw
 aTw
@@ -78847,7 +78996,7 @@ vxN
 foi
 vxN
 hvO
-wOD
+dKt
 wOD
 kIF
 gjk
@@ -85325,7 +85474,7 @@ hyc
 aaB
 aaB
 aaB
-aae
+aaa
 aaa
 "}
 (113,1,1) = {"
@@ -85834,7 +85983,7 @@ hVy
 rkl
 rkl
 aae
-aae
+aaa
 aaa
 ulL
 elW
@@ -86091,7 +86240,7 @@ wEd
 wEd
 wEd
 aae
-aae
+aaa
 aaa
 aaB
 aaB
@@ -86348,12 +86497,12 @@ wEd
 wEd
 wEd
 wEd
-aae
-aae
+aaa
+aaa
 kiu
 jSK
 aaB
-aae
+aaa
 aaa
 "}
 (117,1,1) = {"
@@ -86605,12 +86754,12 @@ wEd
 wEd
 wEd
 wEd
-aae
+aaa
 aaa
 aaa
 gDj
 aaa
-aae
+aaa
 aaa
 "}
 (118,1,1) = {"
@@ -86862,12 +87011,12 @@ wEd
 wEd
 wEd
 wEd
-aae
+aaa
 aaa
 eNC
 oOx
-aae
-aae
+aaa
+aaa
 aaa
 "}
 (119,1,1) = {"
@@ -87119,12 +87268,12 @@ wEd
 wEd
 wEd
 wEd
-aae
+aaa
 aaa
 vJK
 aaa
-aae
-aae
+aaa
+aaa
 aaa
 "}
 (120,1,1) = {"
@@ -87376,12 +87525,12 @@ jns
 jns
 jns
 kVc
-aae
-aae
-aaB
 aaa
-aae
-aae
+aaa
+gDj
+aaa
+aaa
+aaa
 aaa
 "}
 (121,1,1) = {"
@@ -87633,12 +87782,12 @@ jns
 jns
 jns
 jns
-aae
 aaa
+afn
 vJK
 geq
+afn
 aaa
-aae
 aaa
 "}
 (122,1,1) = {"
@@ -87890,12 +88039,12 @@ jns
 jns
 jns
 jns
-aae
-aae
+aaa
+aaa
 aaa
 aaB
 kiu
-aae
+aaa
 aaa
 "}
 (123,1,1) = {"
@@ -88149,10 +88298,10 @@ jns
 jns
 aae
 aae
-aae
+aaa
 aaB
 vJK
-aae
+aaa
 aaa
 "}
 (124,1,1) = {"
@@ -88406,10 +88555,10 @@ jns
 kDp
 aae
 aae
-aae
+aaa
 aaB
 aaB
-aae
+aaa
 aaa
 "}
 (125,1,1) = {"
@@ -88663,10 +88812,10 @@ xyM
 ksO
 aae
 aae
-aae
+aaa
 abV
 aaa
-aae
+aaa
 aaa
 "}
 (126,1,1) = {"
@@ -90489,7 +90638,7 @@ xyU
 xyU
 ajF
 rRH
-xyU
+atv
 afb
 ajF
 aaa
@@ -90959,8 +91108,8 @@ gLq
 goh
 goh
 goh
-poN
-poN
+bqw
+bqw
 goh
 adl
 adl
@@ -91511,7 +91660,7 @@ wXH
 abY
 abY
 adO
-hZD
+aYh
 oiZ
 adO
 adO
@@ -92285,12 +92434,12 @@ adO
 acN
 ajF
 adO
-adO
+bqD
 aek
 ajF
 iqB
 acC
-acC
+cRy
 afI
 ajF
 aaa
@@ -94287,7 +94436,7 @@ goh
 jaE
 tCQ
 bfo
-bfo
+jYW
 bfo
 acV
 csX
@@ -95057,7 +95206,7 @@ swq
 goh
 iqS
 jaE
-jaE
+jWz
 jaE
 jaE
 jaE
@@ -95107,7 +95256,7 @@ rkl
 aae
 rkl
 mRs
-xyU
+atv
 dHr
 dAO
 ndo
@@ -95569,14 +95718,14 @@ xZN
 bgH
 wdP
 goh
-wGr
+oxR
 ibr
 acV
 jaE
 jaE
-jaE
+jWz
 acV
-csX
+dFZ
 goh
 bhT
 gZf
@@ -96095,7 +96244,7 @@ acV
 jaE
 oev
 oev
-oev
+uno
 cKE
 yeo
 gVo
@@ -96384,7 +96533,7 @@ aaa
 aae
 aae
 rkl
-xyU
+aru
 qmV
 xyU
 xyU
@@ -96854,12 +97003,12 @@ xZN
 cKl
 reb
 goh
-bou
+bvf
 kVR
 iQL
 acV
 jaE
-oev
+kqw
 oev
 arH
 goh
@@ -97902,8 +98051,8 @@ coA
 bhN
 aSi
 goh
+thC
 bhp
-roK
 bub
 bhp
 aQb
@@ -98986,7 +99135,7 @@ xjM
 xjM
 prR
 cpq
-cpq
+eeF
 cpq
 cpq
 cpq
@@ -99263,7 +99412,7 @@ cpq
 cpq
 cpq
 izc
-cpq
+eeF
 cpq
 cpq
 nCn
@@ -99439,7 +99588,7 @@ aae
 aae
 jns
 jns
-jns
+mQN
 jns
 jns
 jns
@@ -99694,11 +99843,11 @@ aae
 aae
 aae
 aae
-adg
-cyT
-qrs
+afn
 omh
-adg
+pal
+omh
+afn
 aae
 aae
 aae
@@ -99951,11 +100100,11 @@ aae
 aae
 aae
 aae
-adg
+aae
 rRe
+mrI
 rRe
-aaB
-adg
+aae
 aae
 aae
 aae
@@ -100208,11 +100357,11 @@ aae
 aak
 aae
 aae
-pal
+asS
+dbM
 rRe
 rRe
-rRe
-adg
+aae
 aae
 aae
 aae
@@ -100465,11 +100614,11 @@ aae
 aak
 aae
 aae
-pal
-wzH
-aaB
+asS
+rRe
+rRe
 mrI
-adg
+aae
 aae
 asS
 aae
@@ -100539,7 +100688,7 @@ cpq
 cpq
 cpq
 cpq
-cpq
+eeF
 cpq
 cpq
 cpq
@@ -100722,11 +100871,11 @@ aae
 aak
 aae
 aae
+lpt
+mrI
 pal
-rRe
-aaB
-aaB
-pal
+pEe
+afn
 aae
 asS
 asS
@@ -100979,11 +101128,11 @@ aae
 aak
 aae
 aak
-pal
+asS
+dbM
 rRe
 rRe
-rRe
-pal
+asS
 aae
 asS
 asS
@@ -101236,11 +101385,11 @@ aae
 aae
 aae
 aak
-pal
+asS
 rRe
 rRe
 rRe
-pal
+asS
 aae
 asS
 asS
@@ -101493,11 +101642,11 @@ aae
 aae
 aae
 aak
-pal
-rRe
-aaB
-aaB
-adg
+asS
+mrI
+heN
+mrI
+aae
 aae
 asS
 asS
@@ -101750,11 +101899,11 @@ aae
 aae
 aae
 aak
+lpt
+rRe
 pal
 rRe
-aaB
-aaB
-pal
+lpt
 aak
 hdm
 aae
@@ -102007,11 +102156,11 @@ aae
 aae
 aae
 aae
-adg
+aae
+pEe
 rRe
-aaB
-rRe
-adg
+mrI
+aae
 aak
 hdm
 aae
@@ -102264,11 +102413,11 @@ aae
 aae
 aae
 aae
-adg
+aae
+mrI
 rRe
-aaB
-rRe
-adg
+dbM
+aae
 aak
 aak
 aae
@@ -102521,11 +102670,11 @@ aae
 aae
 aae
 aae
-adg
+aae
 rRe
-aaB
 rRe
-adg
+mrI
+aae
 aae
 aae
 aae
@@ -102778,11 +102927,11 @@ aae
 aae
 aae
 aae
-adg
+lpt
+dbM
+pal
 rRe
-rRe
-aaB
-adg
+lpt
 atS
 atS
 atS
@@ -102861,7 +103010,7 @@ cpq
 cpq
 cpq
 cpq
-cpq
+eeF
 cpq
 cpq
 nrn
@@ -103035,12 +103184,12 @@ aae
 aae
 aae
 aae
-adg
-rRe
-rRe
-aaB
-adg
 aae
+rRe
+mrI
+rRe
+aae
+atS
 aae
 aae
 aae
@@ -103292,12 +103441,12 @@ aae
 aae
 aae
 aae
-adg
-aaB
-rRe
-aaB
-adg
 aae
+mrI
+rRe
+rRe
+aae
+atS
 aae
 aae
 aae
@@ -103548,13 +103697,13 @@ aae
 aae
 aae
 aae
-aae
+atS
 adg
 mvu
-rRe
+oQI
 lVz
 adg
-aak
+atS
 aak
 aak
 aak
@@ -103641,7 +103790,7 @@ cpq
 cpq
 cpq
 cpq
-gGg
+nCn
 gGg
 mCP
 ejj
@@ -103805,11 +103954,11 @@ aaa
 aae
 aae
 aae
-aak
+atS
 adg
-rRe
+vdV
 aaB
-rRe
+jUU
 adg
 aae
 aae
@@ -103898,7 +104047,7 @@ cpq
 cpq
 cpq
 cpq
-gGg
+nCn
 gGg
 gGg
 ejj
@@ -104062,7 +104211,7 @@ aaa
 aae
 aae
 aae
-aak
+atS
 adg
 rRe
 aaB
@@ -104155,7 +104304,7 @@ aae
 aae
 aae
 cpq
-gGg
+nCn
 gGg
 gGg
 ejj
@@ -104319,7 +104468,7 @@ aaa
 aae
 aae
 aae
-aak
+atS
 adg
 rRe
 aaB
@@ -104412,7 +104561,7 @@ aae
 aae
 aae
 aae
-gGg
+nCn
 gGg
 gGg
 ejj
@@ -104576,7 +104725,7 @@ aae
 aae
 aae
 aae
-aak
+atS
 adg
 rRe
 aaB
@@ -104833,7 +104982,7 @@ aae
 aae
 aae
 aae
-aae
+atS
 adg
 rRe
 rRe
@@ -105090,7 +105239,7 @@ aae
 aae
 aae
 aae
-aae
+atS
 adg
 rRe
 rRe
@@ -105347,7 +105496,7 @@ aae
 aae
 aae
 aae
-aae
+atS
 adg
 aaB
 aaB
@@ -105368,7 +105517,7 @@ exB
 kOz
 kOz
 wsY
-rRe
+sxL
 aae
 aae
 aae
@@ -105614,7 +105763,7 @@ kOz
 kOz
 dET
 exB
-kOz
+wAK
 wlj
 kOz
 kOz
@@ -106395,7 +106544,7 @@ iEy
 guj
 aae
 aae
-aaB
+jfz
 aaB
 aaB
 aae
@@ -107937,7 +108086,7 @@ qdI
 pKA
 aaB
 aaB
-aaB
+jfz
 aae
 aak
 aak
@@ -108448,7 +108597,7 @@ iEy
 knL
 bQS
 qdI
-eeF
+guj
 guj
 atS
 atS
@@ -108945,7 +109094,7 @@ iEy
 upT
 iEy
 hWr
-aGi
+hWr
 eCO
 aGi
 urG
@@ -109133,7 +109282,7 @@ aae
 aKP
 eNY
 uZZ
-aWZ
+poN
 oUA
 aWZ
 aKP
@@ -111180,7 +111329,7 @@ aic
 cpx
 vrG
 xyU
-xyU
+lGE
 xyU
 xyU
 xyU
@@ -111450,7 +111599,7 @@ aKP
 sql
 fFp
 bgI
-fFp
+qrs
 beT
 beT
 beT
@@ -112980,7 +113129,7 @@ xyU
 xyU
 xyU
 meQ
-xyU
+lGE
 xyU
 xyU
 aqQ
@@ -112991,7 +113140,7 @@ cpx
 aKP
 asX
 fFp
-bgI
+roK
 aKP
 aKP
 aKP
@@ -114000,7 +114149,7 @@ abP
 afz
 oYe
 cqj
-xyU
+lGE
 xyU
 xyU
 aqQ
@@ -114275,7 +114424,7 @@ iXx
 aKP
 ats
 tBw
-fFp
+qrs
 asX
 tew
 bhJ
@@ -117932,9 +118081,9 @@ gJv
 cyw
 jVJ
 jVJ
-cRy
+hWr
 dme
-lGE
+nQf
 nQf
 nQf
 nQf
@@ -118700,7 +118849,7 @@ obz
 obz
 obz
 obz
-fij
+jXD
 sca
 opa
 hWr
@@ -120718,8 +120867,8 @@ aak
 aae
 aae
 aae
-aru
-aru
+aab
+aab
 arx
 aud
 aud
@@ -120732,7 +120881,7 @@ aud
 aud
 aym
 aab
-adg
+aab
 aae
 aae
 aak
@@ -120976,7 +121125,7 @@ aae
 aae
 aae
 aae
-aru
+aab
 arx
 aud
 aud
@@ -121233,7 +121382,7 @@ aae
 aae
 aae
 aae
-aru
+aab
 arx
 aud
 aud
@@ -121490,7 +121639,7 @@ aae
 aae
 aae
 aae
-aru
+aab
 ast
 aud
 aud
@@ -121747,7 +121896,7 @@ aae
 aae
 aae
 aae
-aru
+aab
 asA
 aus
 aus
@@ -122005,7 +122154,7 @@ aaa
 aaa
 aaa
 bmi
-atv
+hiV
 dcd
 rbw
 hOA

--- a/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings-Upper.dmm
@@ -69,6 +69,16 @@
 	baseturfs = /turf/open/indestructible/ground/outside/sidewalk
 	},
 /area/f13/building)
+"ak" = (
+/obj/machinery/door/unpowered/securedoor{
+	damage_deflection = 28;
+	max_integrity = 600;
+	name = "Vertan Decanus' Quarters";
+	obj_integrity = 600;
+	req_access_txt = "123"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
 "aq" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -1629,6 +1639,16 @@
 	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/legion)
+"mY" = (
+/obj/machinery/door/unpowered/securedoor{
+	damage_deflection = 28;
+	max_integrity = 600;
+	name = "Venator's Quarters";
+	obj_integrity = 600;
+	req_access_txt = "123"
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
 "na" = (
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -1701,8 +1721,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nt" = (
-/obj/effect/landmark/start/f13/decanvet,
-/turf/open/floor/carpet/black,
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood,
 /area/f13/legion)
 "nx" = (
 /obj/structure/dresser,
@@ -2316,6 +2337,9 @@
 "sP" = (
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/legion)
+"sQ" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/legion)
 "sT" = (
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood/wood_wide,
@@ -2483,6 +2507,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"uw" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/low_chance,
+/area/f13/legion)
 "uz" = (
 /obj/structure/bed/wooden,
 /turf/open/floor/wood/wood_fancy{
@@ -3119,6 +3147,11 @@
 	baseturfs = /turf/open/indestructible/ground/outside/sidewalk
 	},
 /area/f13/building)
+"zB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/decanvet,
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/legion)
 "zC" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	baseturfs = /turf/open/indestructible/ground/outside/sidewalk;
@@ -3618,6 +3651,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/rocksprings)
+"Hz" = (
+/obj/effect/landmark/start/f13/explorer{
+	name = "Legion Immune"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "HH" = (
 /obj/machinery/defibrillator_mount,
 /turf/closed/indestructible/riveted{
@@ -3658,14 +3697,7 @@
 	},
 /area/f13/building)
 "IP" = (
-/obj/machinery/door/unpowered/securedoor{
-	damage_deflection = 28;
-	max_integrity = 600;
-	name = "Venator's Quarters";
-	obj_integrity = 600;
-	req_access_txt = "123"
-	},
-/turf/open/floor/wood/wood_mosaic,
+/turf/closed/wall/f13/sunset/brick_small,
 /area/f13/legion)
 "Jd" = (
 /obj/effect/decal/remains/human,
@@ -14327,10 +14359,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 DH
 DH
 UL
@@ -14584,10 +14616,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 UL
@@ -14841,10 +14873,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -15098,10 +15130,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -15355,10 +15387,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 DH
 DH
 DH
@@ -15612,10 +15644,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -15869,10 +15901,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -16126,10 +16158,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -16383,10 +16415,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 DH
 DH
 DH
@@ -17411,10 +17443,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 DH
 DH
 DH
@@ -17668,10 +17700,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -17925,10 +17957,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -18182,10 +18214,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -18439,10 +18471,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 DH
 DH
 DH
@@ -18696,10 +18728,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 DH
 DH
 DH
@@ -18953,10 +18985,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 Wi
 ar
@@ -19210,10 +19242,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 op
 Uu
@@ -19467,10 +19499,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 Wi
 rl
 ac
@@ -19724,10 +19756,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 xo
 BS
@@ -19981,10 +20013,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 KM
 BS
@@ -19993,7 +20025,7 @@ bJ
 Br
 Va
 Va
-Va
+Hz
 Va
 Va
 Wi
@@ -20238,10 +20270,10 @@ DH
 DH
 DH
 DH
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 ZJ
 BS
@@ -20495,10 +20527,10 @@ DH
 DH
 DH
 DH
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 Wi
 qN
 ad
@@ -20507,7 +20539,7 @@ yr
 ar
 Va
 Va
-Va
+Hz
 Va
 Va
 Wi
@@ -21021,7 +21053,7 @@ Wi
 Wi
 SG
 Va
-Va
+Hz
 Va
 Ce
 Wi
@@ -21523,10 +21555,10 @@ AI
 AI
 AI
 AI
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 Wi
 tH
 UI
@@ -21535,7 +21567,7 @@ uZ
 ar
 Va
 Va
-Va
+Hz
 Va
 Va
 Wi
@@ -21780,10 +21812,10 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 qN
 ZT
@@ -22037,14 +22069,14 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 dp
 BS
-nt
+BS
 oP
 Vs
 Va
@@ -22294,10 +22326,10 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 CU
 BS
@@ -22551,10 +22583,10 @@ AI
 AI
 AI
 AI
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 Wi
 tH
 fJ
@@ -22808,10 +22840,10 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
 Wi
 hD
 oP
@@ -22819,9 +22851,9 @@ xf
 un
 Wi
 cL
-Wi
-IP
-Wi
+Va
+Va
+Va
 cL
 Wi
 rn
@@ -23065,19 +23097,19 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
+IP
+sQ
+sQ
+IP
+Wi
+Wi
+ak
 Wi
 Wi
 Wi
 Wi
 Wi
-Wi
-Wi
-Wi
-sP
+mY
 Wi
 Wi
 Wi
@@ -23322,16 +23354,16 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
-AI
-AI
-AI
-AI
-AI
-AI
+IP
+sQ
+sQ
+IP
+Wi
+zF
+sP
+RO
+RO
+Wi
 Wi
 zF
 sP
@@ -23579,16 +23611,16 @@ AI
 AI
 AI
 AI
-Qo
-Qf
-Qf
-Qo
-AI
-AI
-AI
-AI
-AI
-AI
+nt
+uw
+uw
+nt
+Wi
+RM
+MT
+kT
+RO
+Wi
 Wi
 RM
 MT
@@ -23836,16 +23868,16 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
-AI
-AI
-AI
-AI
-AI
-AI
+IP
+sQ
+sQ
+IP
+Wi
+rn
+MT
+MT
+zB
+Wi
 Wi
 rn
 MT
@@ -24093,16 +24125,16 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
-AI
-AI
-AI
-AI
-AI
-AI
+IP
+sQ
+sQ
+IP
+Wi
+sP
+bW
+nL
+xc
+Wi
 Wi
 sP
 bW
@@ -24350,16 +24382,16 @@ AI
 AI
 AI
 AI
-kx
-AI
-AI
-kx
-AI
-AI
-AI
-AI
-AI
-AI
+IP
+sQ
+sQ
+IP
+Wi
+Wi
+Wi
+Wi
+Wi
+Wi
 Wi
 Wi
 Wi
@@ -24607,10 +24639,10 @@ AI
 AI
 AI
 AI
-Qo
-Qf
-Qf
-Qo
+nt
+uw
+uw
+nt
 AI
 AI
 AI

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -1103,6 +1103,10 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"bjU" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bkq" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -1225,6 +1229,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
+"bsw" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/caves)
 "btu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -1259,6 +1269,7 @@
 /area/f13/building)
 "bul" = (
 /obj/structure/table/wood/junk,
+/obj/effect/spawner/lootdrop/f13/bomb/tier3,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -1366,6 +1377,7 @@
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
 	},
+/obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
 	},
@@ -2101,7 +2113,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "cug" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -2850,7 +2862,7 @@
 	dir = 8
 	},
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/caves)
+/area/f13/legion)
 "dio" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -3049,6 +3061,15 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/rocksprings)
+"dvr" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	icon_state = "ladder10";
+	id = "LegionNoMans";
+	name = "Ladder To NML"
+	},
+/turf/open/floor/wood/wood_wide,
+/area/f13/legion)
 "dvF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -4383,6 +4404,13 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/caves)
+"fdw" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/caves)
 "fdA" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4880,9 +4908,11 @@
 	},
 /area/f13/wasteland/rocksprings)
 "fKY" = (
-/obj/structure/beebox/premade/random,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland/rocksprings)
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/caves)
 "fLf" = (
 /obj/effect/overlay/junk/sink{
 	dir = 4;
@@ -5225,11 +5255,10 @@
 	},
 /area/f13/building)
 "gel" = (
-/obj/structure/rack,
-/obj/item/book/manual/advice_blacksmith,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_color = "#f4e3b0"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/wood/post{
+	pixel_x = 14;
+	pixel_y = -14
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
@@ -5509,6 +5538,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/rocksprings)
+"gyr" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/dirthole,
+/area/f13/caves)
 "gyL" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
@@ -5893,6 +5926,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/rocksprings)
+"gXF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legion)
 "gXG" = (
 /obj/structure/rack,
 /obj/item/stack/crafting/armor_plate/five,
@@ -6743,6 +6781,9 @@
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
+"hYe" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/legion)
 "hYI" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -6851,8 +6892,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
+	pixel_x = 13
 	},
 /obj/effect/decal/riverbank,
 /turf/open/water/hwater,
@@ -7271,12 +7311,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_common,
 /area/f13/building)
-"iIg" = (
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/legion)
 "iIY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/green,
@@ -7289,7 +7323,7 @@
 /turf/open/indestructible/ground/outside/dirt/dark{
 	icon_state = "dirtfull_dark"
 	},
-/area/f13/wasteland/rocksprings)
+/area/f13/legion)
 "iJY" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/effect/decal/cleanable/oil{
@@ -7787,11 +7821,16 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
+	pixel_x = 13
 	},
 /turf/open/water/hwater,
 /area/f13/wasteland/rocksprings)
+"jqV" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/caves)
 "jrH" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -8074,6 +8113,7 @@
 /area/f13/wasteland/rocksprings)
 "jNt" = (
 /obj/structure/table,
+/obj/item/clothing/under/misc/bathrobe,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -8561,10 +8601,6 @@
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
-"kvF" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland/rocksprings)
 "kvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8771,19 +8807,18 @@
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
 "kMW" = (
-/obj/item/sign/bee_warning{
-	pixel_y = -6
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+/area/f13/caves)
 "kMY" = (
 /obj/structure/fence/wooden{
 	climbable = 0;
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
+	pixel_x = 13
 	},
 /obj/effect/decal/riverbank{
 	dir = 1
@@ -8863,7 +8898,7 @@
 "kSg" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/water/hwater,
-/area/f13/caves)
+/area/f13/wasteland/rocksprings)
 "kSw" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13{
@@ -9128,7 +9163,9 @@
 /area/f13/caves)
 "llH" = (
 /obj/structure/chair/bench,
-/turf/open/water/hwater,
+/turf/open/indestructible/ground/outside/water{
+	name = "clean spring water"
+	},
 /area/f13/legion)
 "lmz" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -9570,6 +9607,10 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meatsalted,
 /turf/open/floor/wood/wood_wide,
+/area/f13/legion)
+"lLp" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/low_chance,
 /area/f13/legion)
 "lMa" = (
 /obj/machinery/light/sign/kebab{
@@ -10323,9 +10364,11 @@
 	},
 /area/f13/building)
 "mHg" = (
-/obj/item/sign/bee_warning,
-/turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland/rocksprings)
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2bottom"
+	},
+/area/f13/caves)
 "mHX" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/decal/cleanable/dirt,
@@ -10682,6 +10725,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/rocksprings)
+"nio" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_y = -32
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "njp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11112,16 +11162,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building)
-"nIp" = (
-/obj/structure/ladder/unbreakable{
-	name = "Tunnel to No Man's Land";
-	id = "LegionNoMans"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/legion)
 "nIE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -11402,6 +11442,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/rocksprings)
+"nXT" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/caves)
 "nXV" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/indestructible/ground/inside/mountain,
@@ -11588,7 +11634,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "okw" = (
-/turf/open/water/hwater,
+/turf/open/indestructible/ground/outside/water{
+	name = "clean spring water"
+	},
 /area/f13/legion)
 "okN" = (
 /obj/structure/chair/wood{
@@ -11881,6 +11929,12 @@
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
+"ozo" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/caves)
 "ozw" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/outside/dirt/dark{
@@ -12595,11 +12649,6 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland/rocksprings)
-"ppF" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood,
 /area/f13/wasteland/rocksprings)
 "ppY" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -13454,8 +13503,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
+	pixel_x = 13
 	},
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -13805,7 +13853,7 @@
 	pixel_x = -4
 	},
 /turf/closed/wall/f13/sunset/brick_small,
-/area/f13/caves)
+/area/f13/legion)
 "qQu" = (
 /obj/structure/spacevine,
 /turf/open/water/hwater,
@@ -14343,7 +14391,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/tentclothcorner,
 /turf/closed/wall/f13/wood,
-/area/f13/caves)
+/area/f13/legion)
 "rwP" = (
 /turf/open/floor/plasteel/f13{
 	dir = 8;
@@ -15397,6 +15445,18 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"sGH" = (
+/turf/open/floor/wood/wood_wide,
+/area/f13/caves)
+"sGK" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/caves)
 "sHx" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -15451,6 +15511,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland/rocksprings)
+"sJE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/wood{
+	density = 0;
+	dir = 1;
+	pixel_y = -11
+	},
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legion)
 "sJS" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -15978,6 +16047,12 @@
 	icon_state = "whiteyellowrustychess"
 	},
 /area/f13/building)
+"tsr" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/caves)
 "tsO" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
@@ -16256,9 +16331,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/wood/wood_common,
 /area/f13/building)
-"tMa" = (
-/turf/closed/wall/f13/sunset/brick_small,
-/area/f13/caves)
 "tMV" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/water/hwater,
@@ -16340,6 +16412,12 @@
 /obj/item/twohanded/sledgehammer/simple,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
+"tSu" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/caves)
 "tSB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16472,17 +16550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ubs" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	light_color = "#f4e3b0";
-	pixel_y = 24
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/legion)
 "ubw" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt{
@@ -16684,7 +16751,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uqB" = (
-/obj/machinery/autolathe/ammo,
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/item/stack/ore/blackpowder/twenty,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
 "uqV" = (
@@ -17269,8 +17337,15 @@
 /area/f13/building)
 "uXK" = (
 /obj/effect/decal/riverbank,
-/turf/open/floor/wood/wood_worn/wood_worn_dark,
-/area/f13/wasteland/rocksprings)
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = 13
+	},
+/turf/open/water/hwater,
+/area/f13/caves)
 "uXQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -17489,6 +17564,12 @@
 	icon_state = "greenrusty"
 	},
 /area/f13/building)
+"vlX" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/caves)
 "vmn" = (
 /turf/closed/wall/f13/store/constructed,
 /area/f13/building)
@@ -17828,6 +17909,17 @@
 /obj/structure/bonfire,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/legion)
+"vJx" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/fence/wooden{
+	climbable = 0;
+	density = 0;
+	dir = 1;
+	layer = 3.6;
+	pixel_x = 13
+	},
+/turf/open/water/hwater,
+/area/f13/caves)
 "vJK" = (
 /obj/structure/chair/f13chair2,
 /obj/effect/decal/cleanable/dirt,
@@ -18096,6 +18188,15 @@
 	name = "dirty water"
 	},
 /area/f13/wasteland/rocksprings)
+"vYM" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/caves)
 "vYV" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
@@ -18296,6 +18397,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/rocksprings)
+"wlL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/wood/post{
+	pixel_x = -14;
+	pixel_y = -14
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	light_color = "#f4e3b0";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legion)
 "wlX" = (
 /obj/structure/spacevine,
 /turf/open/water/hwater,
@@ -19170,6 +19284,12 @@
 /obj/item/flag/legion,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/rocksprings)
+"xpK" = (
+/obj/structure/fence/wooden{
+	pixel_x = -18
+	},
+/turf/open/water/hwater,
+/area/f13/caves)
 "xql" = (
 /obj/item/nullrod/tribal_knife{
 	name = "shiv"
@@ -19483,6 +19603,13 @@
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/legion)
+"xGP" = (
+/obj/effect/decal/riverbank,
+/obj/structure/fence/wooden{
+	pixel_x = -18
+	},
+/turf/open/water/hwater,
+/area/f13/caves)
 "xGT" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13{
@@ -19674,6 +19801,13 @@
 	light_color = "#f4e3b0"
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legion)
+"xVe" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	light_color = "#f4e3b0"
+	},
+/obj/structure/rack,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legion)
 "xVN" = (
@@ -20507,7 +20641,7 @@ lOb
 lOb
 lzo
 wdu
-lOb
+rPW
 rPW
 rPW
 rPW
@@ -20764,7 +20898,7 @@ lOb
 lOb
 iQz
 wdu
-lOb
+yen
 rPW
 rPW
 rPW
@@ -21019,14 +21153,14 @@ lOb
 lOb
 lOb
 lOb
-lzo
-oDO
+uXK
+vJx
 lOb
-lOb
-rPW
-rPW
-rPW
-lqw
+nio
+apl
+apl
+apl
+apl
 lqw
 lqw
 rPW
@@ -21276,14 +21410,14 @@ pCr
 pus
 lOb
 lOb
-iQz
-qQu
+sGH
+sGH
 lOb
 lOb
-rPW
-rPW
-rPW
-rPW
+pCr
+dkO
+dvr
+apl
 lqw
 rPW
 rPW
@@ -21322,10 +21456,10 @@ rPW
 uGk
 uGk
 uGk
-wdu
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
+uGk
 rfA
 rfA
 rfA
@@ -21533,14 +21667,14 @@ dkO
 ihS
 lOb
 lOb
-lzo
-wdu
+xGP
+xpK
 lOb
-lOb
-rPW
-rPW
-rPW
-rPW
+nio
+apl
+apl
+apl
+apl
 rPW
 rPW
 rPW
@@ -21581,10 +21715,10 @@ uGk
 uGk
 uGk
 uGk
-wdu
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -21792,7 +21926,7 @@ lOb
 lOb
 iQz
 qQu
-lOb
+yen
 rPW
 rPW
 rPW
@@ -21839,10 +21973,10 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
-wdu
-rPW
+uGk
+uGk
+uGk
+rfA
 rPW
 rPW
 rPW
@@ -22013,12 +22147,12 @@ rPW
 rPW
 rPW
 rPW
-jLa
-jLa
-jLa
-jLa
-jLa
-jLa
+rPW
+rPW
+rPW
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -22096,9 +22230,9 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -22270,12 +22404,12 @@ rPW
 rPW
 rPW
 rPW
-jLa
-iIg
-gtX
-gtX
-gtX
-jLa
+rPW
+rPW
+rPW
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -22306,7 +22440,7 @@ lOb
 lOb
 iQz
 wdu
-lOb
+rPW
 rPW
 rPW
 rPW
@@ -22527,12 +22661,12 @@ rPW
 rPW
 rPW
 rPW
-jLa
-ubs
-gtX
-gtX
-yjZ
-jLa
+rPW
+rPW
+rPW
+rPW
+rPW
+rPW
 rPW
 rPW
 lqw
@@ -22784,12 +22918,12 @@ rPW
 rPW
 rPW
 rPW
-jLa
-nIp
-gtX
-gtX
-gtX
-jLa
+rPW
+rPW
+rPW
+rPW
+rPW
+rPW
 rPW
 rPW
 rPW
@@ -23041,11 +23175,11 @@ rPW
 rPW
 rPW
 rPW
-jLa
-ubs
-gtX
-gtX
-yjZ
+rPW
+rPW
+rPW
+rPW
+rPW
 jLa
 jLa
 jLa
@@ -23298,11 +23432,11 @@ rfA
 rfA
 rfA
 rfA
-jLa
-iIg
-gtX
-gtX
-gtX
+rPW
+rPW
+rPW
+rPW
+rPW
 jLa
 vdo
 ett
@@ -23382,7 +23516,7 @@ wlX
 wlX
 lBG
 wlX
-wdu
+uGk
 rPW
 rfA
 rfA
@@ -23558,7 +23692,7 @@ jLa
 jLa
 jLa
 jLa
-hlr
+jLa
 jLa
 jLa
 kkR
@@ -23640,8 +23774,8 @@ rPW
 rPW
 rPW
 kSg
-wdu
-wdu
+uGk
+uGk
 rfA
 rfA
 rfA
@@ -23898,7 +24032,7 @@ rPW
 rPW
 rPW
 rPW
-wdu
+uGk
 rfA
 rfA
 rfA
@@ -24155,10 +24289,10 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
+uGk
 rfA
 rfA
 rPW
@@ -24415,8 +24549,8 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
+uGk
+uGk
 rfA
 rfA
 rPW
@@ -24673,8 +24807,8 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -24931,7 +25065,7 @@ cXY
 rPW
 rPW
 rPW
-wdu
+uGk
 rfA
 rfA
 rPW
@@ -25188,8 +25322,8 @@ lOb
 lOb
 rPW
 rPW
-wdu
-wdu
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -25446,7 +25580,7 @@ lOb
 rPW
 rPW
 rPW
-wdu
+uGk
 rfA
 rfA
 rPW
@@ -25703,8 +25837,8 @@ wdu
 wdu
 rPW
 rPW
-wdu
-wdu
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -25961,8 +26095,8 @@ wdu
 rPW
 rPW
 rPW
-wdu
-rPW
+uGk
+rfA
 rPW
 rPW
 rPW
@@ -26208,7 +26342,7 @@ con
 rPW
 rPW
 rPW
-lOb
+bjU
 jDi
 lOb
 wWI
@@ -26218,8 +26352,8 @@ wdu
 wdu
 rPW
 rPW
-wdu
-rPW
+uGk
+rfA
 rPW
 rPW
 rPW
@@ -26474,9 +26608,9 @@ rPW
 rPW
 wdu
 wdu
-wdu
-wdu
-rPW
+uGk
+uGk
+rfA
 rPW
 rPW
 rPW
@@ -26730,9 +26864,9 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -26988,7 +27122,7 @@ rPW
 rPW
 rPW
 rPW
-wdu
+uGk
 rfA
 rfA
 rPW
@@ -27243,9 +27377,9 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
-wdu
+uGk
+uGk
+uGk
 rfA
 rPW
 rPW
@@ -27500,8 +27634,8 @@ rPW
 rPW
 rPW
 rPW
-wdu
-wdu
+uGk
+uGk
 rfA
 rfA
 rPW
@@ -27681,22 +27815,22 @@ nRc
 fHD
 vzx
 jLa
-pnL
-tMa
-tMa
-tMa
-tMa
-pnL
+iDR
+pnE
+pnE
+pnE
+pnE
+iDR
 dhW
 qPV
 qPV
 qPV
 rwv
-tMa
-tMa
-tMa
-tMa
-pnL
+pnE
+pnE
+pnE
+pnE
+iDR
 wli
 fLL
 hXy
@@ -27752,12 +27886,12 @@ hgP
 hgP
 hgP
 hgP
-hNq
-hNq
-wdu
+hgP
+hgP
+uGk
 rPW
 kSg
-wdu
+uGk
 rfA
 rfA
 rPW
@@ -27938,22 +28072,22 @@ jLa
 jLa
 jLa
 jLa
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
 nsp
 cUg
 hXy
@@ -28010,10 +28144,10 @@ hgP
 hgP
 hgP
 hgP
-hNq
-wdu
-wdu
-wdu
+hgP
+uGk
+uGk
+uGk
 rfA
 rfA
 rPW
@@ -28195,22 +28329,22 @@ rfA
 rfA
 rfA
 rfA
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
-rPW
-rPW
-rPW
-rPW
-rSn
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
+hYe
+hYe
+hYe
+hYe
+lLp
 hgP
 pPg
 anP
@@ -28268,7 +28402,7 @@ hgP
 hgP
 hgP
 hgP
-wdu
+uGk
 rfA
 rfA
 rfA
@@ -28452,22 +28586,22 @@ rPW
 rPW
 rPW
 rPW
-pnL
-tMa
-tMa
-tMa
-tMa
-pnL
-tMa
-tMa
-tMa
-tMa
-pnL
-tMa
-tMa
-tMa
-tMa
-pnL
+iDR
+pnE
+pnE
+pnE
+pnE
+iDR
+pnE
+pnE
+pnE
+pnE
+iDR
+pnE
+pnE
+pnE
+pnE
+iDR
 rqF
 pPg
 anP
@@ -28739,10 +28873,10 @@ hXy
 hXy
 psz
 nsp
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 hXy
 anP
 jLa
@@ -28996,10 +29130,10 @@ anP
 ppY
 vTD
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 hXy
 anP
 jLa
@@ -29253,10 +29387,10 @@ anP
 qWV
 hgP
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 rNm
 hXy
 rnh
@@ -29510,10 +29644,10 @@ hXy
 qWV
 hgP
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 hXy
 hXy
 hXy
@@ -29767,10 +29901,10 @@ hXy
 qWV
 hgP
 hgP
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 hXy
 anP
 anP
@@ -30024,10 +30158,10 @@ hXy
 qWV
 hgP
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 hXy
 hXy
 hXy
@@ -30281,10 +30415,10 @@ hXy
 qWV
 hgP
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 rNm
 hXy
 pyd
@@ -30538,10 +30672,10 @@ hXy
 uwo
 rqF
 hgP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 anP
 hXy
 iYE
@@ -30795,10 +30929,10 @@ hXy
 hXy
 rnh
 gNZ
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 anP
 hXy
 iYE
@@ -31077,7 +31211,7 @@ pqR
 pqR
 hwN
 wSY
-uXK
+xOf
 xOf
 paT
 paT
@@ -31334,7 +31468,7 @@ pqR
 pqR
 gtX
 gtX
-uXK
+xOf
 xOf
 paT
 paT
@@ -31546,7 +31680,7 @@ hXy
 hXy
 hXy
 hXy
-kvF
+wfb
 hXy
 hXy
 anP
@@ -31803,7 +31937,7 @@ qyA
 qyA
 qyA
 qdO
-ppF
+iDR
 qyA
 cgm
 anP
@@ -31823,10 +31957,10 @@ vTD
 pPg
 hXy
 hXy
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 anP
 anP
 iYE
@@ -32080,10 +32214,10 @@ hgP
 pPg
 anP
 hXy
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 anP
 hXy
 iYE
@@ -32337,10 +32471,10 @@ hgP
 pPg
 hXy
 kAg
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 rNm
 hXy
 bUs
@@ -32594,10 +32728,10 @@ rqF
 pPg
 hXy
 hXy
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 anP
 hXy
 anP
@@ -32851,10 +32985,10 @@ qWV
 pPg
 hXy
 anP
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 toe
 hXy
 hXy
@@ -33108,10 +33242,10 @@ qWV
 pPg
 hXy
 anP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 iAF
 nsp
 nsp
@@ -33365,10 +33499,10 @@ qWV
 pPg
 hXy
 uQf
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 jLa
 hgz
@@ -33622,10 +33756,10 @@ qWV
 pPg
 hXy
 hXy
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 hAL
 hrG
@@ -33879,10 +34013,10 @@ qWV
 pPg
 anP
 anP
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 jLa
 uqB
 gtX
@@ -34136,10 +34270,10 @@ vTD
 pPg
 anP
 anP
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 vLp
 amM
@@ -34393,10 +34527,10 @@ lof
 gct
 anP
 kAg
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 eSR
 kjx
@@ -34650,10 +34784,10 @@ pPg
 paT
 anP
 hXy
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 amp
 amM
@@ -34907,10 +35041,10 @@ iAF
 toe
 hXy
 hXy
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 jLa
 gQp
 gtX
@@ -35935,10 +36069,10 @@ gVR
 bXZ
 jLa
 jLa
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 jLa
 jLa
 xKi
@@ -36192,10 +36326,10 @@ amM
 amM
 azr
 jLa
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 lle
 gtX
@@ -36444,15 +36578,15 @@ rPW
 iQz
 oDO
 vfE
-amM
+gXF
 kjx
 amM
 gox
 jLa
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 otN
 lle
 amM
@@ -36706,10 +36840,10 @@ amM
 gtX
 uDW
 jLa
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 gBX
 amM
@@ -36961,12 +37095,12 @@ jLa
 gtX
 gtX
 kjx
-gtX
+hAL
 jLa
-pnL
-rSn
-rSn
-pnL
+iDR
+lLp
+lLp
+iDR
 jLa
 amM
 gtX
@@ -37218,12 +37352,12 @@ jLa
 rRf
 gtX
 kwK
-gtX
+xVe
 otN
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 lRV
 fCY
@@ -38245,13 +38379,13 @@ rPW
 jLa
 jLa
 xGu
-jLa
+sJE
 byk
 jLa
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 xGu
 hAL
 gtX
@@ -38501,14 +38635,14 @@ rfA
 rPW
 rPW
 rPW
-rPW
 jLa
+wlL
+amM
 jLa
-jLa
-tMa
-rPW
-rPW
-tMa
+pnE
+hYe
+hYe
+pnE
 jLa
 dKQ
 gXG
@@ -38758,14 +38892,14 @@ rfA
 rPW
 rPW
 rPW
-rPW
-rPW
-rPW
-rPW
-tMa
-rPW
-rPW
-tMa
+jLa
+jLa
+jLa
+jLa
+pnE
+hYe
+hYe
+pnE
 jLa
 jLa
 otN
@@ -44611,8 +44745,8 @@ hmL
 "}
 (97,1,1) = {"
 qzU
-ckR
-ckR
+fKY
+ozo
 ckR
 ckR
 ckR
@@ -44868,7 +45002,7 @@ hmL
 "}
 (98,1,1) = {"
 qzU
-dOp
+kMW
 dOp
 dOp
 dOp
@@ -45119,13 +45253,13 @@ eKm
 ckR
 ckR
 ckR
-ckR
-ckR
+ozo
+fKY
 qzU
 "}
 (99,1,1) = {"
 qzU
-dOp
+kMW
 dOp
 dOp
 dOp
@@ -45377,12 +45511,12 @@ dOp
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (100,1,1) = {"
 qzU
-npk
+mHg
 jIP
 dOp
 dOp
@@ -45634,12 +45768,12 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (101,1,1) = {"
 qzU
-npk
+mHg
 dOp
 dOp
 dOp
@@ -45891,7 +46025,7 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (102,1,1) = {"
@@ -46148,12 +46282,12 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (103,1,1) = {"
 qzU
-dOp
+kMW
 dOp
 dOp
 dOp
@@ -46405,12 +46539,12 @@ aXD
 lYn
 lYn
 lYn
-jam
+sGK
 qzU
 "}
 (104,1,1) = {"
 qzU
-cYN
+gyr
 tdZ
 npk
 dOp
@@ -46662,12 +46796,12 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (105,1,1) = {"
 qzU
-tdZ
+tSu
 npk
 dOp
 dOp
@@ -46919,12 +47053,12 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (106,1,1) = {"
 qzU
-dOp
+kMW
 dOp
 dOp
 dOp
@@ -47176,13 +47310,13 @@ hwx
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (107,1,1) = {"
 qzU
-bGw
-bGw
+nXT
+vlX
 bGw
 bGw
 bGw
@@ -47433,7 +47567,7 @@ dOp
 dOp
 dOp
 dOp
-dOp
+kMW
 qzU
 "}
 (108,1,1) = {"
@@ -47689,8 +47823,8 @@ pMj
 bGw
 bGw
 bGw
-bGw
-bGw
+vlX
+nXT
 qzU
 "}
 (109,1,1) = {"
@@ -76245,7 +76379,7 @@ hgP
 hgP
 hgP
 hgP
-mHg
+hgP
 hgP
 hgP
 hgP
@@ -78307,7 +78441,7 @@ hgP
 hgP
 hgP
 hgP
-mHg
+hgP
 hgP
 hgP
 hgP
@@ -80354,7 +80488,7 @@ vdF
 vdF
 vdF
 oXV
-kMW
+oXV
 paT
 paT
 paT
@@ -80866,7 +81000,7 @@ hgP
 pPg
 ubP
 paT
-fKY
+paT
 vYK
 fBl
 paT
@@ -81648,7 +81782,7 @@ hgP
 hgP
 hgP
 hgP
-mHg
+hgP
 hgP
 hgP
 hgP
@@ -84883,11 +85017,11 @@ rPW
 rPW
 rPW
 eUg
-dmU
+bsw
 rOx
 rOx
 puN
-dmU
+bsw
 rPW
 rPW
 rPW
@@ -85140,11 +85274,11 @@ rPW
 rPW
 rPW
 eUg
-rOx
-btu
-btu
-puN
-dmU
+fdw
+jqV
+jqV
+vYM
+tsr
 rPW
 rPW
 eUg

--- a/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren-Upper.dmm
@@ -1294,11 +1294,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/autolathe/ammo/unlocked,
 /obj/item/stack/ore/blackpowder/twenty,
-/obj/item/book/granter/crafting_recipe/gunsmith_two,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "pN" = (

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -63,6 +63,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "aag" = (
@@ -384,6 +385,12 @@
 	name = "regulation wall"
 	},
 /area/f13/city)
+"anO" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2top"
+	},
+/area/f13/city)
 "anQ" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblecorner"
@@ -395,6 +402,7 @@
 /area/f13/wasteland/warren)
 "api" = (
 /obj/structure/chair/stool/retro/backed,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "apj" = (
@@ -665,6 +673,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/f13/ncrtrooper,
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "aBI" = (
@@ -740,18 +749,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"aGJ" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/warren)
 "aGZ" = (
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/city)
 "aHl" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
-/obj/structure/simple_door/dirtyglass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "aHo" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -775,16 +787,11 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/city)
 "aIW" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/planks,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "aJz" = (
 /mob/living/simple_animal/opossum,
 /turf/open/indestructible/ground/outside/dirt,
@@ -994,16 +1001,11 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
 "aTf" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/planks{
-	icon_state = "board-2"
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/obj/structure/decoration/rag,
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "aTg" = (
 /turf/closed/wall/f13/sunset/brick_small_light,
 /area/f13/city)
@@ -1652,8 +1654,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
 "bwo" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/wasteland/warren)
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/caves)
 "bwN" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1890,11 +1895,11 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
 "bKz" = (
-/obj/item/sign/bee_warning,
+/obj/effect/landmark/latejoin,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+	icon_state = "horizontaloutermain1"
 	},
-/area/f13/wasteland/warren)
+/area/f13/caves)
 "bKS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -2149,6 +2154,13 @@
 /obj/effect/spawner/lootdrop/waste_loot_poor,
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
+"bWE" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_x = 32
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/ncr)
 "bWJ" = (
 /obj/effect/overlay/turfs/cliff/corner{
 	dir = 9;
@@ -3035,6 +3047,7 @@
 /area/f13/raiders)
 "cNx" = (
 /obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
 	},
@@ -3165,6 +3178,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/ncrtrooper,
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "cSp" = (
@@ -3608,6 +3622,11 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/black,
 /area/f13/ncr)
+"dpz" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/bomb/tier3,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/city)
 "dpW" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -4636,6 +4655,12 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/city)
+"ewU" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland/warren)
 "exi" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -4740,6 +4765,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "eCt" = (
@@ -5001,6 +5027,7 @@
 "eNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro/backed,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "eOx" = (
@@ -6559,13 +6586,11 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "gnT" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "gnU" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -6634,18 +6659,11 @@
 	},
 /area/f13/wasteland/warren)
 "grE" = (
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/planks{
-	icon_state = "board-2"
+/obj/effect/landmark/start/f13/raider,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4;
+	icon_state = "graveldirtedge"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/structure/decoration/rag,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "gsp" = (
 /obj/structure/wreck/trash/autoshaft,
@@ -7389,6 +7407,12 @@
 "gZs" = (
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/ncr)
+"gZE" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland/warren)
 "gZT" = (
 /obj/structure/fence/corner,
 /obj/structure/destructible/tribal_torch/lit,
@@ -7470,6 +7494,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "hdM" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
+	pixel_x = 32
+	},
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark"
@@ -7864,6 +7892,13 @@
 	icon_state = "worn_dark-broken6"
 	},
 /area/f13/wasteland/warren)
+"hxe" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/obj/effect/landmark/start/f13/ncrtrooper,
+/turf/open/floor/plasteel/vault,
+/area/f13/ncr)
 "hxk" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/concrete/ten,
@@ -7875,6 +7910,16 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
+"hxs" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/caves)
 "hxv" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -8310,6 +8355,12 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/city)
+"hTA" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft1"
+	},
+/area/f13/wasteland/warren)
 "hTM" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -8356,6 +8407,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
+/obj/effect/landmark/start/f13/raider,
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8;
 	icon_state = "graveldirtedge"
@@ -8578,6 +8630,12 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/radiation)
+"ijP" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland/warren)
 "ikC" = (
 /obj/structure/simple_door/metal/barred{
 	req_access_txt = "87"
@@ -8807,12 +8865,10 @@
 	},
 /area/f13/wasteland/ncr)
 "isU" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/decoration/rag,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/effect/landmark/start/f13/raider,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "itj" = (
 /obj/structure/window/fulltile/store,
@@ -9353,6 +9409,12 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/ncr)
+"iUm" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2"
+	},
+/area/f13/wasteland/warren)
 "iUx" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
@@ -9777,6 +9839,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/effect/landmark/start/f13/ncrtrooper,
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "jws" = (
@@ -10383,6 +10446,13 @@
 	dir = 1
 	},
 /area/f13/wasteland/warren)
+"jZk" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubble"
+	},
+/area/f13/wasteland/warren)
 "jZr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -10680,6 +10750,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"ktQ" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/warren)
 "kue" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -11070,6 +11146,7 @@
 /area/f13/city)
 "kNv" = (
 /obj/structure/chair/stool/retro/tan,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "kNG" = (
@@ -11856,6 +11933,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/city)
+"lAc" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
+	},
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/warren)
 "lAl" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12995,9 +13081,11 @@
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/ncr)
 "mFn" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/landmark/start/f13/raider,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 10;
+	icon_state = "graveldirtedge"
+	},
 /area/f13/raiders)
 "mFE" = (
 /turf/open/indestructible/ground/outside/road{
@@ -13460,10 +13548,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
 "mZn" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/raiders)
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/caves)
 "mZF" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -14949,6 +15036,7 @@
 /area/f13/city)
 "oxk" = (
 /obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
@@ -15318,13 +15406,10 @@
 	},
 /area/f13/city)
 "oTi" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/decoration/rag,
-/obj/structure/curtain{
-	color = "#363636"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "oTq" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -15413,12 +15498,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/city)
 "oWz" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain{
-	color = "#363636"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "oXC" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4;
@@ -16529,15 +16612,10 @@
 	},
 /area/f13/city)
 "qdy" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "qeh" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_south"
@@ -17366,6 +17444,7 @@
 /area/f13/city)
 "qOl" = (
 /obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/city)
 "qOq" = (
@@ -18426,6 +18505,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"rIl" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/warren)
 "rIU" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -19125,9 +19210,10 @@
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
 "suC" = (
-/obj/structure/beebox/premade/random,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/caves)
 "suF" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -19674,8 +19760,15 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
+"sUl" = (
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2"
+	},
+/area/f13/radiation)
 "sUn" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/f13{
@@ -19814,11 +19907,11 @@
 	},
 /area/f13/wasteland/ncr)
 "taX" = (
-/obj/item/sign/bee_warning,
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland/warren)
+/area/f13/caves)
 "tbl" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/wooden,
@@ -21309,6 +21402,12 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/warren)
+"uvP" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/warren)
 "uwB" = (
 /obj/effect/overlay/turfs/cliff/alt{
 	dir = 5;
@@ -21723,6 +21822,10 @@
 "uPk" = (
 /turf/open/floor/wood/wood_wide,
 /area/f13/city)
+"uPq" = (
+/obj/effect/landmark/start/f13/raider,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/raiders)
 "uPI" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -22687,6 +22790,7 @@
 /area/f13/wasteland/warren)
 "vEx" = (
 /obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "vEK" = (
@@ -22810,12 +22914,10 @@
 	},
 /area/f13/ncr)
 "vMc" = (
-/obj/structure/barricade/bars,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
+/area/f13/caves)
 "vMd" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/wood_fancy,
@@ -22856,6 +22958,12 @@
 /obj/effect/overlay/turfs/sidewalk,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/ncr)
+"vOk" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft1"
+	},
+/area/f13/wasteland/warren)
 "vOq" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -22927,6 +23035,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/ncrtrooper,
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
 "vSu" = (
@@ -24449,6 +24558,14 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland/warren)
+"xnk" = (
+/obj/structure/simple_door/metal/barred{
+	req_access_txt = "87"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/warren)
 "xnl" = (
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -24601,6 +24718,12 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
+"xrL" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/warren)
 "xss" = (
 /obj/structure/railing/wood{
 	dir = 1;
@@ -24615,6 +24738,12 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 8
+	},
+/area/f13/caves)
+"xth" = (
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/caves)
 "xtt" = (
@@ -25117,6 +25246,7 @@
 "xSc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/raider,
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "xSq" = (
@@ -25717,9 +25847,9 @@ qZx
 "}
 (2,1,1) = {"
 qZx
-dlr
-lsq
-lsq
+qZx
+mZn
+jbA
 dlr
 lsq
 lsq
@@ -25826,15 +25956,15 @@ xdG
 qJL
 pLS
 vol
-uch
-nFf
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
-wXB
+gZE
+ijP
+ktQ
+ktQ
+lAc
+ktQ
+ktQ
+uvP
+rIl
 vol
 pLS
 pSQ
@@ -25868,10 +25998,10 @@ fKu
 qZx
 "}
 (3,1,1) = {"
-bwo
-boQ
-boQ
-boQ
+rlz
+aHl
+oTi
+oTi
 boQ
 boQ
 uhx
@@ -25978,7 +26108,7 @@ vIt
 uxI
 qCL
 vol
-uch
+ewU
 nFf
 pbp
 pbp
@@ -25986,7 +26116,7 @@ rsF
 pbp
 pbp
 jfK
-wXB
+xrL
 vol
 pSQ
 pSQ
@@ -26020,10 +26150,10 @@ fKu
 qZx
 "}
 (4,1,1) = {"
-bwo
-pDT
-pDT
-pDT
+rlz
+aIW
+oWz
+oWz
 pDT
 pDT
 pDT
@@ -26172,10 +26302,10 @@ fKu
 qZx
 "}
 (5,1,1) = {"
-bwo
-snq
-snq
-snq
+rlz
+aTf
+qdy
+qdy
 snq
 snq
 snq
@@ -26324,10 +26454,10 @@ fKu
 qZx
 "}
 (6,1,1) = {"
+rlz
 bwo
-dgH
-dgH
-ouI
+suC
+hxs
 jWt
 jWt
 jWt
@@ -26477,8 +26607,8 @@ qZx
 "}
 (7,1,1) = {"
 qZx
-dgH
-dgH
+bKz
+suC
 xOe
 dnq
 dnq
@@ -28440,7 +28570,7 @@ fQl
 fQl
 vsK
 kwt
-qOl
+dpz
 qzv
 pLS
 pLS
@@ -29044,13 +29174,13 @@ lsq
 uUe
 kwt
 fQl
-rKL
+anO
 hKb
 ucF
 uBq
 tWH
 jDZ
-xcb
+sUl
 qzv
 pLS
 pLS
@@ -29809,7 +29939,7 @@ uUe
 cOJ
 fQl
 rKL
-qsY
+iUm
 qHk
 qHk
 lez
@@ -30257,12 +30387,12 @@ fTN
 iha
 dNs
 yeV
+vOk
 uhx
 uhx
 uhx
 uhx
-uhx
-uhx
+hTA
 rqx
 rqx
 rqx
@@ -30875,7 +31005,7 @@ pfm
 pbp
 pbp
 wXB
-ceg
+aGJ
 ceg
 wsA
 mvy
@@ -31030,7 +31160,7 @@ aXI
 ceg
 vSw
 ceg
-suC
+ceg
 mvy
 pLS
 qZx
@@ -31472,11 +31602,11 @@ gVA
 gVA
 gVA
 qzI
-bKz
+uch
 nFf
 pbp
 pbp
-taX
+gsT
 mzI
 eKG
 jOK
@@ -32217,7 +32347,7 @@ rme
 brC
 ucF
 ens
-uNY
+jZk
 anq
 gVA
 gVA
@@ -38029,9 +38159,9 @@ qZx
 "}
 (83,1,1) = {"
 qZx
-vol
-vol
-vol
+ilV
+ilV
+ilV
 boQ
 boQ
 boQ
@@ -38180,10 +38310,10 @@ aRt
 qZx
 "}
 (84,1,1) = {"
-bwo
-pDT
-pDT
-pDT
+rlz
+aIW
+taX
+oWz
 pDT
 pDT
 pDT
@@ -38332,10 +38462,10 @@ uAm
 qZx
 "}
 (85,1,1) = {"
-bwo
-lMO
-pbp
-pbp
+rlz
+gnT
+vMc
+vMc
 pbp
 pbp
 pbp
@@ -38484,10 +38614,10 @@ uAm
 qZx
 "}
 (86,1,1) = {"
-bwo
-lMO
-pbp
-pbp
+rlz
+gnT
+vMc
+vMc
 pbp
 pbp
 pbp
@@ -38636,10 +38766,10 @@ jjr
 qZx
 "}
 (87,1,1) = {"
-bwo
-snq
-snq
-snq
+rlz
+aTf
+xth
+qdy
 snq
 snq
 snq
@@ -38789,9 +38919,9 @@ qZx
 "}
 (88,1,1) = {"
 qZx
-vol
-vol
-vol
+ilV
+ilV
+ilV
 jWt
 jWt
 jWt
@@ -39264,7 +39394,7 @@ mwd
 vrA
 pbp
 pbp
-pbp
+xnk
 pbp
 pbp
 pbp
@@ -41983,7 +42113,7 @@ qZx
 qZx
 xqa
 keO
-unF
+uPq
 unF
 unF
 qKh
@@ -44717,7 +44847,7 @@ qZx
 "}
 (127,1,1) = {"
 aAj
-luW
+grE
 pdT
 swo
 nxO
@@ -44869,7 +44999,7 @@ qZx
 "}
 (128,1,1) = {"
 fpe
-swo
+isU
 snh
 swo
 nxO
@@ -45021,7 +45151,7 @@ qZx
 "}
 (129,1,1) = {"
 fpe
-swo
+isU
 swo
 kEw
 xbI
@@ -45173,7 +45303,7 @@ qZx
 "}
 (130,1,1) = {"
 gzt
-nbD
+mFn
 swo
 ijy
 iTK
@@ -45781,7 +45911,7 @@ qZx
 "}
 (134,1,1) = {"
 qZx
-aTf
+vVX
 unF
 unF
 xJu
@@ -45933,7 +46063,7 @@ qZx
 "}
 (135,1,1) = {"
 qZx
-oTi
+vVX
 unF
 unF
 oKF
@@ -46085,7 +46215,7 @@ qZx
 "}
 (136,1,1) = {"
 qZx
-qdy
+vVX
 unF
 unF
 jiC
@@ -46370,9 +46500,9 @@ mCm
 gUg
 goE
 aAM
-pFA
+hxe
 cJB
-pFA
+hxe
 jvk
 goE
 rBN
@@ -46389,7 +46519,7 @@ qZx
 "}
 (138,1,1) = {"
 qZx
-gnT
+vVX
 unF
 unF
 yln
@@ -46521,11 +46651,11 @@ pSU
 nRO
 nRO
 cJB
-pFA
-pFA
+hxe
+hxe
 cJB
 cSh
-pFA
+hxe
 cJB
 lrJ
 nRO
@@ -46541,7 +46671,7 @@ qZx
 "}
 (139,1,1) = {"
 qZx
-mFn
+vVX
 unF
 unF
 iKD
@@ -46673,11 +46803,11 @@ pSU
 nRO
 nRO
 cJB
-pFA
+hxe
 cSh
 qCs
-pFA
-pFA
+hxe
+hxe
 cJB
 lrJ
 icS
@@ -46693,7 +46823,7 @@ qZx
 "}
 (140,1,1) = {"
 qZx
-vMc
+vVX
 unF
 unF
 wUz
@@ -46826,9 +46956,9 @@ nRO
 vYU
 goE
 vRU
-pFA
+hxe
 cJB
-pFA
+hxe
 jvk
 goE
 vhR
@@ -46997,10 +47127,10 @@ qZx
 "}
 (142,1,1) = {"
 qZx
-aIW
+vVX
 unF
 unF
-aHl
+tIx
 sNb
 sNb
 oTq
@@ -47149,7 +47279,7 @@ qZx
 "}
 (143,1,1) = {"
 qZx
-isU
+vVX
 unF
 unF
 qUj
@@ -47274,7 +47404,7 @@ aNO
 btw
 mhZ
 cMJ
-cMJ
+bWE
 mhZ
 cMJ
 mRV
@@ -47301,7 +47431,7 @@ qZx
 "}
 (144,1,1) = {"
 qZx
-grE
+vVX
 unF
 unF
 yln
@@ -47454,8 +47584,8 @@ qZx
 (145,1,1) = {"
 xqa
 vVX
-mZn
-oWz
+hBB
+vVX
 vVX
 yln
 yln
@@ -47607,7 +47737,7 @@ qZx
 xqa
 lAL
 unF
-unF
+lva
 vVX
 iZK
 sNb

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -191,6 +191,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isitem(A) (istype(A, /obj/item))
 
+#define isstack(A) (istype(A, /obj/item/stack))
+
 #define isgrenade(A) (istype(A, /obj/item/grenade))
 
 #define islandmine(A) (istype(A, /obj/item/mine))

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -1,7 +1,7 @@
 /* Table Frames
  * Contains:
- *		Frames
- *		Wooden Frames
+ * Frames
+ * Wooden Frames
  */
 
 
@@ -21,42 +21,56 @@
 	var/framestack = /obj/item/stack/rods
 	var/framestackamount = 2
 
+
+/obj/structure/table_frame/wrench_act(mob/living/user, obj/item/I)
+	to_chat(user, span_notice("You start disassembling [src]..."))
+	I.play_tool_sound(src)
+	if(!I.use_tool(src, user, 3 SECONDS))
+		return TRUE
+	playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+	deconstruct(TRUE)
+	return TRUE
+
+
 /obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WRENCH)
-		to_chat(user, "<span class='notice'>You start disassembling [src]...</span>")
-		I.play_tool_sound(src)
-		if(I.use_tool(src, user, 30))
-			playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
-			deconstruct(TRUE)
+	if(isstack(I))
+		var/obj/item/stack/material = I
+		if(material.tableVariant)
+			if(material.get_amount() < 1)
+				to_chat(user, span_warning("You need one [material.name] sheet to do this!"))
+				return
+			if(locate(/obj/structure/table) in loc)
+				to_chat(user, span_warning("There's already a table built here!"))
+				return
+			to_chat(user, span_notice("You start adding [material] to [src]..."))
+			if(!do_after(user, 2 SECONDS, target = src) || !material.use(1) || (locate(/obj/structure/table) in loc))
+				return
+			make_new_table(material.tableVariant)
+		else if(istype(material, /obj/item/stack/sheet))
+			if(material.get_amount() < 1)
+				to_chat(user, span_warning("You need one sheet to do this!"))
+				return
+			if(locate(/obj/structure/table) in loc)
+				to_chat(user, span_warning("There's already a table built here!"))
+				return
+			to_chat(user, span_notice("You start adding [material] to [src]..."))
+			if(!do_after(user, 2 SECONDS, target = src) || !material.use(1) || (locate(/obj/structure/table) in loc))
+				return
+			var/list/material_list = list()
+			if(material.material_type)
+				material_list[material.material_type] = MINERAL_MATERIAL_AMOUNT
+			make_new_table(/obj/structure/table/greyscale, material_list)
 		return
+	return ..()
 
-	var/obj/item/stack/material = I
-	if (istype(I, /obj/item/stack))
-		if(material?.tableVariant)
-			if(material.get_amount() < 1)
-				to_chat(user, "<span class='warning'>You need one [material.name] sheet to do this!</span>")
-				return
-			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
-			if(do_after(user, 20, target = src) && material.use(1))
-				make_new_table(material.tableVariant)
-		else
-			if(material.get_amount() < 1)
-				to_chat(user, "<span class='warning'>You need one sheet to do this!</span>")
-				return
-			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
-			if(do_after(user, 20, target = src) && material.use(1))
-				var/list/material_list = list()
-				if(material.material_type)
-					material_list[material.material_type] = MINERAL_MATERIAL_AMOUNT
-				make_new_table(/obj/structure/table/greyscale, material_list)
-	else
-		return ..()
 
-/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials) //makes sure the new table made retains what we had as a frame
+/obj/structure/table_frame/proc/make_new_table(table_type, custom_materials, carpet_type) //makes sure the new table made retains what we had as a frame
 	var/obj/structure/table/T = new table_type(loc)
 	T.frame = type
 	T.framestack = framestack
 	T.framestackamount = framestackamount
+	if (carpet_type)
+		T.buildstack = carpet_type
 	if(custom_materials)
 		T.set_custom_materials(custom_materials)
 	qdel(src)
@@ -67,10 +81,6 @@
 
 /obj/structure/table_frame/narsie_act()
 	new /obj/structure/table_frame/wood(src.loc)
-	qdel(src)
-
-/obj/structure/table_frame/ratvar_act()
-	new /obj/structure/table_frame/brass(src.loc)
 	qdel(src)
 
 /*
@@ -86,23 +96,28 @@
 	resistance_flags = FLAMMABLE
 
 /obj/structure/table_frame/wood/attackby(obj/item/I, mob/user, params)
-	if (istype(I, /obj/item/stack))
+	if (isstack(I))
 		var/obj/item/stack/material = I
 		var/toConstruct // stores the table variant
+		var/carpet_type // stores the carpet type used for construction in case of poker tables
 		if(istype(I, /obj/item/stack/sheet/mineral/wood))
 			toConstruct = /obj/structure/table/wood
 		else if(istype(I, /obj/item/stack/tile/carpet))
 			toConstruct = /obj/structure/table/wood/poker
-
+			carpet_type = I.type
 		if (toConstruct)
 			if(material.get_amount() < 1)
-				to_chat(user, "<span class='warning'>You need one [material.name] sheet to do this!</span>")
+				to_chat(user, span_warning("You need one [material.name] sheet to do this!"))
 				return
-			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
+			to_chat(user, span_notice("You start adding [material] to [src]..."))
 			if(do_after(user, 20, target = src) && material.use(1))
-				make_new_table(toConstruct)
+				make_new_table(toConstruct, null, carpet_type)
 	else
 		return ..()
+
+/*
+ * Brass Frames
+ */
 
 /obj/structure/table_frame/brass
 	name = "brass table frame"


### PR DESCRIPTION
- - -
Balance:
 - Various mid-to-high tier gun spawns sprinkled around the Valley.
 - Singular Deathclaw Spear spawns in the valley, within the coom shack. Go find it.
 - Securitrons, mostly, replaced by Protectrons.
 - NML loot table buffed significantly with high end ballistics.
 - Brotherhood's topside area blocked off by default, the tunnel needing to be cleared and given a reason not to be meta'd.
 - Legion's reloading bench removed, replaced with the improved version that has basic recipes unlocked, alongside a twenty stack of gunpowder.
 - NCR's fully unlocked reloading bench (what the fuck why) has been removed, given an identical bench to the Legion. This was pretty blatant favoritism.
 - All major factions can once again access NML.
 - Legion capable of accessing the rear of the crusher within the forge area, for retrieving reclaimed material.
 - ALL BEES REMOVED.
 - South bunker within the valley has been adjusted, difficulty wise, to compensate for removal of Securitrons. Rest in piss, you awful NPCs.
- - -
Corrections:
 - Trooper and Immune, for the NCR and Legion respectively, now spawn within their camps.
 - Tables can no longer be stacked. Pulled from modern TG.
 - Brotherhood stairs topside should now be fully functional. Here's hoping.
 - Spawns for both Rock Springs and Warren, as late joining players and Wastelander role added.
 - Outlaws may now spawn within the outlaw fort, within Warren, by chance.
 - Bathhouse for the Legion should no longer give you super aids. Probably. Probably not. Meh.
 - You can no longer dive down the entirety of the stairs in the Mayor's fort. lol
- - -
Other Stuff:
 - Veteran Decani receives their own quarters, identically to the Venator.
- - -