### PR TITLE
Reaver Adjustment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -79,7 +79,7 @@
 	name = "radioactive glob"
 	damage = 15
 	armour_penetration = 5
-	irradiate = 250//Toxic threshold. Don't tweak this any higher.
+	irradiate = 25//Toxic threshold is 250.
 	pass_flags = PASSTABLE | PASSGRILLE
 	icon_state = "toxin"
 

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -68,8 +68,8 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	armour_penetration = 0.2//Making them some manner of threat.
-	retreat_distance = 0
-	minimum_distance = 2
+	ranged_message = "throws a chunk of flesh"
+	ranged_cooldown_time = 60
 	ranged = 1
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	projectiletype = /obj/item/projectile/reaver


### PR DESCRIPTION
Massively tanks the radiation damage of the Reaver's radioactive projectile. This lowers it to 25, from 250.