### PR TITLE
Reduces the movespeed penalties of a few semi-automatic weapons.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -764,7 +764,7 @@
 	spread = 1
 	extra_damage = 32
 	extra_penetration = 0.2
-	slowdown = 0.5
+	slowdown = 0.3
 	can_attachments = FALSE
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
@@ -911,7 +911,7 @@
 	extra_speed = 500
 	burst_size = 1
 	fire_delay = 4
-	slowdown = 0.4
+	slowdown = 0.3
 	spread = 1
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -764,7 +764,7 @@
 	spread = 1
 	extra_damage = 32
 	extra_penetration = 0.2
-	slowdown = 0.3
+	slowdown = 0.25
 	can_attachments = FALSE
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Reduces the movespeed penalty of (thus far) the combat rifle and the rangemaster.
Rangemaster movespeed penalty reduced to 0.3 from 0.4
Combat rifle movespeed penalty reduced to 0.25 from 0.5 (Absurd)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This brings the two guns down to a better baseline with the rest of the semi-automatic weapons in the game. The best example is the marksman carbine with 0.2 movespeed and comparable stats to the changed weapons.

Combat rifle movespeed was reduced to 0.25 as 0.5 was simply absurd for a semi-auto weapon with its stats and fire delay. Seriously.

Rangemaster movespeed was reduced to 0.3 from 0.4 because it only has 1 more damage and 0.8 more AP than the marksman carbine, along with increased projectile speed. It's fire delay is however double that of the marksman carbine. Simply put, whilst it did compete with the marksman carbine most would argue in favor of the marksman.

Movespeed is simply a lot more important on this server than on wasteland or other FO13 servers, when people run around at mach 5 having this much slowdown on what is supposed to be high tier semi-auto ballistics is kind of dumb.

I'm no savant at balancing weapons, this is just to bring attention to the fact we have these weapons with absurd movespeed penalties when they are literally comparable to the marksman carbine, though slower to fire whilst hitting harder in regards to AP.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Rangemaster movespeed penalty reduced to 0.3 from 0.4
Combat rifle movespeed penalty reduced to 0.25 from 0.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
