### PR TITLE
blood and tastes

### DIFF
--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -416,7 +416,7 @@
 		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/pda = 1,
 		/obj/item/gun/energy/gammagun = 1,
-		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/stock_parts/cell/ammo/mfc = 2,
 		/obj/item/storage/bag/money/small/wastelander = 1,
 		/obj/item/melee/onehanded/knife/survival = 1,
 		/obj/item/clothing/head/beret/enclave/science = 1,

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -248,13 +248,13 @@
 		"AB+" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "SY"),
 		"O-" = list("O-","SY"),
 		"O+" = list("O-", "O+","SY"),
-		"L" = list("L","SY"),
+		"L" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L","SY"),
 		"U" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U","SY"),
 		"HF" = list("HF", "SY"),
 		"X*" = list("X*", "SY"),
 		"SY" = list("SY"),
 		"GEL" = list("GEL","SY"),
-		"BUG" = list("BUG", "SY")
+		"BUG" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "BUG", "SY")
 	)
 
 	var/safe = bloodtypes_safe[bloodtype]

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -7,7 +7,7 @@
 	mutant_bodyparts = list("mcolor" = "FFFFFF", "mcolor2" = "FFFFFF","mcolor3" = "FFFFFF","tail_human" = "None", "ears" = "None", "taur" = "None", "deco_wings" = "None", "legs" = "Plantigrade", "mam_body_markings" = list())
 	use_skintones = USE_SKINTONES_GRAYSCALE_CUSTOM
 	skinned_type = /obj/item/stack/sheet/animalhide/human
-	disliked_food = GROSS | RAW | LONGPORK
+	disliked_food = GROSS | TOXIC
 	liked_food = JUNKFOOD | FRIED
 
 	tail_type = "tail_human"

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -21,7 +21,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"
 	exotic_blood_color = BLOOD_COLOR_LIZARD
-	disliked_food = GRAIN | DAIRY
+	disliked_food = NONE
 	liked_food = GROSS | MEAT
 	inert_mutation = FIREBREATH
 	species_language_holder = /datum/language_holder/lizard

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -12,7 +12,7 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/moth
 	liked_food = VEGETABLES | DAIRY
-	disliked_food = FRUIT | GROSS
+	disliked_food = GROSS
 	toxic_food = MEAT | RAW
 	mutanteyes = /obj/item/organ/eyes/moth
 	laugh_male = 'sound/voice/moth/mothlaugh.ogg'


### PR DESCRIPTION
## About The Pull Request

clears a few species food dislikes to allow for more RP-decided dislikes rather than mechanically enforced. also sets bug and lizard type blood to be a universal recipient. also changes enclave scientist ammo cause im retarded and gave them the wrong ammo type after they'd already gotten the right type


## Why It's Good For The Game

allows for characters to have RP-decided food dislikes rather than mechanically enforced ones. for example, a cannibal character getting cucked by mechanically-enforced cannibalism dislike is lame. as for the blood change, lizard and bug blood are only compatible with themselves and synthetic blood. if you were bleeding badly, you might as well just ghost lmao. this fixes that so bug/lizard players actually have a chance when it comes to bloodloss (universal recipient decision endorsed by badmancarl). ammo change is self explanatory

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.


## Changelog

:cl:
tweak: changes lizard and bug blood to be a universal recipient
tweak: changes human, lizard and moth food dislikes to be a bit more freeform while not completely broken by being able to eat anything
fix: gives enclave scientists correct ammo for the gamma gun (im retarded)
/:cl: