### PR TITLE
Major Balance Pass #1

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/ballistic.dm
+++ b/code/modules/projectiles/ammunition/caseless/ballistic.dm
@@ -17,6 +17,10 @@
 	name = "4.73mm U-235 cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/uraniumtipped
 
+/obj/item/ammo_casing/caseless/g11/minigun
+	name = "4.73mm caseless cartridge"
+	projectile_type  = /obj/item/projectile/bullet/a473/minigun
+
 /obj/item/ammo_casing/caseless/g11/dumdum
 	name = "4.73mm flat-nose cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/dumdum

--- a/code/modules/projectiles/boxes_magazines/internal/misc.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/misc.dm
@@ -24,7 +24,7 @@
 
 /obj/item/ammo_box/magazine/internal/encminigunbal4mm
 	name = "minigun ammo pack"
-	ammo_type = /obj/item/ammo_casing/caseless/g11
+	ammo_type = /obj/item/ammo_casing/caseless/g11/minigun
 	caliber = "473mm"
 	max_ammo = 480
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -219,7 +219,6 @@
 	autofire_shot_delay = 1.75
 	spread = 18
 	burst_shot_delay = 1.5
-	extra_damage = 10
 	suppressed = 1
 	actions_types = null
 	fire_sound = 'sound/f13weapons/american180.ogg'
@@ -237,8 +236,6 @@
 	automatic = 1
 	autofire_shot_delay = 3.25
 	spread = 9
-	extra_damage = 32
-	extra_penetration = 0.1
 	recoil = 0.35
 	can_attachments = TRUE
 	can_suppress = FALSE
@@ -253,7 +250,6 @@
 	item_state = "smg9mm"
 	mag_type = /obj/item/ammo_box/magazine/greasegun
 	spread = 8
-	extra_damage = 19
 	slowdown = 0.3
 	burst_shot_delay = 2.75
 	is_automatic = TRUE
@@ -295,7 +291,6 @@
 	can_attachments = FALSE
 	spread = 16.5
 	recoil = 0.3
-	extra_damage = 17
 
 /obj/item/gun/ballistic/automatic/smg/greasegun/worn/auto_select()
 	var/mob/living/carbon/human/user = usr
@@ -335,7 +330,6 @@
 	autofire_shot_delay = 2.35
 	spread = 12
 	slowdown = 0.3
-	extra_damage = 22
 	recoil = 0.5
 	fire_delay = 3.25
 	can_attachments = TRUE
@@ -350,7 +344,6 @@
 	desc = "Mass-produced weapon from the Great War, this one has seen use ever since. Grip is wrapped in tape to keep the plastic from crumbling, the metals are oxidizing, but the gun still works."
 	init_mag_type = /obj/item/ammo_box/magazine/m10mm_adv/ext
 	worn_out = TRUE
-	extra_damage = 18
 	spread = 10
 
 /obj/item/gun/ballistic/automatic/smg/smg10mm/auto_select()
@@ -390,7 +383,6 @@
 	slowdown = 0.3
 	autofire_shot_delay = 2
 	spread = 16
-	extra_damage = 17
 	can_suppress = TRUE
 	can_attachments = TRUE
 	suppressor_state = "uzi_suppressor"
@@ -435,7 +427,6 @@
 	autofire_shot_delay = 2.5
 	spread = 12
 	fire_delay = 3.5
-	extra_damage = 20
 	recoil = 0.1
 	can_attachments = TRUE
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
@@ -457,7 +448,6 @@
 	autofire_shot_delay = 2.25
 	burst_shot_delay = 2.75
 	fire_delay = 3.75
-	extra_damage = 25
 	spread = 15
 	recoil = 0.5
 
@@ -468,7 +458,6 @@
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
 	init_mag_type = /obj/item/ammo_box/magazine/tommygunm45/stick
 	fire_delay = 3.75
-	extra_damage = 23
 	spread = 19
 
 //P90				Keywords: 10mm, Automatic, 50 rounds. Special modifiers: damage +1
@@ -479,8 +468,6 @@
 	item_state = "m90"
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/m10mm_p90
-	extra_damage = 22
-	extra_penetration = 0.15
 	burst_size = 1
 	fire_delay = 3
 	spread = 14
@@ -500,7 +487,6 @@
 	desc = "A FN P90 manufactured by Fabrique Nationale. This one is beat to hell but still works."
 	autofire_shot_delay = 2.25
 	spread = 16
-	extra_damage = 20
 
 
 //MP-5 SD				Keywords: 9mm, Automatic, 32 rounds, Suppressed
@@ -517,7 +503,6 @@
 	automatic = 1
 	autofire_shot_delay = 2.15
 	burst_shot_delay = 2
-	extra_damage = 17
 	suppressed = 1
 	recoil = 0.05
 	can_attachments = TRUE
@@ -540,8 +525,7 @@
 	automatic = 1
 	autofire_shot_delay = 2.25
 	burst_shot_delay = 1.5
-	extra_damage = 18
-	extra_penetration = 0.05
+
 	recoil = 0.25
 	can_attachments = TRUE
 	can_scope = TRUE
@@ -565,8 +549,7 @@
 	burst_size = 1
 	fire_delay = 3
 	spread = 2
-	extra_damage = 20
-	extra_penetration = 0.1
+
 	slowdown = 0.05
 	automatic_burst_overlay = FALSE
 	can_bayonet = TRUE
@@ -594,7 +577,6 @@
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "ncr-m1carbine"
 	item_state = "rifle"
-	extra_damage = 25
 
 
 //M1A1 Carbine				Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel, Folding stock.
@@ -642,9 +624,8 @@
 	slowdown = 0.2
 	is_automatic = TRUE
 	automatic = TRUE
-	extra_damage = 20
 	autofire_shot_delay = 1.75
-	extra_penetration = 0.2
+
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	spread = 3 //foregrip
@@ -672,8 +653,7 @@
 	fire_delay = 3.5
 	burst_size = 1
 	spread = 0
-	extra_damage = 20
-	extra_speed = 500
+
 	can_bayonet = FALSE
 	semi_auto = TRUE
 	automatic_burst_overlay = FALSE
@@ -695,8 +675,6 @@
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
 	slowdown = 0.05
-	extra_damage = 22
-	extra_penetration = 0.05
 	fire_delay = 4
 	burst_size = 1
 	spread = 0
@@ -726,7 +704,7 @@
 	desc = "Legends are told of the \"Ratslayer\", a custom-made souped-up varmint rifle with a sick paintjob. This is a pale imitation, made of chopped-up bits of other guns."
 	icon_state = "verminrifle"
 	item_state = "ratslayer"
-	extra_damage = 25
+
 	suppressed = 1
 	zoomable = TRUE
 	zoom_amt = 10
@@ -741,8 +719,6 @@
 	desc = "A modified varmint rifle with better stopping power, a scope, and suppressor. Oh, don't forget the sick paint job."
 	icon_state = "ratslayer"
 	item_state = "ratslayer"
-	extra_damage = 30
-	extra_penetration = 0.1
 	suppressed = 1
 	zoomable = TRUE
 	zoom_amt = 10
@@ -760,8 +736,6 @@
 	fire_delay = 3
 	burst_size = 1
 	spread = 1
-	extra_damage = 32
-	extra_penetration = 0.2
 	slowdown = 0.25
 	can_attachments = FALSE
 	automatic_burst_overlay = FALSE
@@ -780,7 +754,6 @@
 	fire_delay = 1
 	burst_size = 1
 	spread = 1
-	extra_damage = 25
 	can_attachments = TRUE
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
@@ -800,7 +773,6 @@
 	fire_delay = 1
 	burst_size = 2
 	spread = 1
-	extra_damage = 27
 	can_attachments = FALSE
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
@@ -818,7 +790,6 @@
 	icon_state = "scout_carbine"
 	spread = 1.2
 	slowdown = 0.05
-	extra_damage = 25
 	can_scope = TRUE
 	scope_state = "scope_short"
 	scope_x_offset = 4
@@ -838,8 +809,6 @@
 	icon_state = "rifle-police"
 	item_state = "assault_carbine"
 	init_mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	extra_damage = 25
-	extra_penetration = 0.1
 	spread = 1.1
 	fire_delay = 4
 	can_suppress = FALSE
@@ -855,8 +824,6 @@
 	item_state = "marksman"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 2
-	extra_penetration = 0.1
-	extra_damage = 34
 	slowdown = 0.2
 	burst_size = 1
 	spread = 1
@@ -887,8 +854,6 @@
 	icon_state = "rifle-police"
 	item_state = "assault_carbine"
 	init_mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	extra_damage = 25
-	extra_penetration = 0.1
 	spread = 1.1
 	fire_delay = 2
 	can_suppress = FALSE
@@ -904,8 +869,6 @@
 	icon_prefix = "308"
 	force = 20
 	mag_type = /obj/item/ammo_box/magazine/m762
-	extra_damage = 35
-	extra_penetration = 0.18
 	extra_speed = 500
 	burst_size = 1
 	fire_delay = 4
@@ -964,8 +927,6 @@
 	force = 20
 	slowdown = 0.2
 	mag_type = /obj/item/ammo_box/magazine/garand308
-	extra_damage = 38
-	extra_penetration = 0.1
 	fire_delay = 2
 	burst_size = 1
 	spread = 1
@@ -997,7 +958,6 @@
 	name = "Old Glory"
 	desc = "This Machine kills communists!"
 	icon_state = "oldglory"
-	extra_damage = 50
 
 //Republics Pride			Keywords: UNIQUE, 7.62mm, Semi-auto, 8 rounds internal, Scoped, Damage +8, Penetration +0.1
 /obj/item/gun/ballistic/automatic/m1garand/republicspride
@@ -1005,8 +965,6 @@
 	desc = "A well-tuned scoped M1C rifle crafted by master gunsmith from the Gunrunners. Chambered in 7.62x51."
 	icon_state = "republics_pride"
 	item_state = "scoped308"
-	extra_damage = 45
-	extra_penetration = 0.3
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
@@ -1019,7 +977,6 @@
 	desc = "A special modified heavy battle rifle built on the BAR, featuring an added pistol grip and a Cutts recoil compensator. This one features a long-range scope and its receiver bears a red star."
 	slowdown = 1.35
 	autofire_shot_delay = 2.95
-	extra_penetration = 0.2
 	spread = 8
 	recoil = 0.2
 	extra_speed = 250 //Get a load of this guy.
@@ -1041,8 +998,6 @@
 	item_state = "sks"
 	mag_type = /obj/item/ammo_box/magazine/sks
 	fire_delay = 2
-	extra_damage = 40
-	extra_penetration = 0.1
 	extra_speed = 100
 	bayonet_state = "bayonet"
 	knife_x_offset = 24
@@ -1065,8 +1020,6 @@
 	fire_delay = 3
 	burst_size = 1
 	extra_speed = 900
-	extra_penetration = 0.2
-	extra_damage = 43
 	slowdown = 0.3
 	zoom_amt = 10
 	zoom_out_amt = 13
@@ -1097,8 +1050,6 @@
 	slowdown = 0.25
 	zoom_amt = 15
 	zoom_out_amt = 17
-	extra_penetration = 0.4
-	extra_damage = 45
 
 /obj/item/gun/ballistic/automatic/marksman/sniper/sniperranger
 	name = "compact sniper rifle"
@@ -1118,7 +1069,6 @@
 	icon_state = "m16a1"
 	item_state = "servicerifle"
 	icon_prefix = "m16a1"
-	extra_damage = 28
 	fire_delay = 2.5
 	is_automatic = TRUE
 	slowdown = 0.3
@@ -1141,7 +1091,6 @@
 	fire_delay = 2.5
 	slowdown = 0.35
 	spread = 10
-	extra_damage = 25
 	recoil = 0.1
 	is_automatic = TRUE
 	automatic = 1
@@ -1166,7 +1115,6 @@
 	icon_state = "infiltrator"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
-	extra_damage = 25
 	spread = 9
 	fire_delay = 3.5
 	burst_shot_delay = 2
@@ -1195,7 +1143,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 1.15
 	spread = 1
-	extra_damage = 25
 	burst_size = 1
 	can_attachments = FALSE
 	semi_auto = TRUE
@@ -1218,8 +1165,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	fire_delay = 4
 	spread = 10
-	extra_damage = 23
-	extra_penetration = 0.05
 	is_automatic = TRUE
 	automatic = 1
 	autofire_shot_delay = 3
@@ -1239,7 +1184,6 @@
 	item_state = "handmade_rifle"
 	fire_delay = 5
 	spread = 13
-	extra_damage = 21
 	can_suppress = FALSE
 
 
@@ -1255,7 +1199,6 @@
 	automatic = 1
 	autofire_shot_delay = 2
 	burst_shot_delay = 1.5
-	extra_damage = 25
 	fire_delay = 3
 	spread = 8
 	recoil = 0.1
@@ -1283,8 +1226,6 @@
 	is_automatic = TRUE
 	automatic = 1
 	autofire_shot_delay = 1.75
-	extra_damage = 16
-	extra_penetration = 0.50
 	spread = 18 //high-velocity
 	can_attachments = TRUE
 	can_scope = FALSE
@@ -1311,10 +1252,8 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "rifle-police"
 	autofire_shot_delay = 3.5 //not a real auto-gun, a lot slower than the assault carbine
-	extra_damage = 24 //longer barrel
 	spread = 8 //more accurate than the assault carbine, its a rifle
 	can_scope = TRUE
-	extra_penetration = 0.10
 
 /obj/item/gun/ballistic/automatic/assault_carbine/worn
 	name = "worn assault carbine"
@@ -1323,8 +1262,7 @@
 	fire_delay = 3.5
 	burst_shot_delay = 2.2
 	spread = 18
-	extra_damage = 13
-	extra_penetration = 0.30
+
 //FN-FAL				Keywords: 7.62mm, Automatic, 10/20 round magazine
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"
@@ -1332,8 +1270,6 @@
 	icon_state = "fnfal"
 	item_state = "fnfal"
 	force = 20
-	extra_damage = 28
-	extra_penetration = 0.1
 	extra_speed = 400
 	fire_delay = 3.5
 	is_automatic = TRUE
@@ -1358,8 +1294,6 @@
 	force = 24 //club
 	slowdown = 1.5 //really goddamn big
 	autofire_shot_delay = 1.7
-	extra_damage = 32
-	extra_penetration = 0.35
 	spread = 10
 	recoil = 0.85
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -1374,7 +1308,6 @@
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/m473
 	burst_size = 1
-	extra_damage = 16
 	fire_delay = 2
 	is_automatic = TRUE
 	automatic = 1
@@ -1416,8 +1349,6 @@
 	slowdown = 1.25
 	recoil = 1
 	mag_type = /obj/item/ammo_box/magazine/lmg
-	extra_damage = 17
-	extra_penetration = 0.15
 	fire_delay = 2.7
 	burst_shot_delay = 3
 	is_automatic = TRUE
@@ -1444,7 +1375,6 @@
 	burst_shot_delay = 2
 	is_automatic = TRUE
 	automatic = 1
-	extra_damage = 23
 	spread = 12
 	spawnwithmagazine = TRUE
 	zoomable = TRUE
@@ -1470,8 +1400,6 @@
 	automatic = 1
 	autofire_shot_delay = 1.1
 	fire_delay = 2
-	extra_damage = 30
-	extra_penetration = 0.35
 	spread = 8
 	can_attachments = FALSE
 	var/cover_open = FALSE
@@ -1540,7 +1468,6 @@
 	item_state = "sniper"
 	slot_flags = SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/m2mm
-	extra_damage = 40
 	burst_size = 1
 	fire_delay = 10
 	zoomable = TRUE
@@ -1562,7 +1489,6 @@
 	automatic = 1
 	autofire_shot_delay = 2.5
 	spawnwithmagazine = TRUE
-	extra_damage = 25
 	spread = 8
 	can_attachments = TRUE
 	zoomable = TRUE

--- a/code/modules/projectiles/guns/ballistic/enc_minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/enc_minigun.dm
@@ -118,8 +118,6 @@
 	ranged_attack_speed = CLICK_CD_RAPID
 	spread = 18
 	weapon_weight = WEAPON_HEAVY
-	extra_penetration = 0.1
-	extra_damage = 12
 	fire_sound = 'sound/f13weapons/boltfire.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/encminigunbal4mm
 	casing_ejector = FALSE//For now.

--- a/code/modules/projectiles/guns/ballistic/minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/minigun.dm
@@ -115,8 +115,6 @@
 	ranged_attack_speed = CLICK_CD_RAPID
 	spread = 12
 	weapon_weight = WEAPON_HEAVY
-	extra_penetration = 0.01
-	extra_damage = 10
 	fire_sound = 'sound/f13weapons/assaultrifle_fire.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/minigunbal5mm
 	casing_ejector = FALSE//For now.

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -55,7 +55,6 @@
 	desc = "The silenced .22 pistol is a sporting handgun with an integrated silencer."
 	icon_state = "silenced22"
 	mag_type = /obj/item/ammo_box/magazine/m22
-	extra_damage = 18
 	weapon_weight = WEAPON_LIGHT
 	w_class = WEIGHT_CLASS_TINY
 	can_attachments = TRUE
@@ -71,7 +70,6 @@
 	desc = "A pre-war large-framed, gas-operated advanced 10mm pistol."
 	icon_state = "n99"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
-	extra_damage = 22
 	fire_delay = 1
 	recoil = 0.05
 	can_attachments = TRUE
@@ -87,7 +85,6 @@
 	desc = "A modified N99 pistol with an accurate two-round-burst and a blue Vault-Tec finish, a status symbol for some Overseers."
 	icon_state = "executive"
 	burst_size = 2
-	extra_damage = 4
 	semi_auto = FALSE
 	can_automatic = FALSE
 
@@ -95,8 +92,6 @@
 /obj/item/gun/ballistic/automatic/pistol/n99/crusader
 	name = "\improper Crusader pistol"
 	desc = "A large-framed N99 pistol emblazoned with the colors and insignia of the Brotherhood of Steel. It feels heavy in your hand."
-	extra_penetration = 0.1
-	extra_damage = 26
 	force = 18
 	icon_state = "crusader"
 	item_state = "crusader"
@@ -111,7 +106,6 @@
 	icon_state = "chinapistol"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
 	fire_delay = 1
-	extra_damage = 24
 	recoil = 0.1
 	spread = 3
 	can_suppress = FALSE
@@ -153,7 +147,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
 	weapon_weight = WEAPON_LIGHT
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 20
 	can_attachments = TRUE
 	suppressor_state = "pistol_suppressor"
 	suppressor_x_offset = 30
@@ -166,8 +159,6 @@
 	desc = "An ornately-decorated pre-war Browning Hi-power 9mm pistol with pearl grips and a polished nickel finish. The firing mechanism has been upgraded, so for anyone on the receiving end, it must seem like an eighteen-karat run of bad luck."
 	icon_state = "maria"
 	fire_delay = 2
-	extra_damage = 25
-	extra_penetration = 0.2
 
 
 //Sig Sauer P220						Keywords: 9mm, Semi-auto, 10 round magazine
@@ -178,7 +169,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_LIGHT
 	mag_type = /obj/item/ammo_box/magazine/m9mm
-	extra_damage = 19
 	can_attachments = TRUE
 	suppressor_state = "pistol_suppressor"
 	suppressor_x_offset = 30
@@ -193,7 +183,6 @@
 	icon_state = "beretta"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
 	weapon_weight = WEAPON_LIGHT
-	extra_damage = 20
 	spread = 1
 	can_attachments = TRUE
 	can_suppress = "pistol_suppressor"
@@ -248,7 +237,6 @@
 	fire_delay = 2
 	slowdown = 0.05
 	mag_type = /obj/item/ammo_box/magazine/m45
-	extra_damage = 30
 	recoil = 0.15
 	can_attachments = TRUE
 	suppressor_state = "pistol_suppressor"
@@ -273,7 +261,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m45exp
 	fire_delay = 2
 	slowdown = 0.07
-	extra_damage = 34
 	spread = 1
 	can_flashlight = TRUE
 	gunlight_state = "flight"
@@ -300,8 +287,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m44
 	fire_delay = 3
 	force = 15
-	extra_damage = 38
-	extra_penetration = 0.05
 	extra_speed = 300
 	recoil = 0.2
 	can_suppress = FALSE
@@ -316,8 +301,6 @@
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/m14mm
 	fire_delay = 0
-	extra_damage = 45
-	extra_penetration = 0.15
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
 
 //Automag			Keywords: .44 Magnum, Semi-auto, Long barrel, 7 rounds, Heavy. Special modifiers: bullet speed +300
@@ -328,7 +311,6 @@
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/automag
 	fire_delay = 4
-	extra_damage = 41
 	extra_speed = 300
 	recoil = 0.2
 	can_suppress = FALSE
@@ -343,8 +325,6 @@
 	icon_state = "pistol14"
 	mag_type = /obj/item/ammo_box/magazine/m14mm
 	force = 15
-	extra_damage = 44
-	extra_penetration = 0.1
 	fire_delay = 5
 	recoil = 0.25
 	can_suppress = FALSE
@@ -356,7 +336,6 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a compact model for concealed carry."
 	icon_state = "pistol14_compact"
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 42
 	spread = 5
 
 //Little Devil							Keywords: UNIQUE, 14mm, Semi-auto, Short barrel, 7 Rounds, Heavy. Special modifiers: damage +4, penetration +0.05, spread -3
@@ -365,7 +344,6 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a finely tuned custom firearm from the Gunrunners."
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 50
 	fire_delay = 4
 
 /obj/item/gun/ballistic/automatic/pistol/pistol14/custom
@@ -373,7 +351,6 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a finely tuned custom firearm. How'd this get into service?"
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 50
 	fire_delay = 4
 
 /////////////////////////////////

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -134,7 +134,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	force = 10
-	extra_damage = 30
 	spread = 4
 	obj_flags = UNIQUE_RENAME
 	var/list/safe_calibers
@@ -151,7 +150,6 @@
 	item_state = "45revolver"
 	icon_state = "45revolver"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45
-	extra_damage = 34
 	fire_delay = 4.5
 	spread = 1
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
@@ -169,7 +167,6 @@
 	icon_state = "357colt"
 	item_state = "357colt"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
-	extra_damage = 34
 	fire_delay = 4.5
 	spread = 0
 	fire_sound = 'sound/f13weapons/357magnum.ogg'
@@ -180,7 +177,6 @@
 	icon_state = "mateba"
 	item_state = "mateba"
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
-	extra_damage = 34
 
 //Lucky							Keywords: UNIQUE, .357, Double action, 6 rounds cylinder, Block chance, Fire delay -1
 /obj/item/gun/ballistic/revolver/colt357/lucky
@@ -189,7 +185,6 @@
 	icon_state = "lucky37"
 	item_state = "lucky"
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 40
 	fire_delay = 3
 	block_chance = 20
 
@@ -198,7 +193,6 @@
 	name = "police revolver"
 	desc = "Pre-war double action police revolver chambered in .357 magnum."
 	icon_state = "police"
-	extra_damage = 32
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
 	w_class = WEIGHT_CLASS_SMALL
 	spread = 2
@@ -217,8 +211,6 @@
 	item_state = "model29"
 	icon_state = "m29"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
-	extra_damage = 38
-	extra_penetration = 0.1
 	recoil = 0.1
 	can_scope = FALSE
 	scope_state = "revolver_scope"
@@ -231,7 +223,6 @@
 	item_state = "44magnum"
 	icon_state = "mysterious_m29"
 	can_scope = FALSE
-	extra_damage = 38
 
 
 //Peacekeeper					 Keywords: OASIS, .44, Double action, 6 rounds cylinder, Extra Firemode
@@ -240,7 +231,6 @@
 	desc = "When you don't just need excessive force, but crave it. This .44 has a special hammer mechanism, allowing for measured powerful shots, or fanning for a flurry of inaccurate shots."
 	item_state = "m29peace"
 	icon_state = "m29peace"
-	extra_damage = 45
 	automatic = 1
 	autofire_shot_delay = 1
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -252,7 +242,6 @@
 	desc = "A snubnose variant of the commonplace .44 magnum. An excellent holdout weapon for self defense."
 	icon_state = "m29_snub"
 	w_class = WEIGHT_CLASS_SMALL
-	extra_damage = 36
 	spread = 3
 
 
@@ -264,7 +253,6 @@
 	icon_state = "44colt"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
 	fire_delay = 4.5
-	extra_damage = 40
 	spread = 0
 	fire_sound = 'sound/f13weapons/44revolver.ogg'
 
@@ -274,15 +262,11 @@
 	name = "desert ranger revolver"
 	desc = "I hadn't noticed, but there on his hip, was a really spiffy looking iron..."
 	fire_delay = 4
-	extra_penetration = 0.1
-	extra_damage = 40
 
 //Sheriff's revolver			Keywords: .44, Single action, 6 rounds cylinder, 5 less damage than sequoia, 20% more pen
 /obj/item/gun/ballistic/revolver/revolver44/sheriff
 	name = "Biggest Iron"
 	desc = "There was forty feet between them, when they stopped to make their play..."
-	extra_penetration = 0.3
-	extra_damage = 40
 	force = 25
 	casing_ejector = TRUE//WHAT THE FUCK IS THIS GUN? FASTEST HAND IN THE WEST BETWEEN SHOTS, THAT'S WHAT.
 	can_scope = TRUE
@@ -305,8 +289,6 @@
 	weapon_weight = WEAPON_MEDIUM
 	recoil = 0.2
 	fire_delay = 1
-	extra_damage = 45
-	extra_penetration = 0.1
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev4570
 	fire_sound = 'sound/f13weapons/sequoia.ogg'
 
@@ -336,8 +318,6 @@
 	recoil = 0.1
 	can_scope = TRUE
 	scope_state = "revolver_scope"
-	extra_damage = 44
-	extra_penetration = 0.1
 	fire_delay = 5.5
 	scope_x_offset = 9
 	scope_y_offset = 20
@@ -346,8 +326,6 @@
 /obj/item/gun/ballistic/revolver/hunting/klatue
 	name = "degraded hunting revolver"
 	desc = "A scoped double action revolver chambered in 45-70. This one is very worn."
-	extra_damage = 34
-	extra_penetration = 0
 
 /////////////////////
 // WEIRD REVOLVERS //
@@ -361,8 +339,6 @@
 	item_state = "coltwalker"
 	icon_state = "peacemaker"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev45/gunslinger
-	extra_damage = 38
-	extra_penetration = 0.15
 	fire_delay = 4.5
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
 	spread = 0 //Your reward for the slower fire rate is less spread anddd
@@ -375,8 +351,6 @@
 	icon_state = "thatgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/thatgun
 	weapon_weight = WEAPON_MEDIUM
-	extra_damage = 33
-	extra_penetration = 0.2
 	spread = 4
 	recoil = 0.5
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
@@ -391,7 +365,6 @@
 /obj/item/gun/ballistic/revolver/needler
 	name = "Needler pistol"
 	desc = "You suspect this Bringham needler pistol was once used in scientific field studies. It uses small hard-plastic hypodermic darts as ammo. "
-	extra_damage = 21
 	icon_state = "needler"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -116,7 +116,6 @@
 	icon_state = "cowboyrepeater"
 	item_state = "cowboyrepeater"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube357
-	extra_damage = 35
 	extra_speed = 300
 	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
 
@@ -128,7 +127,6 @@
 	icon_state = "trailcarbine"
 	item_state = "trailcarbine"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44
-	extra_damage = 40
 	extra_speed = 200
 	fire_sound = 'sound/f13weapons/44mag.ogg'
 
@@ -140,8 +138,6 @@
 	icon_state = "brushgun"
 	item_state = "brushgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube4570
-	extra_damage = 50
-	extra_penetration = 0.05
 	extra_speed = 100
 	fire_delay = 3
 	recoil = 0.15
@@ -153,8 +149,6 @@
 	desc = "A custom-made Gun Runners brush gun with a shorter tube, featuring a sturdier frame, longer barrel, reinforced rifling, padded lever and a muzzle device. A medicine wheel is attached to one side of the stock along with two feathers."
 	icon_state = "medistick"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube4570/medicine
-	extra_damage = 50
-	extra_penetration = 0.2
 	extra_speed = 150
 	fire_delay = 2.25
 	recoil = 0.10
@@ -175,8 +169,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting
 	sawn_desc = "A hunting rifle, crudely shortened with a saw. It's far from accurate, but the short barrel makes it quite portable."
 	fire_delay = 4
-	extra_damage = 37
-	extra_penetration = 0.20
 	extra_speed = 800
 	spread = 0
 	force = 18
@@ -202,7 +194,6 @@
 	desc = "A militarized hunting rifle rechambered to 7.62. This one has had the barrel floated with shims to increase accuracy."
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting/remington
 	fire_delay = 2
-	extra_damage = 39
 	extra_speed = 800
 	force = 18
 
@@ -225,8 +216,6 @@
 	item_state = "paciencia"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting/paciencia
 	fire_delay = 9
-	extra_damage = 50 //hits like an AMR
-	extra_penetration = 0.2
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
@@ -250,7 +239,6 @@
 	icon_state = "mosin"
 	item_state = "308"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
-	extra_damage = 37
 	extra_speed = 600
 	fire_delay = 3
 	force = 18
@@ -272,7 +260,6 @@
 	icon_state = "enfield2"
 	item_state = "308"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
-	extra_damage = 40
 	extra_speed = 600
 	fire_delay = 1
 	slowdown = 0.35
@@ -341,8 +328,6 @@
 	item_state = "amr"
 	mag_type = /obj/item/ammo_box/magazine/amr
 	fire_delay = 12 //Heavy round, tiny bit slower
-	extra_damage = 60
-	extra_penetration = 1//Chunky munitions.
 	recoil = 1
 	spread = 0
 	force = 10 //Big clumsy and sensitive scope, makes for a poor club

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -115,8 +115,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/simple
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
-	extra_damage = 3.2
-	extra_penetration = 0.1
 	recoil = 1.55
 
 /obj/item/gun/ballistic/revolver/caravan_shotgun/attackby(obj/item/A, mob/user, params)
@@ -154,8 +152,6 @@
 	force = 20
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'
-	extra_damage = 2
-	extra_penetration = 0.05
 	recoil = 0.55
 
 /obj/item/gun/ballistic/revolver/widowmaker/attackby(obj/item/A, mob/user, params)
@@ -271,7 +267,6 @@
 /obj/item/gun/ballistic/shotgun/automatic/combat
 	name = "semi-auto shotgun template"
 	fire_delay = 6
-	extra_damage = 0
 	recoil = 0.1
 	spread = 2
 

--- a/code/modules/projectiles/guns/energy/plasmaf13.dm
+++ b/code/modules/projectiles/guns/energy/plasmaf13.dm
@@ -78,7 +78,6 @@
 	icon_state = "plasma"
 	armour_penetration = 0.1
 	slowdown = 0.75 //this is one of the worst slowdowns in the game
-	extra_damage = 30
 	fire_delay = 5.2
 	desc = "A miniaturized plasma caster that fires bolts of magnetically accelerated toroidal plasma towards an unlucky target."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
@@ -94,7 +93,6 @@
 	desc = "A burst-fire energy weapon that fires a steady stream of toroidal plasma towards an unlucky target."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasmacarbine)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
-	extra_damage = 15
 	burst_size = 2
 	burst_shot_delay = 1.5
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -119,7 +117,6 @@
 	item_state = "multiplas"
 	icon_state = "multiplas"
 	fire_delay = 3
-	extra_damage = 15
 	desc = "A modified A3-20 plasma caster built by REPCONN equipped with a multicasting kit that creates multiple weaker clots."
 	equipsound = 'sound/f13weapons/equipsounds/plasequip.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/scatter)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -313,7 +313,7 @@
 
 /obj/item/gun/energy/emitter
 	name = "Emitter Carbine"
-	desc = "A small emitter fitted into a handgun case, do to size constraints and safety it can only shoot about ten times when fully charged."
+	desc = "A small emitter fitted into a handgun case, due to size constraints and safety it can only shoot about ten times when fully charged."
 	icon_state = "emitter_carbine"
 	force = 12
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/projectiles/guns/hoboguns.dm
+++ b/code/modules/projectiles/guns/hoboguns.dm
@@ -72,7 +72,6 @@
 	slowdown = 0.1
 	mag_type = /obj/item/ammo_box/magazine/zipgun
 	force = 16
-	extra_damage = 27 //unrealistically high to make up for low capacity and explode in your hands, roughly where the old 9mm used to be
 
 	spread = 8
 	fire_delay = 4
@@ -94,7 +93,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvisedpipe
 	force = 20
 	fire_delay = 0.25
-	extra_damage = 33
 	spread = 2
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 
@@ -118,7 +116,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised10mm
 	force = 20
 	fire_delay = 0.25
-	extra_damage = 28
 	spread = 7
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 
@@ -145,7 +142,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	force = 26 //Good club
 	fire_delay = 0.5
-	extra_damage = 2
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
 
 /obj/item/gun/ballistic/revolver/single_shotgun/update_icon_state()
@@ -164,7 +160,6 @@
 	force = 24
 	fire_delay = 0.5
 	spread = 4
-	extra_damage = 32
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 
 
@@ -181,7 +176,6 @@
 	force = 24
 	fire_delay = 0.25
 	spread = 5
-	extra_damage = 32
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 
 
@@ -198,8 +192,6 @@
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/autopipe
 	force = 20
-	extra_damage = 25 //a lot less than the .357 magnum, because OP
-	extra_penetration = 0.05 //long barrel
 	burst_size = 4
 	fire_delay = 6
 	burst_shot_delay = 6
@@ -265,7 +257,6 @@
 	icon_state = "destroyer-carbine"
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/greasegun
-	extra_damage = 30
 	fire_delay = 5
 	burst_size = 1
 	can_attachments = FALSE
@@ -309,7 +300,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised762
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	extra_damage = 30
 	fire_delay = 0.25
 	force = 20
 	spread = 5

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -524,14 +524,12 @@
 
 /obj/item/projectile/f13plasma/pistol //Plasma pistol
 	damage = 18
-	wound_bonus = 20 //being hit with plasma is horrific
 
 /obj/item/projectile/f13plasma/pistol/worn
 	damage = 16
 
 /obj/item/projectile/f13plasma/pistol/glock //Glock (streamlined plasma pistol)
 	damage = 20
-	wound_bonus = 35 //being hit with plasma is horrific
 
 /obj/item/projectile/f13plasma/scatter //Multiplas, fires 3 shots, will melt you
 	damage = 25
@@ -546,7 +544,7 @@
 /obj/item/projectile/beam/laser/rcw/hitscan //RCW
 	name = "rapidfire beam"
 	icon_state = "emitter"
-	damage = 15
+	damage = 18
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
 	tracer_type = /obj/effect/projectile/tracer/laser/emitter

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -37,19 +37,19 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c22
 	name = ".22lr bullet"
-	damage = 0
+	damage = 12
 	wound_bonus = 6
 
 /obj/item/projectile/bullet/c22/rubber
 	name = ".22lr rubber bullet"
-	damage = 0
+	damage = 2
 	stamina = 22
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c22/shock
 	name = ".22lr shock bullet"
-	damage = -4 //about -25% damage
+	damage = 8
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
@@ -63,22 +63,22 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 0
-	wound_bonus = 10
+	damage = 14
+	wound_bonus = 12
 
 /obj/item/projectile/bullet/c38/rubber
 	name = ".38 rubber bullet"
-	damage = -28
+	damage = 4
 	stamina = 32
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c38/improv
-	damage = -3
+	damage = 12
 
 /obj/item/projectile/bullet/c38/acid
 	name = ".38 acid-tipped bullet"
-	damage = -5
+	damage = 4
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	var/acid_type = /datum/reagent/toxin/acid/fluacid
@@ -98,7 +98,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c38/incendiary
 	name = ".38 incendiary bullet"
-	damage = -5
+	damage = 4
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c38/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -116,24 +116,24 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm FMJ bullet"
-	damage = 0
+	damage = 16
 	wound_bonus = 10
 
 /obj/item/projectile/bullet/c9mm/op
 	name = "9mm +P bullet"
-	damage = 27
+	damage = 18
 	var/extra_speed = 500
 
 /obj/item/projectile/bullet/c9mm/rubber
 	name = "9mm rubber bullet"
-	damage = -15
+	damage = 6
 	stamina = 25
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c9mm/acid
 	name = "9mm acid-tipped bullet"
-	damage = -5
+	damage = 4
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	var/acid_type = /datum/reagent/toxin/acid/fluacid
@@ -152,7 +152,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c9mm/incendiary
 	name = "9mm incendiary bullet"
-	damage = -5
+	damage = 4
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c9mm/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -163,7 +163,7 @@ Uranium, Contaminated
 		M.IgniteMob()
 
 /obj/item/projectile/bullet/c9mm/improv
-	damage = -3
+	damage = 14
 
 /obj/item/projectile/bullet/c9mm/simple //for simple mobs, separate to allow balancing
 	name = "9mm bullet"
@@ -176,25 +176,25 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c10mm
 	name = "10mm FMJ bullet"
-	damage = 0
-	wound_bonus = 11
+	damage = 18
+	wound_bonus = 24
 
 /obj/item/projectile/bullet/c10mm/simple
 	name = "10mm FMJ bullet"
 	damage = 20
 	armour_penetration = 0.1
-	wound_bonus = 11
+	wound_bonus = 24
 
 /obj/item/projectile/bullet/c10mm/rubber
 	name = "10mm rubber bullet"
-	damage = -15
+	damage = 8
 	stamina = 26
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c10mm/incendiary
 	name = "10mm incendiary bullet"
-	damage = -5
+	damage = 5
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c10mm/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -212,29 +212,29 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c45
 	name = ".45 FMJ bullet"
-	damage = 0
+	damage = 24
 	wound_bonus = 15
 
 /obj/item/projectile/bullet/c45/simple
 	name = ".45 FMJ bullet"
-	damage = 30
+	damage = 24
 	wound_bonus = 15
 
 /obj/item/projectile/bullet/c45/op
 	name = ".45 +P bullet"
-	damage = 32
+	damage = 28
 	var/extra_speed = 500
 
 /obj/item/projectile/bullet/c45/rubber
 	name = ".45 rubber bullet"
-	damage = -28
-	stamina = 45
+	damage = 6
+	stamina = 24
 	sharpness = SHARP_NONE
 	wound_bonus = 0
 
 /obj/item/projectile/bullet/c45/incendiary
 	name = ".45 incendiary bullet"
-	damage = -5
+	damage = 6
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c45/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -251,14 +251,14 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
-	damage = 0
-	wound_bonus = 12
+	damage = 28
+	wound_bonus = 20
 	bare_wound_bonus = -14
 
 // 3 ricochets, more than enough to kill anything that moves
 /obj/item/projectile/bullet/a357/ricochet
 	name = ".357 ricochet bullet"
-	damage = 0
+	damage = 24
 	ricochets_max = 3
 	ricochet_chance = 140
 	ricochet_auto_aim_angle = 50
@@ -267,7 +267,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357/acid
 	name = ".357 acid-tipped bullet"
-	damage = -5
+	damage = 12
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	var/acid_type = /datum/reagent/toxin/acid/fluacid
@@ -286,7 +286,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357/incendiary
 	name = ".357 incendiary bullet"
-	damage = -5
+	damage = 12
 	var/fire_stacks = 2
 
 /obj/item/projectile/bullet/a357/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -299,25 +299,25 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357/improv
 	name = "poor .357 bullet"
-	damage = -5
+	damage = 22
 ////////////////
 // .44 MAGNUM //
 ////////////////		- Higher power round
 
 /obj/item/projectile/bullet/m44
 	name = ".44 FMJ bullet"
-	damage = 0
-	wound_bonus = 15
+	damage = 32
+	wound_bonus = 24
 	bare_wound_bonus = -20
 
 
 /obj/item/projectile/bullet/m44/simple //for simple mobs, separate to allow balancing
 	name = ".44 bullet"
-	damage = 40
+	damage = 32
 
 /obj/item/projectile/bullet/m44/incendiary
 	name = ".44 incendiary bullet"
-	damage = -5
+	damage = 16
 	var/fire_stacks = 2
 
 /obj/item/projectile/bullet/m44/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -333,12 +333,12 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c4570
 	name = ".45-70 FMJ bullet"
-	damage = 0
-	wound_bonus = 18
+	damage = 38
+	wound_bonus = 32
 	bare_wound_bonus = -24
 
 /obj/item/projectile/bullet/c4570/explosive
-	damage = -15
+	damage = 6
 	pixels_per_second = TILES_TO_PIXELS(500)
 	name = ".45-70 explosive bullet"
 
@@ -348,7 +348,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c4570/acid
 	name = ".45-70 acid-tipped bullet"
-	damage = -10
+	damage = 16
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	var/acid_type = /datum/reagent/toxin/acid/fluacid
@@ -367,7 +367,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c4570/knockback
 	name = ".45-70 ultradense bullet"
-	damage = -15
+	damage = 18
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	pixels_per_second = TILES_TO_PIXELS(500)
@@ -386,13 +386,13 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
-	damage = 0
-	wound_bonus = 25
-	bare_wound_bonus = -28
+	damage = 32
+	wound_bonus = 42
+	bare_wound_bonus = 28
 
 /obj/item/projectile/bullet/mm14/contam
 	name = "14mm contaiminated bullet"
-	damage = -10
+	damage = 18
 	var/smoke_radius = 1
 
 /obj/item/projectile/bullet/mm14/contam/Initialize()
@@ -412,9 +412,9 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/mm14/uraniumtipped
 	name = "14mm uranium-tipped bullet"
-	damage = -5
+	damage = 24
 	armour_penetration = 0.1
-	irradiate = 300
+	irradiate = 30
 
 
 
@@ -425,7 +425,7 @@ Uranium, Contaminated
 //45 Long Colt. Bouncy ammo but less damage then the Sequoia. It's in one of the Vet Ranger kits
 /obj/item/projectile/bullet/a45lc
 	name = ".45 LC bullet"
-	damage = 0
+	damage = 32
 	armour_penetration = 0
 	wound_bonus = 20
 	bare_wound_bonus = -20

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -39,28 +39,28 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a556
 	name = "5.56 FMJ bullet"
-	damage = 0
-	wound_bonus = 15
-	bare_wound_bonus = -18
+	damage = 32
+	wound_bonus = 24
+	bare_wound_bonus = 18
 
 /obj/item/projectile/bullet/a556/match
 	name = "5.56 match bullet"
-	damage = 29
+	damage = 28
 	armour_penetration = 0.21
-	wound_bonus = 15
-	bare_wound_bonus = -16
+	wound_bonus = 18
+	bare_wound_bonus = 12
 	var/extra_speed = 200
 
 /obj/item/projectile/bullet/a556/sport
 	name = ".223 FMJ bullet"
-	damage = -4
-	wound_bonus = 18
-	bare_wound_bonus = -18
+	damage = 28
+	wound_bonus = 32
+	bare_wound_bonus = 32//Gives a reason to actually use this round.
 
 /obj/item/projectile/bullet/a556/rubber
 	name = "5.56 rubber bullet"
-	damage = -21
-	stamina = 30
+	damage = 8
+	stamina = 32
 	sharpness = SHARP_NONE
 	armour_penetration = 0
 	wound_bonus = 0
@@ -68,26 +68,26 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a556/microshrapnel
 	name = "5.56 microshrapnel bullet"
-	damage = -5
-	wound_bonus = 15
-	bare_wound_bonus = 15
-	wound_falloff_tile = 0.5
+	damage = 12
+	wound_bonus = 42
+	bare_wound_bonus = 62
+	wound_falloff_tile = 1.5
 	embed_falloff_tile = 0.5
 	embedding = list(embed_chance=5, fall_chance=1, jostle_chance=1, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=5, jostle_pain_mult=6, rip_time=10, embed_chance_turf_mod=100, projectile_payload = /obj/item/shrapnel/bullet/a556/microshrapnel)
 
 /obj/item/projectile/bullet/a556/uraniumtipped
 	name = "5.56 uranium-tipped bullet"
-	damage = -9
-	armour_penetration = 0
-	irradiate = 300
+	damage = 24
+	armour_penetration = 0.1
+	irradiate = 30
 
 /obj/item/projectile/bullet/a556/simple //for simple mobs, separate to allow balancing
 	name = "5.56 bullet"
-	damage = 25
+	damage = 24
 
 /obj/item/projectile/bullet/a556/ap/simple //for simple mobs, separate to allow balancing
 	name = "5.56 bullet"
-	damage = 19
+	damage = 28
 	armour_penetration = 0.1
 
 ////////////////////
@@ -96,18 +96,20 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a762
 	name = "7.62 FMJ bullet"
-	damage = 0
-	wound_bonus = 18
-	bare_wound_bonus = -20
+	damage = 34
+	wound_bonus = 28
+	bare_wound_bonus = 24
 
 //.308 Winchester
 /obj/item/projectile/bullet/a762/sport
 	name = ".308 bullet"
-	damage = -4
+	damage = 28
+	wound_bonus = 32
+	bare_wound_bonus = 24
 
 /obj/item/projectile/bullet/a762/rubber
 	name = "7.62 rubber bullet"
-	damage = -30
+	damage = 8
 	stamina = 30
 	sharpness = SHARP_NONE
 	armour_penetration = 0
@@ -116,21 +118,21 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a762/sport/simple //for simple mobs, separate to allow balancing
 	name = ".308 bullet"
-	damage = 35
+	damage = 34
 	armour_penetration = 0.2
 
 /obj/item/projectile/bullet/a762/uraniumtipped
 	name = "7.62 uranium-tipped bullet"
-	damage = -10
-	armour_penetration = 0
-	irradiate = 300
+	damage = 30
+	armour_penetration = 0.2
+	irradiate = 30
 
 /obj/item/projectile/bullet/a762/microshrapnel
 	name = "7.62 microshrapnel bullet"
-	damage = -7
-	wound_bonus = 15
-	bare_wound_bonus = 15
-	wound_falloff_tile = 0.5
+	damage = 24
+	wound_bonus = 42
+	bare_wound_bonus = 62
+	wound_falloff_tile = 1.5
 	embed_falloff_tile = 0.5
 	embedding = list(embed_chance=12, fall_chance=1, jostle_chance=1, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.3, pain_mult=5, jostle_pain_mult=6, rip_time=10, embed_chance_turf_mod=100, projectile_payload = /obj/item/shrapnel/bullet/a762/microshrapnel)
 
@@ -139,14 +141,15 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /////////			-Very heavy rifle round.
 
 /obj/item/projectile/bullet/a50MG
-	damage = 0
+	damage = 75
+	armour_penetration = 1
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
-	wound_bonus = 20
-	bare_wound_bonus = 60
+	wound_bonus = 60
+	bare_wound_bonus = 80//Same as the HMG.
 
 /obj/item/projectile/bullet/a50MG/incendiary
-	damage = -10
+	damage = 60
 	var/fire_stacks = 4
 	zone_accuracy_factor = 100
 
@@ -158,7 +161,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 		M.IgniteMob()
 
 /obj/item/projectile/bullet/a50MG/explosive
-	damage = -20
+	damage = 50
 
 /obj/item/projectile/bullet/a50MG/explosive/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -166,25 +169,25 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a50MG/rubber
 	name = ".50 rubber bullet"
-	damage = -50
-	stamina = 80
+	damage = 25
+	stamina = 100
 	armour_penetration = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/a50MG/penetrator
 	name = ".50 penetrator round"
-	damage = -10
+	damage = 50
 	movement_type = FLYING | PHASING
 
 /obj/item/projectile/bullet/a50MG/uraniumtipped
 	name = "12.7mm uranium-tipped bullet"
-	damage = -15
-	armour_penetration = 0.2
-	irradiate = 500
+	damage = 50
+	armour_penetration = 1
+	irradiate = 30
 
 /obj/item/projectile/bullet/a50MG/contam
 	name = "12.7mm contaminated bullet"
-	damage = -10
+	damage = 50
 	var/smoke_radius = 1
 
 /obj/item/projectile/bullet/a50MG/contam/Initialize()
@@ -215,22 +218,23 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473
 	name = "4.73 FMJ bullet"
-	damage = 0
-	wound_bonus = 10
-	bare_wound_bonus = -10
+	damage = 32
+	armour_penetration = 0.1
+	wound_bonus = 8
+	bare_wound_bonus = 12
 
 /obj/item/projectile/bullet/a473/rubber
 	name = "4.73 polyurethane bullet"
-	damage = -20
-	stamina = 18
+	damage = 6
+	stamina = 24
 	sharpness = SHARP_NONE
-	armour_penetration = 0.05
+	armour_penetration = 0.1
 	wound_bonus = 0
 	bare_wound_bonus = 0
 
 /obj/item/projectile/bullet/a473/incendiary
 	name = "4.73 tracer bullet"
-	damage = -8
+	damage = 16
 	armour_penetration = 0.1
 	var/fire_stacks = 3
 	zone_accuracy_factor = 100
@@ -244,9 +248,16 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/uraniumtipped
 	name = "4.73 U-235 bullet"
-	damage = -2
+	damage = 12
 	armour_penetration = 0.3
-	irradiate = 300
+	irradiate = 30
+
+/obj/item/projectile/bullet/a473/minigun
+	name = "4.73 FMJ bullet"
+	damage = 18
+	armour_penetration = 0.1
+	wound_bonus = 24
+	bare_wound_bonus = 32
 
 /obj/item/projectile/bullet/a473/dumdum
 	name = "4.73 flat-nose bullet"
@@ -259,7 +270,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/explosive
 	name = "4.73 explosive bullet"
-	damage = 0
+	damage = 6
 
 /obj/item/projectile/bullet/a473/explosive/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -270,7 +281,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/shock
 	name = "4.73mm shock bullet"
-	wound_bonus = 0
+	wound_bonus = 24
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/a473/shock/on_hit(atom/target, blocked = FALSE)
@@ -279,7 +290,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a473/hv
 	name = "4.73mm highvelocity bullet"
-	damage = -6 //the g11 is now just straight up 16 damage so this makes it 10
+	damage = 16
 	hitscan = TRUE
 	wound_bonus = 0
 
@@ -288,19 +299,20 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 //////////////////////////
 
 /obj/item/projectile/bullet/m5mm  //for rifles// one of the only bullets to have integral AP
-	damage = 0
-	wound_bonus = 10
-	bare_wound_bonus = -10
+	damage = 30
+	wound_bonus = 24
+	bare_wound_bonus = 10
+	armour_penetration = 0.1
 	var/extra_speed = 200
 
 /obj/item/projectile/bullet/m5mm/simple //for simple mobs, separate to allow balancing
 	name = "5mm bullet"
 	damage = 19
-	armour_penetration = 0.19
+	armour_penetration = 0.2
 
 /obj/item/projectile/bullet/m5mm/shock
 	name = "5mm shock bullet"
-	damage = -6 //about -30% damage
+	damage = 16 //about -30% damage
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
@@ -322,13 +334,13 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /////////////////////////			- Gauss rifle
 
 /obj/item/projectile/bullet/c2mm
-	damage = 0
-	armour_penetration = 0.9 //if only one bullet has built in AP, its this one
+	damage = 52
+	armour_penetration = 0.9
 	pixels_per_second = TILES_TO_PIXELS(100)
 
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town
 	name = "2mm blender projectile"
-	damage = -20
+	damage = 42
 	hitscan = TRUE
 	pass_flags = PASSTABLE
 	armour_penetration = 1

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 40
-	stamina = 15 
+	stamina = 15
 	sharpness = SHARP_POINTY
 	wound_bonus = 45
 	bare_wound_bonus = 30
@@ -43,6 +43,8 @@
 	light_color = LIGHT_COLOR_FIRE
 	damage_type = BURN
 	damage = 12 //slight damage on impact
+	wound_bonus = 60//Most wounds come from fire stacks, but this is insult to injury. :)
+	bare_wound_bonus = 80
 	range = 10
 
 /obj/item/projectile/incendiary/flamethrower/on_hit(atom/target)


### PR DESCRIPTION
- - -
Balance:
 - All guns separated from extra damage / extra penetration values. This unifies cartridges being the primary source for damage, identically to shotguns.
 - Every (used) projectile touched up and given DWP. Damage, wound, penetration.
 - Vindicator given its own unique round, due to the above. Otherwise it'd be using the G11 projectile still.
 - Plasma now uses the same wound modifier. Pistols are no longer weaker in their wound application.
 - Flamethrowers now apply serious wound damage to their target, as you'd expect a flamethrower to do. This makes it impossible to escape scalding, even if you immediately put the flames out.
 - All radiation bullets do 30 rad damage, rather than the previous 300.
 - RCW damage increased from 15 to 18.
- - -