### PR TITLE
Trait Rebalance

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -230,8 +230,8 @@
 /area/f13/followers)
 "aaW" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe{
-	pixel_y = 22;
-	density = 0
+	density = 0;
+	pixel_y = 22
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -870,7 +870,6 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "aAb" = (
-/obj/item/clothing/suit/armor/f13/power_armor/midwest,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/west,
@@ -878,7 +877,6 @@
 /obj/machinery/door/window/brigdoor{
 	req_access_txt = "255"
 	},
-/obj/item/clothing/head/helmet/f13/power_armor/midwest,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault/side,
 /area/f13/brotherhood)
@@ -6430,8 +6428,8 @@
 "dbG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/card/bos{
-	pixel_y = 18;
-	density = 0
+	density = 0;
+	pixel_y = 18
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -6577,8 +6575,8 @@
 /area/f13/tunnel)
 "dlV" = (
 /obj/machinery/vending/medical{
-	pixel_y = 22;
-	density = 0
+	density = 0;
+	pixel_y = 22
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -7113,14 +7111,16 @@
 	},
 /area/f13/tunnel)
 "eaY" = (
-/obj/item/clothing/suit/armor/f13/power_armor/midwest,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/helmet/f13/power_armor/midwest,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "255"
+	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
@@ -7688,8 +7688,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop";
-	dir = 1
+	dir = 1;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "eVN" = (
@@ -8103,13 +8103,15 @@
 	},
 /area/f13/tunnel)
 "fIn" = (
-/obj/item/clothing/suit/armor/f13/power_armor/midwest,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/helmet/f13/power_armor/midwest,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	req_access_txt = "255"
+	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
 	},
@@ -8427,8 +8429,8 @@
 /area/f13/brotherhood)
 "gkC" = (
 /obj/structure/closet/crate/bin{
-	pixel_y = 27;
-	density = 0
+	density = 0;
+	pixel_y = 27
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -8825,8 +8827,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 8;
-	termtag = "Private";
-	pixel_y = 5
+	pixel_y = 5;
+	termtag = "Private"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -9790,8 +9792,8 @@
 	pixel_y = 11
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 6;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/bottle/wine{
@@ -9972,8 +9974,8 @@
 	},
 /obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop";
-	dir = 1
+	dir = 1;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "iNY" = (
@@ -10648,8 +10650,8 @@
 /area/f13/building/massfusion)
 "jRx" = (
 /obj/machinery/door/airlock/hatch{
-	req_access_txt = "120";
-	name = "Meeting Room"
+	name = "Meeting Room";
+	req_access_txt = "120"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/offices1st)
@@ -11552,8 +11554,8 @@
 "lsS" = (
 /obj/item/flag/bos{
 	density = 0;
-	pixel_y = 29;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 29
 	},
 /obj/machinery/light{
 	dir = 1
@@ -13475,8 +13477,8 @@
 /area/f13/tunnel)
 "oBx" = (
 /obj/machinery/vending/wardrobe/science_wardrobe{
-	pixel_y = 22;
-	density = 0
+	density = 0;
+	pixel_y = 22
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -14129,8 +14131,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 4;
-	termtag = "Business";
-	pixel_y = 5
+	pixel_y = 5;
+	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/offices1st)
@@ -14645,9 +14647,9 @@
 /area/f13/tunnel)
 "qmd" = (
 /obj/machinery/chem_dispenser/drinks/beer{
+	density = 0;
 	dir = 1;
-	pixel_y = -15;
-	density = 0
+	pixel_y = -15
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -15032,8 +15034,8 @@
 /area/f13/tunnel)
 "qRH" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe{
-	pixel_y = 22;
-	density = 0
+	density = 0;
+	pixel_y = 22
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -15195,8 +15197,8 @@
 /area/f13/tunnel)
 "rhX" = (
 /obj/machinery/door/airlock/hatch{
-	req_access_txt = "120";
-	name = "Medical Bay"
+	name = "Medical Bay";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/medical)
@@ -15787,7 +15789,6 @@
 	},
 /area/f13/tunnel)
 "sbH" = (
-/obj/item/clothing/suit/armor/f13/power_armor/excavator,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -15795,8 +15796,9 @@
 /obj/machinery/door/window/brigdoor{
 	req_access_txt = "255"
 	},
-/obj/item/clothing/head/helmet/f13/power_armor/excavator,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/energy/laser/plasma/pistol/remnant/is,
+/obj/item/clothing/head/helmet/f13/enclave/officer,
 /turf/open/floor/plasteel/vault,
 /area/f13/brotherhood)
 "scA" = (
@@ -18153,8 +18155,8 @@
 "vWe" = (
 /obj/item/flag/bos{
 	density = 0;
-	pixel_y = 1;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/darkred/side{
@@ -18330,8 +18332,8 @@
 "wlK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser{
-	pixel_y = 20;
-	density = 0
+	density = 0;
+	pixel_y = 20
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
@@ -18725,8 +18727,8 @@
 /area/f13/building/museum)
 "wTx" = (
 /obj/machinery/door/airlock/hatch{
-	req_access_txt = "120";
-	name = "Recovery Ward"
+	name = "Recovery Ward";
+	req_access_txt = "120"
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -18770,9 +18772,9 @@
 /area/f13/tunnel)
 "wWo" = (
 /obj/machinery/chem_dispenser/drinks{
+	density = 0;
 	dir = 1;
-	pixel_y = -15;
-	density = 0
+	pixel_y = -15
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -18878,12 +18880,12 @@
 "xeZ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 4;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 9;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 9
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -878,6 +878,7 @@
 	req_access_txt = "255"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/bos_vault_armor,
 /turf/open/floor/plasteel/vault/side,
 /area/f13/brotherhood)
 "aAJ" = (
@@ -7110,21 +7111,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"eaY" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "255"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 8
-	},
-/area/f13/brotherhood)
 "ebV" = (
 /obj/item/storage/box/lights/tubes,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -8029,13 +8015,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"fAE" = (
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/f13/brotherhood)
 "fCT" = (
 /turf/open/floor/f13{
 	icon_state = "rampdowntop"
@@ -8102,20 +8081,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"fIn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	req_access_txt = "255"
-	},
-/turf/open/floor/plasteel/vault/side{
-	dir = 4
-	},
-/area/f13/brotherhood)
 "fII" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -12236,10 +12201,16 @@
 	},
 /area/f13/brotherhood/armory)
 "mqg" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	req_access_txt = "255"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/bos_vault,
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
 	},
@@ -13723,14 +13694,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oTd" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/vault/side{
-	dir = 1
-	},
-/area/f13/brotherhood)
 "oTg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17512,10 +17475,17 @@
 	},
 /area/f13/bunker)
 "uUY" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	req_access_txt = "255"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/bos_vault,
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
 	},
@@ -78982,7 +78952,7 @@ aae
 oVq
 iko
 dIo
-fIn
+mqg
 dIo
 mqg
 oVq
@@ -79497,7 +79467,7 @@ oVq
 sEc
 duV
 hpP
-fAE
+mpk
 cdu
 tpb
 vuj
@@ -79755,7 +79725,7 @@ aAb
 hpP
 sbH
 hpP
-oTd
+mpk
 soO
 oCe
 gYI
@@ -80011,7 +79981,7 @@ oVq
 sEc
 duV
 hpP
-fAE
+mpk
 cdu
 oVq
 mNH
@@ -80524,7 +80494,7 @@ aae
 oVq
 sWg
 hSI
-eaY
+uUY
 hSI
 uUY
 oVq

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -20100,8 +20100,8 @@
 	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "rampdowntop";
-	dir = 4
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "bvf" = (
@@ -25516,8 +25516,8 @@
 "dGj" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -26371,8 +26371,8 @@
 "enf" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
-	pixel_y = 14;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 14
 	},
 /obj/item/storage/box/beakers{
 	pixel_x = -6;
@@ -27071,8 +27071,8 @@
 "eMv" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer{
-	pixel_y = 15;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 15
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -30156,8 +30156,8 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_y = 29;
-	density = 0
+	density = 0;
+	pixel_y = 29
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -32906,8 +32906,8 @@
 "iGg" = (
 /obj/structure/railing,
 /turf/open/floor/f13{
-	icon_state = "rampdowntop";
-	dir = 4
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "iGv" = (
@@ -33735,8 +33735,8 @@
 /area/f13/building/mall)
 "jbP" = (
 /obj/machinery/vending/dinnerware{
-	pixel_y = -7;
-	density = 0
+	density = 0;
+	pixel_y = -7
 	},
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/leisure)
@@ -36159,8 +36159,8 @@
 "kKN" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
-	pixel_y = 30;
-	density = 0
+	density = 0;
+	pixel_y = 30
 	},
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -41188,21 +41188,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland/museum)
-"obz" = (
-/obj/machinery/button/door{
-	id = "bosgateinside";
-	name = "Watchhouse Shutters";
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	pixel_y = 8;
-	pixel_x = -8;
-	id = "Front Shutters";
-	name = "Front Shutters"
-	},
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/brotherhood)
 "obM" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
@@ -42611,8 +42596,8 @@
 /area/f13/wasteland/valley)
 "oQI" = (
 /turf/open/floor/f13{
-	icon_state = "rampdowntop";
-	dir = 4
+	dir = 4;
+	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood)
 "oQP" = (
@@ -48976,6 +48961,18 @@
 /area/f13/building/hospital)
 "thC" = (
 /obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "Front Shutters";
+	name = "Front Shutters";
+	pixel_x = -8;
+	pixel_y = -32
+	},
+/obj/machinery/button/door{
+	id = "bosgateinside";
+	name = "Watchhouse Shutters";
+	pixel_x = 8;
+	pixel_y = -32
+	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
@@ -51475,10 +51472,10 @@
 "uKa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
+	density = 0;
 	dir = 4;
-	termtag = "Business";
 	pixel_y = 6;
-	density = 0
+	termtag = "Business"
 	},
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -52249,12 +52246,12 @@
 "vgq" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/pillbottles{
-	pixel_y = 14;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 14
 	},
 /obj/item/storage/box/gloves{
-	pixel_y = 4;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
@@ -102016,7 +102013,7 @@ dbM
 dbM
 uKa
 thC
-obz
+rcg
 nwf
 kIC
 dbM

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -864,9 +864,9 @@ GLOBAL_LIST_INIT(loot_t3_money, list(
 ))
 
 GLOBAL_LIST_INIT(loot_skillbook, list(
-	/obj/item/book/granter/trait/chemistry,
+//	/obj/item/book/granter/trait/chemistry,
 	/obj/item/book/granter/trait/trekking,
-	/obj/item/book/granter/trait/pa_wear,
+//	/obj/item/book/granter/trait/pa_wear,
 	/obj/item/book/granter/crafting_recipe/gunsmith_one,
 	/obj/item/book/granter/crafting_recipe/gunsmith_two,
 	/obj/item/book/granter/crafting_recipe/gunsmith_three,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2077,10 +2077,10 @@
 	name = "trait book spawner"
 	lootcount = 1
 	loot = list(/obj/item/book/granter/trait/lowsurgery = 10,
-				/obj/item/book/granter/trait/chemistry = 10,
+//				/obj/item/book/granter/trait/chemistry = 10,
 				/obj/item/book/granter/trait/trekking = 10,
-				/obj/item/book/granter/trait/techno = 10,
-				/obj/item/book/granter/trait/pa_wear = 1,
+//				/obj/item/book/granter/trait/techno = 10,
+//				/obj/item/book/granter/trait/pa_wear = 1,
 				/obj/item/book/granter/trait/explosives = 10,
 				/obj/item/book/granter/trait/explosives_advanced = 5,
 				/obj/item/book/granter/trait/rifleman = 5,
@@ -2093,8 +2093,8 @@
 	name = "low trait book spawner"
 	lootcount = 1
 	loot = list(/obj/item/book/granter/trait/lowsurgery = 5,
-				/obj/item/book/granter/trait/chemistry = 1,
-				/obj/item/book/granter/trait/techno = 10,
+//				/obj/item/book/granter/trait/chemistry = 1,
+//				/obj/item/book/granter/trait/techno = 10,
 				/obj/item/book/granter/crafting_recipe/scav_one = 10,
 				/obj/item/book/granter/crafting_recipe/scav_two = 10,
 				/obj/item/book/granter/trait/explosives = 10,

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1043,7 +1043,7 @@
 	time_per_page = 0
 
 /obj/item/book/granter/trait/selection/attack_self(mob/user)
-	var/list/choices = list("Big Book of Science","Dean's Electronics","Grognak the Barbarian","First Aid Pamphlet","Wasteland Survival Guide")
+	var/list/choices = list("Grognak the Barbarian","Wasteland Survival Guide")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1053,20 +1053,6 @@
 				granted_trait = TRAIT_HARD_YARDS
 				traitname = "trekking"
 				remarks = list("Tribes and gangs often hide the best loot in the back room.", "Radiation is best avoided entirely, but it helps to carry spare rad-x.", "Whether ancient or recent, landmines are still a threat, and readers should look out for them. Their detonators can be removed with a screwdriver.", "Injuries and open bleeding make it harder to travel, always carry spare medical supplies.", "Most animals are simple-minded, and can be led into easy lines of fire.")
-			if("First Aid Pamphlet")
-				granted_trait = TRAIT_SURGERY_LOW
-				traitname = "minor surgery"
-				remarks = list("Keep your hands and any injuries clean!", "While bandages help to seal a wound, they do not heal a wound.", "Remain calm, focus on the task at hand, stop the bleeding.", "An open wound can lead to easy infection of said wound.", "Keep track of your home's first aid kit, restock used components regularly.", "If a body part has been lost, ice and transport it with the injured to a hospital.",)
-			if("Big Book of Science")
-				granted_trait = TRAIT_CHEMWHIZ
-				traitname = "chemistry"
-				crafting_recipe_types = list(/datum/crafting_recipe/jet, /datum/crafting_recipe/turbo, /datum/crafting_recipe/psycho, /datum/crafting_recipe/medx, /datum/crafting_recipe/buffout)
-				remarks = list("Always ensure a safe working environment, promptly clean any chemical mess.", "Improperly stored chemicals can quickly lead to safety hazards.", "Do not abuse chemicals for recreational use in the laboratory!", "Labcoats and goggles not only protect you from burns, but give an aura of authority.", "Keep your laboratory clean and organized, utilize cabinets and shelves.", "Potassium and water should not be mixed, or they will react violently.")
-			if("Dean's Electronics")
-				granted_trait = TRAIT_TECHNOPHREAK
-				traitname = "craftsmanship"
-				crafting_recipe_types = list(/datum/crafting_recipe/tribalradio)
-				remarks = list("Troubleshooting is a systematic approach to problem solving, do not skip any steps in the process.", "Ensure you have all the required parts before you begin.", "Always wear personal protective equipment, electric shock can be fatal.", "Combustibles and sparks do not mix, store welding fuel in a safe location.", "Don't lose track of your tools, or you have a new problem to deal with.")
 			if("Grognak the Barbarian")
 				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "hitting things"
@@ -1085,7 +1071,7 @@
 		desc = "A compendium of knowledge passed down from the elders. It looks to be in poor condition."
 
 /obj/item/book/granter/trait/selection/tribal/attack_self(mob/user)
-	var/list/choices = list("Hit Them With Sticks","Technophilia","Pugilist","Padded Feet","Veteran Table Climber","Basic Surgery")
+	var/list/choices = list("Hit Them With Sticks","Pugilist","Padded Feet","Veteran Table Climber","Desert Affinity")
 	if(granted_trait == null)
 		var/choice = input("Choose a trait:") in choices
 		switch(choice)
@@ -1094,10 +1080,6 @@
 			if("Hit Them With Sticks")
 				granted_trait = TRAIT_BIG_LEAGUES
 				traitname = "fighting with melee weapons"
-			if("Technophilia")
-				granted_trait = TRAIT_TECHNOPHREAK
-				traitname = "technology and crafting"
-				crafting_recipe_types = list(/datum/crafting_recipe/ninemil, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/n99, /datum/crafting_recipe/huntingrifle, /datum/crafting_recipe/m1911, /datum/crafting_recipe/varmintrifle, /datum/crafting_recipe/autoaxe, /datum/crafting_recipe/steelsaw, /datum/crafting_recipe/tools/forged/entrenching_tool, /datum/crafting_recipe/chainsaw, /datum/crafting_recipe/steeltower, /datum/crafting_recipe/durathread_vest)
 			if("Pugilist")
 				granted_trait = TRAIT_IRONFIST
 				traitname = "using your fists"
@@ -1107,9 +1089,6 @@
 			if("Veteran Table Climber")
 				granted_trait = TRAIT_FREERUNNING
 				traitname = "....climbing tables"
-			if("Basic Surgery")
-				granted_trait = TRAIT_SURGERY_LOW
-				traitname = "basic surgery"
 			if("Desert Affinity")
 				granted_trait = TRAIT_HARD_YARDS
 				traitname = "trekking"

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -531,16 +531,12 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Rad-X pill",					/obj/item/reagent_containers/pill/radx,								20),
 		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							30),
 		new /datum/data/wasteland_equipment("Stimpak",						/obj/item/reagent_containers/hypospray/medipen/stimpak,				100),
-		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								600),
-		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							500)
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Syringe",						/obj/item/reagent_containers/syringe,								10),
 		new /datum/data/wasteland_equipment("Empty pillbottle",				/obj/item/storage/pill_bottle,										15),
 		new /datum/data/wasteland_equipment("Rad-X pill",					/obj/item/reagent_containers/pill/radx,								20),
 		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							30),
-		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								600),
-		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							500)
 		)
 
 /obj/machinery/mineral/wasteland_vendor/khanchem
@@ -739,7 +735,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Explorer satchel",				/obj/item/storage/backpack/satchel/explorer,						25),
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
-		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600)
 		)
 	highpop_list = list(
 		new /datum/data/wasteland_equipment("Drinking glass",				/obj/item/reagent_containers/food/drinks/drinkingglass,				5),
@@ -747,7 +742,6 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Explorer satchel",				/obj/item/storage/backpack/satchel/explorer,						25),
 		new /datum/data/wasteland_equipment("Spray bottle",					/obj/item/reagent_containers/spray,									35),
 		new /datum/data/wasteland_equipment("Bottle of E-Z-Nutrient",		/obj/item/reagent_containers/glass/bottle/nutrient/ez,				40),
-		new /datum/data/wasteland_equipment("Craftsmanship Monthly",		/obj/item/book/granter/trait/techno,								600)
 		)
 
 /* These are shit, don't add them.

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -597,7 +597,7 @@
 	blob_allowed = 0
 	environment = 6
 	grow_chance = 5
-	requires_power = TRUE
+//	requires_power = TRUE
 
 /area/f13/brotherhood/rnd
 	name = "Brotherhood of Steel RnD Department"//Brother Hood

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -835,7 +835,6 @@
 
 /obj/machinery/smartfridge/bottlerack/lootshelf/books
 	chance_initial_contents = list(
-		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/reagent_containers/food/snacks/deadmouse = 1,
 		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one = 1,

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -801,11 +801,6 @@ Senior Knight
 		),
 	)
 
-/datum/outfit/job/bos/f13seniorknight/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 
 /datum/outfit/job/bos/f13seniorknight/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -918,12 +913,6 @@ Knight
 			/datum/job/bos/f13seniorknight,
 		),
 	)
-
-/datum/outfit/job/bos/f13knight/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	ADD_TRAIT(H, TRAIT_PA_WEAR, src)
 
 /datum/outfit/job/bos/f13knight/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -1073,13 +1062,6 @@ Initiate
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/survival = 1,
 		)
-
-/datum/outfit/job/bos/f13initiate/post_equip(mob/living/carbon/human/H, visualsOnly)
-	..()
-	if(visualsOnly)
-		return
-	ADD_TRAIT(H, TRAIT_SURGERY_LOW, src)
-
 
 /datum/outfit/loadout/initiatek
 	name = "Errant"

--- a/modular_sunset/code/mob/renegade.dm
+++ b/modular_sunset/code/mob/renegade.dm
@@ -207,7 +207,7 @@
 	extra_projectiles = 5
 	projectiletype = /obj/item/projectile/bullet/m5mm/simple
 	projectilesound = 'sound/f13weapons/automaticrifle_BAR.ogg'
-	loot = list(/obj/item/book/granter/trait/pa_wear, /obj/item/stack/f13Cash/random/high, /obj/item/advanced_crafting_components/alloys, /obj/item/stack/sheet/plasteel/five)
+	loot = list(/obj/item/stack/f13Cash/random/high, /obj/item/advanced_crafting_components/alloys, /obj/item/stack/sheet/plasteel/five)
 	speak = list("POWER TO THE ARMOR!", "I AM GOING TO BREAK YOU IN HALF!", "YEAH I COMPENSATE WITH BIG FUCKIN' GUNS", "DODGE THIS!", "PEAK RENEGADE PERFORMANCE!")
 	speak_emote = list("says")
 	speak_chance = 1


### PR DESCRIPTION
- - -
Balance:
 - PA Wear can no longer be obtained from lootdrop. You require training roundstart, or staff intervention to obtain it. Get to RPing. This locks the suits to Enclave and Brotherhood.
 - Chemistry, Technophile and Surgery and all variations removed from the general Wastelander trait book, alongside Tribal. The books have also been removed from circulation loot wise, to create some manner of actual RP around the Followers and give them a purpose.
 - Knights no longer have PA Wear, with the exception of the Knight-Commander.
 - Initiate has lost basic surgery.
 - Brotherhood no longer have a power requirement. For now.
- - -
Map:
 - Brotherhood vault emptied. Provided two fluff items in the center. Kind of.
- - -