### PR TITLE
Combat rifle spawner bugfix

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1299,7 +1299,7 @@
 	name = "combat rifle and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/automatic/combat,
-				/obj/item/ammo_box/magazine/greasegun/
+				/obj/item/ammo_box/magazine/tommygunm45/stick
 				)
 
 /obj/effect/spawner/bundle/f13/rcw


### PR DESCRIPTION
## About The Pull Request
Adds the correct ammo for the combat rifle

## Changelog
:cl:
fix: Replaces grease gun mags with tommygun sticks on the lootspawn with the combat rifle.
/:cl: