### PR TITLE
Stimpack Crafting Nerfs Ft. Legion Chems

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -141,7 +141,8 @@
 	time = 20
 	category = CAT_MEDICAL
 
-/*datum/crafting_recipe/superstimpak
+/*
+/datum/crafting_recipe/superstimpak
 	/name = "Super Stimpak"
 	/result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
 	/reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
@@ -159,7 +160,8 @@
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
 	/tools = list(TOOL_WORKBENCH)
 	/time = 30
-	/category = CAT_MEDICAL*/
+	/category = CAT_MEDICAL
+*/
 
 /datum/crafting_recipe/salvage_stimpak
 	name = "Salvage injector"

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -141,25 +141,25 @@
 	time = 20
 	category = CAT_MEDICAL
 
-//datum/crafting_recipe/superstimpak
-	//name = "Super Stimpak"
-	//result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	//reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
-				///obj/item/stack/sheet/leather = 2,
-				///obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
-	//tools = list(TOOL_WORKBENCH)
-	//time = 20
-	//category = CAT_MEDICAL
+/*datum/crafting_recipe/superstimpak
+	/name = "Super Stimpak"
+	/result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
+	/reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+				/obj/item/stack/sheet/leather = 2,
+				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
+	/tools = list(TOOL_WORKBENCH)
+	/time = 20
+	/category = CAT_MEDICAL
 
-//datum/crafting_recipe/superstimpak5
-	//name = "Super Stimpak (x5)"
-	//result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
-	//reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
-				///obj/item/stack/sheet/leather = 10,
-				///obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
-	//tools = list(TOOL_WORKBENCH)
-	//time = 30
-	//category = CAT_MEDICAL
+/datum/crafting_recipe/superstimpak5
+	/name = "Super Stimpak (x5)"
+	/result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
+	/reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+				/obj/item/stack/sheet/leather = 10,
+				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
+	/tools = list(TOOL_WORKBENCH)
+	/time = 30
+	/category = CAT_MEDICAL*/
 
 /datum/crafting_recipe/salvage_stimpak
 	name = "Salvage injector"

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -143,24 +143,24 @@
 
 /*
 /datum/crafting_recipe/superstimpak
-	/name = "Super Stimpak"
-	/result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	/reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+	name = "Super Stimpak"
+	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
+	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 				/obj/item/stack/sheet/leather = 2,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
-	/tools = list(TOOL_WORKBENCH)
-	/time = 20
-	/category = CAT_MEDICAL
+	tools = list(TOOL_WORKBENCH)
+	time = 20
+	category = CAT_MEDICAL
 
 /datum/crafting_recipe/superstimpak5
-	/name = "Super Stimpak (x5)"
-	/result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
-	/reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+	name = "Super Stimpak (x5)"
+	result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
+	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
 				/obj/item/stack/sheet/leather = 10,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
-	/tools = list(TOOL_WORKBENCH)
-	/time = 30
-	/category = CAT_MEDICAL
+	tools = list(TOOL_WORKBENCH)
+	time = 30
+	category = CAT_MEDICAL
 */
 
 /datum/crafting_recipe/salvage_stimpak

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -122,8 +122,8 @@
 	always_available = FALSE
 
 /datum/crafting_recipe/stimpak
-	name = "Stimpak"
-	result = /obj/item/reagent_containers/hypospray/medipen/stimpak
+	name = "Improvised Stimpak"
+	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/imitation
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 2,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 2,
 				/obj/item/reagent_containers/syringe = 1)
@@ -132,8 +132,8 @@
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/stimpak5
-	name = "Stimpak x5"
-	result = /obj/item/storage/box/medicine/stimpaks/stimpaks5
+	name = "Improvised Stimpak x5"
+	result = /obj/item/storage/box/medicine/stimpaks/imitation_stimpaks5
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 10,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 10,
 				/obj/item/reagent_containers/syringe = 5)
@@ -141,25 +141,25 @@
 	time = 20
 	category = CAT_MEDICAL
 
-/datum/crafting_recipe/superstimpak
-	name = "Super Stimpak"
-	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
-				/obj/item/stack/sheet/leather = 2,
-				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
-	tools = list(TOOL_WORKBENCH)
-	time = 20
-	category = CAT_MEDICAL
+//datum/crafting_recipe/superstimpak
+	//name = "Super Stimpak"
+	//result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
+	//reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+				///obj/item/stack/sheet/leather = 2,
+				///obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
+	//tools = list(TOOL_WORKBENCH)
+	//time = 20
+	//category = CAT_MEDICAL
 
-/datum/crafting_recipe/superstimpak5
-	name = "Super Stimpak (x5)"
-	result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
-	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
-				/obj/item/stack/sheet/leather = 10,
-				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
-	tools = list(TOOL_WORKBENCH)
-	time = 30
-	category = CAT_MEDICAL
+//datum/crafting_recipe/superstimpak5
+	//name = "Super Stimpak (x5)"
+	//result = /obj/item/storage/box/medicine/stimpaks/superstimpaks5
+	//reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 5,
+				///obj/item/stack/sheet/leather = 10,
+				///obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
+	//tools = list(TOOL_WORKBENCH)
+	//time = 30
+	//category = CAT_MEDICAL
 
 /datum/crafting_recipe/salvage_stimpak
 	name = "Salvage injector"

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -247,8 +247,8 @@
 	taste_description = "bitterness"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
 	overdose_threshold = 31
-	var/heal_factor = -5 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -5.5 //Multiplier if you have the right perk.
+	var/heal_factor = -3 //Subtractive multiplier if you do not have the perk.
+	var/heal_factor_perk = -3.5 //Multiplier if you have the right perk.
 	ghoulfriendly = TRUE
 
 /datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
@@ -283,8 +283,8 @@
 	taste_description = "bitterness"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
-	var/heal_factor = -1.5 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -2.2 //Multiplier if you have the right perk.
+	var/heal_factor = -0.8 //Subtractive multiplier if you do not have the perk.
+	var/heal_factor_perk = -1 //Multiplier if you have the right perk.
 	ghoulfriendly = TRUE
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)
@@ -321,8 +321,8 @@
 	description = "Restores limb condition and heals rapidly."
 	color = "#C8A5DC"
 	overdose_threshold = 20
-	heal_factor = -3.0
-	heal_factor_perk = -3.5
+	heal_factor = -1.5
+	heal_factor_perk = -2.0
 
 // ---------------------------
 // RAD-X REAGENT
@@ -694,10 +694,23 @@
 	color = "#6D6374"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 16//No real downsides with use, aside from popping it twice quickly.
+	var/heal_factor = -6 //Subtractive multiplier if you do not have the perk.
+	var/heal_factor_perk = -8 //Multiplier if you have the right perk.
 	addiction_threshold = 14//No real downsides with use, aside from popping it twice quickly.
 	self_consuming = TRUE//So you can process without a liver. For future disembowelment reworks.
 
 /datum/reagent/medicine/hydra/on_mob_life(mob/living/carbon/M)
+	var/is_tribal = FALSE
+	if(HAS_TRAIT(M, TRAIT_TRIBAL))
+		is_tribal = TRUE
+	var/heal_rate = (is_tribal ? heal_factor_perk : heal_factor) * REAGENTS_EFFECT_MULTIPLIER
+	if(!M.reagents.has_reagent(/datum/reagent/medicine/stimpak) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder/poultice) && !M.reagents.has_reagent(/datum/reagent/medicine/healing_powder) && !M.reagents.has_reagent(/datum/reagent/medicine/super_stimpak))
+		M.adjustFireLoss(heal_rate)
+		M.adjustBruteLoss(heal_rate)
+		M.adjustToxLoss(heal_rate)
+		M.hallucination = max(M.hallucination, is_tribal ? 0 : 5)
+		M.radiation -= min(M.radiation, 8)
+		. = TRUE
 	for(var/thing in M.all_wounds)
 		var/datum/wound/W = thing
 		var/obj/item/bodypart/wounded_part = W.limb

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -395,11 +395,11 @@
 	name = "Super Stimpak Fluid"
 	id = /datum/reagent/medicine/super_stimpak
 	results = list(/datum/reagent/medicine/super_stimpak = 2)
-	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1) //1 mutfruit at 50 potency yields 6 mutfruit juice
+	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/toxin/plasma = 1) 
 
 /datum/chemical_reaction/superstimpak/synthetic
 	id = "super_stimpak_synthetic"
-	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/consumable/mutjuice = 1) //1 mutfruit at 50 potency yields 6 mutfruit juice
+	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/toxin/plasma = 1) //1 mutfruit at 50 potency yields 6 mutfruit juice
 
 /datum/chemical_reaction/medx
 	name = "Med-X"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -399,7 +399,7 @@
 
 /datum/chemical_reaction/superstimpak/synthetic
 	id = "super_stimpak_synthetic"
-	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/toxin/plasma = 1) //1 mutfruit at 50 potency yields 6 mutfruit juice
+	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/medicine/stimpak = 1, /datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/medx
 	name = "Med-X"


### PR DESCRIPTION
Made it so you can only make imitation stimpacks (because lore wise xander and broc _are_ what you make imitation with. 

The main reason behind this is that people just cheese literally the best healing item in the game. Stimpacks surpass all advanced chems by nearly five times, superstimpacks even more than this. The fact that the best healing chem bar none can be made en masse by planting three crops and printing a bunch of injectors is kinda a joke.

Also removed hand-crafting superstims because, hand-crafting the best pre-war medicine ever created using some flowers and some leather is ???

On top of that, the chemistry recipe for superstims replaced the muttfruit juice ingredient with plasma, making it so you actually have to put in effort in order to make such a rediculously strong healing item. 