### PR TITLE
Prevents stacking of defensive structures

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -6,6 +6,19 @@
 #define WOOD 2
 #define SAND 3
 
+//To avoid cheesing when building defenses
+
+GLOBAL_LIST_INIT(blocking_structures, typecacheof(list(
+		/obj/structure/table,
+		/obj/structure/table_frame,
+		/obj/structure/barricade/concrete,
+		/obj/structure/barricade/sandbags,
+		/obj/structure/barricade/wooden,
+		/obj/structure/obstacle/barbedwire,
+		/obj/structure/grille,
+		/obj/structure/fence
+)))
+
 //Barricades/cover
 
 /obj/structure/barricade
@@ -99,8 +112,6 @@
 	return ..()
 */
 
-
-
 /obj/structure/barricade/sandbags
 	name = "sandbags"
 	desc = "Bags of sand. Self explanatory."
@@ -128,11 +139,6 @@
 
 /obj/structure/barricade/sandbags/make_debris()
 	new /obj/item/stack/ore/glass(get_turf(src), drop_amount)
-
-
-
-
-
 
 /obj/structure/barricade/tent
 	name = "tent wall"
@@ -162,18 +168,6 @@
 /obj/structure/barricade/tent/make_debris()
 	new /obj/item/stack/sheet/cloth(get_turf(src), drop_amount)
 
-
-
-
-
-
-
-
-
-
-
-
-
 /obj/structure/barricade/security
 	name = "security barrier"
 	desc = "A deployable barrier. Provides good cover in fire fights."
@@ -199,7 +193,6 @@
 	anchored = TRUE
 	if(deploy_message)
 		visible_message("<span class='warning'>[src] deploys!</span>")
-
 
 /obj/item/grenade/barrier
 	name = "barrier grenade"

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,20 +1,20 @@
 GLOBAL_LIST_INIT(rod_recipes, list ( \
-	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 	new/datum/stack_recipe("metal bars", /obj/structure/barricade/bars, 4, time = 20, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("barred door", /obj/structure/simple_door/metal/barred, 30, time = 40, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("railing", /obj/structure/railing, 3, time = 18, window_checks = TRUE), \
-	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 	new/datum/stack_recipe("flagpole", /obj/item/flag, 2, time = 8, one_per_turf = 1, on_floor = 1), \
 	null, \
 	new/datum/stack_recipe_list("fences", list( \
-		new /datum/stack_recipe("fence", /obj/structure/fence,8, time = 20, one_per_turf = 1, on_floor = 1), \
-		new /datum/stack_recipe("fence (corner)", /obj/structure/fence/corner, 8, time = 20, one_per_turf = 1, on_floor = 1), \
-		new /datum/stack_recipe("fence (end)", /obj/structure/fence/end, 8, time = 20, one_per_turf = 1, on_floor = 1), \
-		new /datum/stack_recipe("fence (gate)", /obj/structure/simple_door/metal/fence, 8, time = 20, one_per_turf = 1, on_floor = 1), \
+		new /datum/stack_recipe("fence", /obj/structure/fence,8, time = 20, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
+		new /datum/stack_recipe("fence (corner)", /obj/structure/fence/corner, 8, time = 20, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
+		new /datum/stack_recipe("fence (end)", /obj/structure/fence/end, 8, time = 20, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
+		new /datum/stack_recipe("fence (gate)", /obj/structure/simple_door/metal/fence, 8, time = 20, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 		)),
 	null, \
-	new/datum/stack_recipe("barbed wire",/obj/structure/obstacle/barbedwire, 5, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("barbed wire ends", /obj/structure/obstacle/barbedwire/end, 5, time = 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("barbed wire",/obj/structure/obstacle/barbedwire, 5, time = 10, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
+	new/datum/stack_recipe("barbed wire ends", /obj/structure/obstacle/barbedwire/end, 5, time = 10, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 	))
 /obj/item/stack/rods
 	name = "metal rod"

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/mineral/sandbags
 
 GLOBAL_LIST_INIT(sandbag_recipes, list ( \
-	new/datum/stack_recipe("sandbags", /obj/structure/barricade/sandbags, 1, time = 25, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("sandbags", /obj/structure/barricade/sandbags, 1, time = 25, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 	))
 
 /obj/item/stack/sheet/mineral/sandbags/get_main_recipes()
@@ -424,7 +424,7 @@ GLOBAL_LIST_INIT(snow_recipes, list ( \
 GLOBAL_LIST_INIT(abductor_recipes, list ( \
 	new/datum/stack_recipe("poylmer bed", /obj/structure/bed/abductor, 2, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("polymer locker", /obj/structure/closet/abductor, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("polymer table frame", /obj/structure/table_frame/abductor, 1, time = 15, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("polymer table frame", /obj/structure/table_frame/abductor, 1, time = 15, one_per_turf = 1, on_floor = 1, check_for = GLOB.blocking_structures), \
 	new/datum/stack_recipe("polymer bar stool", /obj/item/chair/stool/bar/alien, 1, time = 20, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("polymer stool", /obj/item/chair/stool/alien, 1, time = 20, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("poylmer airlock assembly", /obj/structure/door_assembly/door_assembly_abductor, 4, time = 20, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -309,7 +309,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("fancy chair", /obj/structure/chair/wood/fancy, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("antique chair", /obj/structure/chair/wood/wings, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("deckchair", /obj/structure/chair/comfy/plywood, 4, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("table frame", /obj/structure/table_frame/wood, 2, time = 10), \
+	new/datum/stack_recipe("table frame", /obj/structure/table_frame/wood, 2, time = 10, check_for = GLOB.blocking_structures), \
 	new/datum/stack_recipe("bed", /obj/structure/bed/wooden, 2, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("closet", /obj/structure/closet/cabinet, 2, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("shelf", /obj/structure/shelf_wood, 1, time = 20, one_per_turf = TRUE, on_floor = TRUE), \
@@ -673,7 +673,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	new/datum/stack_recipe("brass chair", /obj/structure/chair/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass bar stool",  /obj/structure/chair/stool/bar/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass stool", /obj/structure/chair/stool/brass, 1, time = 0, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("brass table frame", /obj/structure/table_frame/brass, 1, time = 5, one_per_turf = TRUE, on_floor = TRUE, check_for = GLOB.blocking_structures), \
 	new/datum/stack_recipe("brass anvil", /obj/structure/anvil/obtainable/ratvar, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("brass furnace", /obj/structure/furnace/infinite/ratvar, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -304,6 +304,12 @@
 	if(R.one_per_turf && (locate(R.result_type) in T))
 		to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 		return FALSE
+	if(R.check_for.len)
+		for(var/check in R.check_for)
+			var/obj/found = locate(check) in T
+			if(found)
+				to_chat(usr, "<span class='warning'>There is a [found.name] here!</span>")
+				return FALSE
 	if(R.on_floor)
 		if(!isfloorturf(T) && !isgroundturf(T))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
@@ -495,8 +501,9 @@
 	var/applies_mats = FALSE
 	var/trait_booster = null
 	var/trait_modifier = 1
+	var/list/check_for = list()
 
-/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1,time = 0, one_per_turf = FALSE, on_floor = FALSE, window_checks = FALSE, placement_checks = FALSE, applies_mats = FALSE, trait_booster = null, trait_modifier = 1)
+/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1,time = 0, one_per_turf = FALSE, on_floor = FALSE, window_checks = FALSE, placement_checks = FALSE, applies_mats = FALSE, trait_booster = null, trait_modifier = 1, list/check_for = list())
 
 
 	src.title = title
@@ -512,6 +519,7 @@
 	src.applies_mats = applies_mats
 	src.trait_booster = trait_booster
 	src.trait_modifier = trait_modifier
+	src.check_for = check_for
 /*
  * Recipe list datum
  */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

Simply adds a check when crafting a few structures (like sandbags, tables or barbed wire) to check they don't have another defensive structure under them.
(Also deletes some strange blank spaces left in the deployables file for some reason)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The defense meta has become so deeply-ingrained that every round the factions are basically _forced_ to spend an hour or more building the perfect unbreachable position.
This PR looks to break it up a little, especially the table + sandbags meta that was, in all honesty, an exploit, as you couldn't climb over them. This time that is no longer spent building can be spent roleplaying.
This also does away with some of the cheesing in dungeons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->