### PR TITLE
Hee-Hoo Carl Loadout Abuse

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -844,6 +844,12 @@
 	new /obj/item/ammo_box/m44(src)
 	new /obj/item/ammo_box/m44(src)
 
+/obj/item/storage/belt/holster/regulator/PopulateContents()
+	new /obj/item/gun/energy/laser/complianceregulator(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)
+
 /obj/item/storage/belt/holster/legholster
 	name = "leg holster"
 	desc = "A holster to carry a handgun and ammo worn on the leg."

--- a/code/modules/clothing/custom/custom_clothing.dm
+++ b/code/modules/clothing/custom/custom_clothing.dm
@@ -62,3 +62,64 @@
 		icon_state = "kemblecoat_green"
 		item_state = "kemblecoat_green"
 		to_chat(user, "You reverse the coat to show the green side.")
+
+// CARL //
+
+/obj/item/clothing/suit/armor/f13/rangercombat/desert/carl
+	name = "hazard combat armor"
+	desc = "An older suit used by the Rangers of the NCR, reclaimed from an army depot at some point after the war. This one appears to be specially treated. \
+	Unfortunately, this makes it unsuited to anything but the most basic of duties unrelated to hazard work."
+	//Incredible utility, alongside retaining parent flash resist and such, as it lacks almost all protection.
+	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 65, "bomb" = 5, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wound" = 15)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	heat_protection = CHEST|GROIN|LEGS|ARMS
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+
+//Probably not needed, but we'll see.
+/obj/item/clothing/suit/armor/f13/rangercombat/desert/carl/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)
+
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/carl
+	name = "hazard combat helmet"
+	desc = "An older helmet used by the Rangers of the NCR, reclaimed from an army depot at some point after the war. This one appears to be specially treated and \
+	boasting advanced filters. Unfortunately, this makes it unsuited to anything but the most basic of duties unrelated to hazard work."
+	//Incredible utility, alongside retaining parent flash resist and such, as it lacks almost all protection.
+	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 65, "bomb" = 5, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wound" = 15)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+
+//Probably not needed, but we'll see.
+/obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/carl/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)
+
+/obj/item/clothing/gloves/f13/military/carl
+	desc = "Gloves with an insulating layer for working around chemicals and in hazardous environments. These appear to be from an old army depot."
+	//Incredible utility, as it lacks almost all protection.
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wound" = 0)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	heat_protection = HANDS
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+
+/obj/item/clothing/shoes/f13/military/ncr_officer_boots/carl
+	desc = "Boots with an insulating layer for working around chemicals and in hazardous environments. These appear to be from an old army depot."
+	//Incredible utility, as it lacks almost all protection.
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wound" = 0)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	heat_protection = FEET
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+
+/obj/item/clothing/under/f13/ranger/modif_ranger/carl
+	desc = "A uniform with an insulating layer for working around chemicals and in hazardous environments. These appear to be from an old army depot."
+	//No protection at all. Above should cover everything, and being naked shouldn't provide any protection as the character this is intended for.
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 0)
+
+/obj/item/card/id/rusted/brokenholodog/carl
+	name = "old holotag"
+	desc = "An old advanced holographic dogtag. Kept as a reminder to something."

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -199,3 +199,18 @@
 /obj/item/storage/box/large/custom_kit/krig/PopulateContents()
 	new /obj/item/book/granter/trait/krig(src)
 
+/datum/gear/donator/kits/carl
+	name ="Hazard Gear"
+	path = /obj/item/storage/box/large/custom_kit/carl
+	ckeywhitelist = list ("nothingbutcarl")
+
+/obj/item/storage/box/large/custom_kit/carl/PopulateContents()
+	new /obj/item/clothing/head/helmet/f13/ncr/rangercombat/desert/carl(src)
+	new /obj/item/clothing/suit/armor/f13/rangercombat/desert/carl(src)
+	new /obj/item/card/id/rusted/brokenholodog/carl(src)
+	new /obj/item/clothing/gloves/f13/military/carl(src)
+	new /obj/item/clothing/shoes/f13/military/ncr_officer_boots/carl(src)
+	new /obj/item/clothing/under/f13/ranger/modif_ranger/carl(src)
+	new /obj/item/storage/belt/holster/regulator(src)
+	new /obj/item/nuke_core_container(src)
+	new /obj/item/screwdriver/nuke(src)


### PR DESCRIPTION
- - -
Added my own loadout. Funny abuse time woohoo. Armor has next to no protection outside of utility, and is used for a ghoul character as is, so that's another thing to tack on. It's thematically centred around being hazard equipment and is practically useless in PvP except for the fire immunity, which isn't really used outside of the NCR as is.

Helmet trades practically all protection for utility, and retains flash resist and the NVG overlay, which is worthless for ghouls anyway and not that great as is.

General armor layout, for the suit and helmet, with the rest having identical without actual protection values aside from utility (The 100 row.):
 - melee/bullet/laser = 5
 - energy = 65
 - bomb = 5
 - bio/rad/fire/acid = 100
 - wound = 15
The exception is the uniform, which has no protection whatsoever.

The armor is able to be reinforced with plating, but that can easily be removed. The equipment itself consists of:
 - Suit
 - Helmet
 - Hazard gloves / boots / uniform (None have a unique name, instead having a unique description.)
 - Old dogtags.
 - Compliance Regulator holster.
 - Nuke core container and screwdriver.
- - -