### PR TITLE
Follower Protolathe

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -15957,7 +15957,7 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/tunnel)
 "qKn" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
+/obj/machinery/rnd/production/protolathe,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},


### PR DESCRIPTION
Changes the Followers protolathe back into the regular, after Carl made an oopsie and changed it back to a medical lathe accidentally.