### PR TITLE
uncomments the radio headset

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
@@ -13,7 +13,7 @@
 	build_path = /obj/item/assembly/signaler
 	category = list("initial", "T-Comm")
 
-/*
+
 /datum/design/radio_headset
 	name = "Radio Headset"
 	id = "radio_headset"
@@ -21,7 +21,7 @@
 	materials = list(/datum/material/iron = 75)
 	build_path = /obj/item/radio/headset
 	category = list("initial", "T-Comm")
-*/
+
 
 /datum/design/bounced_radio
 	name = "Station Bounced Radio"


### PR DESCRIPTION
## About The Pull Request

It uncomments and re-adds the radio headset to the workshop T-comms list.

## Why It's Good For The Game

It allows wastelanders and outlaws to be able to walk around with a radio that doesn't require you to manually turn it on from your backpack since we don't have :l or :r in this code. This was a change made in Coyote Bayou that was merged in Sunset Wasteland back in July 26 and no one ever bothered to change. This will make things better since it'll be a Quality of Life, since every faction already gets a headset anyway.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
tweak: uncomments the radio headset
/:cl:
