### PR TITLE
Adds another Enclave scientist

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -372,7 +372,7 @@
 	title = "Enclave Scientist"
 	flag = F13USSCIENTIST
 	total_positions = 3
-	spawn_positions = 2
+	spawn_positions = 3
 	description = "You're a small garrison within a side entrance of a far larger complex. This complex sits within the Casper mountain range. You're responsible for the maintenance of the base and field studies, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in your field of research, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
 	supervisors = "Enclave Research and Development Division."
 	outfit = /datum/outfit/job/enclave/noncombat/enclavesci

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -371,7 +371,7 @@
 /datum/job/enclave/enclavesci
 	title = "Enclave Scientist"
 	flag = F13USSCIENTIST
-	total_positions = 2
+	total_positions = 3
 	spawn_positions = 2
 	description = "You're a small garrison within a side entrance of a far larger complex. This complex sits within the Casper mountain range. You're responsible for the maintenance of the base and field studies, the knowledge you've accumulated over the years is the only thing keeping the remnants alive. You've dabbled in enough to be considered a Professor in your field of research, but they call you Doctor. Support your dwindling forces and listen to the Lieutenant."
 	supervisors = "Enclave Research and Development Division."


### PR DESCRIPTION



## About The Pull Request

Raises enclave scientist roles from 2 to 3. Why? We have 5 labs. Only 2 scientists. Enclave should not be raiding to begin with and scientists got the "No you cant go out and raid" flag on them. I'd argue for 4 slots but lets see if 3 is sufficient.  

## Why It's Good For The Game

Allows for 3 scientists to exist, allows to actually get things done and allows to work better on projects without putting all the pressure on two scientist players that have to manage the entire base full of soldiers wanting some good support and probably having to do a surgery or two if they get killed in the field.  Atleast it should raise the slots by 1. Not sure if spawn points need to be raised. Its changing one number. Man I am good at coding. 


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


I get somebody that actually has patience to check if this would boot up. Should though, its a number change.

## Changelog
:cl:
add: One more scientist slot to Enclave, they are non combatants so they shouldnt go out on PVP raids anyways. Not like Enclave conducts raids.
/:cl:


