### PR TITLE
BUFFS SHOTGUN AMMO & DOUBLE BARRELS + NO AUTOSHOTGUN SIDEGRADES

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -39,7 +39,7 @@
 /obj/item/ammo_box/magazine/internal/shot/com/citykiller
 	name = "city killer shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
-	max_ammo = 12
+	max_ammo = 10
 
 /obj/item/ammo_box/magazine/internal/shot/dual
 	name = "double-barrel shotgun internal magazine"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -365,7 +365,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/citykiller
 	fire_delay = 4.45
 	autofire_shot_delay = 5
-	is_automatic = TRUE
 	automatic = 1
 	recoil = 1.25
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -98,10 +98,10 @@
 ////////////////////////////////////////
 
 
-//Caravan shotgun							Keywords: Shotgun, Double barrel, saw-off, extra damage +1
+//Caravan shotgun							Keywords: Shotgun, Double barrel, saw-off, extra damage +5.2, extra pen 10%
 /obj/item/gun/ballistic/revolver/caravan_shotgun
 	name = "caravan shotgun"
-	desc = "An common over-under double barreled shotgun made in the post-war era."
+	desc = "A common over-under double barreled shotgun made in the post-war era."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -115,6 +115,8 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/simple
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
+	extra_damage = 5.2
+	extra_penetration = 0.1
 
 /obj/item/gun/ballistic/revolver/caravan_shotgun/attackby(obj/item/A, mob/user, params)
 	..()
@@ -134,7 +136,7 @@
 		icon_state = "[initial(icon_state)]"
 
 
-//Widowmaker				Keywords: Shotgun, Double barrel, saw-off
+//Widowmaker				Keywords: Shotgun, Double barrel, saw-off, extra damage +3.5, extra pen 5%
 /obj/item/gun/ballistic/revolver/widowmaker
 	name = "Winchester Widowmaker"
 	desc = "Old-world Winchester Widowmaker double-barreled 12 gauge shotgun, with mahogany furniture"
@@ -151,6 +153,8 @@
 	force = 20
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'
+	extra_damage = 3.5
+	extra_penetration = 0.05
 
 /obj/item/gun/ballistic/revolver/widowmaker/attackby(obj/item/A, mob/user, params)
 	..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -356,15 +356,18 @@
 	toggle_tube(user)
 
 
-//Winchester City-Killer				Keywords: Shotgun, Semi-auto, 12 rounds internal
+//Winchester City-Killer				Keywords: Shotgun, Full-auto, 10 rounds internal
 /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller
 	name = "Winchester City-Killer shotgun"
-	desc = "A semi automatic shotgun with black tactical furniture made by Winchester Arms. This particular model uses a internal tube magazine."
+	desc = "A semi automatic shotgun with black tactical furniture made by Winchester Arms. This particular model uses an internal tube magazine."
 	icon_state = "citykiller"
 	item_state = "shotguncity"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com/citykiller
-	fire_delay = 5
-	var/semi_auto = TRUE
+	fire_delay = 4.45
+	autofire_shot_delay = 5
+	is_automatic = TRUE
+	automatic = 1
+	recoil = 1.25
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
 
 
@@ -379,7 +382,7 @@
 	item_state = "shotgunriot"
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/d12g
-	fire_delay = 5
+	fire_delay = 4
 	burst_size = 1
 	recoil = 0.5
 	automatic_burst_overlay = FALSE

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,10 +1,11 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 50
+	damage = 40
 	stamina = 10 //all shotguns deal a very slight amount of stamina damage from the impact
 	sharpness = SHARP_POINTY
-	wound_bonus = 26
-	bare_wound_bonus = -26
+	wound_bonus = 35
+	bare_wound_bonus = 10
+	armour_penetration = 0.25
 	spread = 2
 
 /obj/item/projectile/bullet/shotgun_slug/executioner
@@ -111,9 +112,9 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 11
-	wound_bonus = 5
-	bare_wound_bonus = 5
+	damage = 11.3
+	wound_bonus = 35
+	bare_wound_bonus = 75
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot


### PR DESCRIPTION
### hiiiii :3 haiiiiiiii >w<
**T**he purpose of this PR is to bring needed relevancy to low-capacity shotguns and to make buckshot a relevant threat in the face of other ammo types (Right now it's just a mob deterrent lol)

### 12 Gauge Slug

- DAMAGE 40 < 50
- WOUND BONUS 35 < 26
- BARE WOUND BONUS 10 < -26
- ARMOR PENETRATION 25% < 0

### 12 Gauge Buckshot

- DAMAGE 11.3 < 11
- WOUND BONUS 35 < 0
- BARE WOUND BONUS 75 < 0

### Caravan Shotgun
- EXTRA DAMAGE 5.2 < 0
- EXTRA PENETRATION 10% < 0

### Winchester Widowmaker

- EXTRA DAMAGE 3.5 < 0
- EXTRA PENETRATION 5% < 0

### Riot Shotgun

- FIRING DELAY 4 < 5

### Winchester City-Killer

- FIREMODE FULL < SEMI
- MAX AMMO 10 < 12
- RECOIL 1.25 < 0