### PR TITLE
DNA manipulator board removal.

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -13651,7 +13651,6 @@
 "qCH" = (
 /obj/structure/table,
 /obj/item/pen/fourcolor,
-/obj/item/circuitboard/machine/plantgenes,
 /turf/open/floor/plasteel/darkgreen/side{
 	dir = 1
 	},


### PR DESCRIPTION
Removes the DNA manipulator from the rocksprings bottom left 'dungeon'. The only faction that ever gets this is the legion, because no one is going to try and contest legion. The legion should not be using a dna manipulator and the only good reason is powergaming, no one else in the wasteland can grab one of these boards, so either it should be removed, or other factions should have access to them. 

Or at the very least it should be put in a more center dungeon that's more difficult.