### PR TITLE
Reverts the welding tool change to synthetic limbs

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -115,7 +115,7 @@
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && user.a_intent != INTENT_HARM)
 		//only heal to 25 if limb is damaged to or past 25 brute, otherwise heal normally
-		var/difference = affecting.brute_dam - 25
+		var/difference = affecting.brute_dam - 0
 		var/heal_amount = 15
 		if(difference >= 0)
 			heal_amount = difference


### PR DESCRIPTION

## About The Pull Request

25 brute is done by many things in a single hit. Many mobs have some degree of AP. Synthetics have to suffer through wounds like organics, have easy to loose limbs and a considerable EMP vulnerability. Their organs also get messed up by EMPs.  This fix is more of a nerf than a fix even if its fixing function. Burn already needs internal surgery to fix. Why should synths currently be the only ones that frequently rely on Followers for what is essentially surgery for being hit by a reaver ghoul? Adding this drawback with no upsides like not having to breath or not taking toxloss? Too much. Give it a try yourself. Play as synthetic get hit by a stray shot of anything. Get tapped by a ghoul reaver. Be stuck with residue damage. Not fun. Hence the revert.

## Why It's Good For The Game

Synths have too much of a drawback with that change with no upsides. If tox immunity and no oxyloss and MAYBE wound immunity would be ported this should be considered. Otherwise they rely on: Followers to get their residue damage fixed. Something organics don't need to do unless they have a critical wound. That is ontop of their gimping EMP weakness and easy limbloss.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog



:cl:
tweak: Reverts the synth damage threshold for brute damage back to zero allowing healing with welding tools. Burn damage still works like before.
/:cl:


