### PR TITLE
Cyborg balance changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -8,7 +8,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1
 
-	var/borghealth = 300
+	var/borghealth = 150
 
 	var/list/basic_modules = list() //a list of paths, converted to a list of instances on New()
 	var/list/emag_modules = list() //ditto
@@ -747,6 +747,7 @@
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/medical,
 		/obj/item/clockwork/weapon/ratvarian_spear)
+	borghealth = 300
 	cyborg_base_icon = "assaultron_sase"
 
 /obj/item/robot_module/syndicate

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -8,7 +8,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1
 
-	var/borghealth = 150
+	var/borghealth = 150 //Slight buff, 100 -> 150
 
 	var/list/basic_modules = list() //a list of paths, converted to a list of instances on New()
 	var/list/emag_modules = list() //ditto

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -31,9 +31,10 @@
 		/obj/item/analyzer/nose,
 		/obj/item/holosign_creator/security,
 		/obj/item/gun/energy/disabler/cyborg,
-		/obj/item/gun/energy/laser/cyborg)
+		/obj/item/gun/energy/laser/pistol/cyborg)
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/security,
 		/obj/item/clockwork/weapon/ratvarian_spear)
+	borghealth = 300
 	cyborg_base_icon = "k9"
 	moduleselect_icon = "k9"
 	moduleselect_alternate_icon = 'modular_citadel/icons/ui/screen_cyborg.dmi'

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -31,7 +31,7 @@
 		/obj/item/analyzer/nose,
 		/obj/item/holosign_creator/security,
 		/obj/item/gun/energy/disabler/cyborg,
-		/obj/item/gun/energy/laser/pistol/cyborg)
+		/obj/item/gun/energy/laser/pistol/cyborg/gutsy)
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/security,
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	borghealth = 300


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Alternative to #488 
Reduces base cyborg health to 150
Reduces medical assaultron health to 300 from 450
Replaces the K9's integrated AER9 with an integrated AEP7
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Saying that "all cyborgs have been buffed" isn't genuine, considering every _selectable_ cyborg prior to #485 already had 300 health or more (Gutsies = 300, Assaultrons = 450)
Still, I've lowered non-combat oriented borgs health by 150. This leaves the janitorial and medical dogborgs at 150 health, the security dogborg and gutsies at 300, and the assaultron at 450.
The medical assaultron had no downsides compared to the regular one, which is why now they have less health (300). They still get to have double the health of the other non-combat borgs.
As an oversight the security K9 borgs were given AER9s. Now they have the same laser pistol Gutsies get.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
