### PR TITLE
xenobio nerf, food prefs, blood compatibility

### DIFF
--- a/code/game/objects/items/storage/f13storage.dm
+++ b/code/game/objects/items/storage/f13storage.dm
@@ -399,7 +399,7 @@
 
 /obj/item/storage/box/ration/ranger_lunch/PopulateContents()
 	. = ..()
-	new /obj/item/reagent_containers/food/snacks/f13/canned/ncr/breakfast(src)
+	new /obj/item/reagent_containers/food/snacks/f13/canned/ncr/lunch(src)
 	new /obj/item/reagent_containers/food/snacks/cracker/k_ration(src)
 	new /obj/item/reagent_containers/food/snacks/cracker/k_ration(src)
 	new /obj/item/reagent_containers/food/snacks/cracker/k_ration(src)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -388,7 +388,7 @@
 		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/pda = 1,
 		/obj/item/gun/energy/gammagun = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/stock_parts/cell/ammo/mfc = 2,
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/clothing/head/beret/enclave/science = 1,

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -388,7 +388,7 @@
 		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/pda = 1,
 		/obj/item/gun/energy/gammagun = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 2,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/clothing/head/beret/enclave/science = 1,

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -248,13 +248,13 @@
 		"AB+" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "SY"),
 		"O-" = list("O-","SY"),
 		"O+" = list("O-", "O+","SY"),
-		"L" = list("L","SY"),
+		"L" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "SY"),
 		"U" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U","SY"),
 		"HF" = list("HF", "SY"),
 		"X*" = list("X*", "SY"),
 		"SY" = list("SY"),
 		"GEL" = list("GEL","SY"),
-		"BUG" = list("BUG", "SY")
+		"BUG" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "BUG", "SY")
 	)
 
 	var/safe = bloodtypes_safe[bloodtype]

--- a/code/modules/mob/living/carbon/human/species_types/bugmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/bugmen.dm
@@ -12,7 +12,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/insect
 	liked_food = MEAT | FRUIT
-	disliked_food = TOXIC
+	disliked_food = NONE
 	exotic_bloodtype = "BUG"
 	exotic_blood_color = BLOOD_COLOR_BUG
 

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -21,8 +21,8 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"
 	exotic_blood_color = BLOOD_COLOR_LIZARD
-	disliked_food = GRAIN | DAIRY
-	liked_food = GROSS | MEAT
+	disliked_food = TOXIC
+	liked_food = RAW | MEAT
 	inert_mutation = FIREBREATH
 	species_language_holder = /datum/language_holder/lizard
 

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -12,7 +12,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
 	liked_food = VEGETABLES | DAIRY
-	disliked_food = FRUIT | GROSS
+	disliked_food = GROSS
 	toxic_food = MEAT | RAW
 	mutanteyes = /obj/item/organ/eyes/moth
 	laugh_male = 'sound/voice/moth/mothlaugh.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -116,7 +116,7 @@
 	flag = "energy"
 	armour_penetration = 1 //it only does 5 damage.
 	damage_type = "toxin"
-	irradiate = 200
+	irradiate = 250
 	range = 15
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
 

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -153,9 +153,9 @@ Burning extracts:
 	colour = "sepia"
 
 /obj/item/slimecross/burning/sepia/do_effect(mob/user)
-	user.visible_message("<span class='notice'>[src] shapes itself into a camera!</span>")
+	/*user.visible_message("<span class='notice'>[src] shapes itself into a camera!</span>")
 	new /obj/item/camera/rewind(get_turf(user))
-	..()
+	..()*/
 
 /obj/item/slimecross/burning/cerulean
 	colour = "cerulean"

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -135,7 +135,7 @@ Chilling extracts:
 	var/active = FALSE
 
 /obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
-	if(!proximity || !isliving(target) || active)
+	/*if(!proximity || !isliving(target) || active)
 		return
 	if(target in allies)
 		allies -= target
@@ -143,7 +143,7 @@ Chilling extracts:
 	else
 		allies |= target
 		to_chat(user, "<span class='notice'>You link [src] with [target].</span>")
-	return
+	return*/
 
 /obj/item/slimecross/chilling/bluespace/do_effect(mob/user)
 	if(allies.len <= 0)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -136,14 +136,14 @@ Regenerative extracts:
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
-	target.visible_message("<span class='warning'>[src] disappears in a shower of sparks!</span>","<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
+	/*target.visible_message("<span class='warning'>[src] disappears in a shower of sparks!</span>","<span class='danger'>The milky goo teleports you somewhere it remembers!</span>")
 	do_sparks(5,FALSE,target)
 	target.forceMove(T)
-	do_sparks(5,FALSE,target)
+	do_sparks(5,FALSE,target)*/
 
 /obj/item/slimecross/regenerative/bluespace/Initialize()
-	. = ..()
-	T = get_turf(src)
+	/*. = ..()
+	T = get_turf(src)*/
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -142,8 +142,8 @@ Regenerative extracts:
 	do_sparks(5,FALSE,target)*/
 
 /obj/item/slimecross/regenerative/bluespace/Initialize()
-	/*. = ..()
-	T = get_turf(src)*/
+	. = ..()
+	T = get_turf(src)
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -492,8 +492,8 @@
 				do_teleport(user, get_turf(user), 6, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 				return 300
 
-		if(SLIME_ACTIVATE_MAJOR)
-			if(!teleport_ready)
+		/*if(SLIME_ACTIVATE_MAJOR)
+			if(teleport_ready)
 				to_chat(user, "<span class='notice'>You feel yourself anchoring to this spot...</span>")
 				var/turf/T = get_turf(user)
 				teleport_x = T.x
@@ -506,7 +506,7 @@
 					var/turf/T = locate(teleport_x, teleport_y, teleport_z)
 					to_chat(user, "<span class='notice'>You snap back to your anchor point!</span>")
 					do_teleport(user, T,  asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-					return 450
+					return 450*/
 
 
 /obj/item/slime_extract/pyrite
@@ -836,7 +836,7 @@
 	icon_state = "potyellow"
 
 /obj/item/slimepotion/speed/afterattack(obj/C, mob/user)
-	. = ..()
+	/*. = ..()
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
 		return
@@ -859,7 +859,7 @@
 	to_chat(user, "<span class='notice'>You slather the red gunk over the [C], making it faster.</span>")
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	C.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)
-	qdel(src)
+	qdel(src)*/
 
 /obj/item/slimepotion/fireproof
 	name = "slime chill potion"


### PR DESCRIPTION
## About The Pull Request

fixes enclave scientist ammo spawn (im retarded and gave it the wrong ammo type after it was already fixed cause i got it mixed up), changes bug and lizard blood to be a universal recipient due to the death sentence that bloodloss as a bug/lizard was, comments out certain overpowered/too strong xenobiological things, and tweaks species food preferences to allow more RP-oriented tastes rather than mechanically enforced
## Why It's Good For The Game


## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.



## Changelog

:cl:
tweak: gives enclave scientists correct ammo upon spawn (im retarded)
tweak: changes some species food dislikes to basically allow players to decide
balance: disables certain overpowered/abusable xenobiology cores/extracts
balance: changes lizard and bug blood to be universal recipients like AB+
/:cl:

