### PR TITLE
Enclave Touchup & Other

### DIFF
--- a/code/game/objects/structures/timeddoor.dm
+++ b/code/game/objects/structures/timeddoor.dm
@@ -13,6 +13,9 @@
 /obj/structure/timeddoor/sixtyminute
 	deletion_time = 60 MINUTES
 
+/obj/structure/timeddoor/onetwozerominutes
+	deletion_time = 120 MINUTES
+
 /obj/structure/timeddoor/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, .proc/timeddeletedoor), deletion_time)

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -8,7 +8,7 @@
 
 /datum/supply_pack/emergency
 	group = "Emergency"
-
+/*
 /datum/supply_pack/emergency/vehicle
 	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
@@ -23,6 +23,7 @@
 					/obj/item/clothing/mask/bandana/skull)//so you can properly #cargoniabikergang
 	crate_name = "Biker Kit"
 	crate_type = /obj/structure/closet/crate/large
+*/
 //fallout changes
 
 /datum/supply_pack/emergency/ids

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -64,7 +64,7 @@
 			/obj/item/clothing/mask/gas/explorer)
 	crate_name = "shaft miner starter kit"
 	crate_type = /obj/structure/closet/crate/secure
-
+/*
 /datum/supply_pack/service/snowmobile
 	name = "Snowmobile kit"
 	desc = "trapped on a frigid wasteland? need to get around fast? purchase a refurbished snowmobile, with a FREE 10 microsecond warranty!"
@@ -74,7 +74,7 @@
 			/obj/item/clothing/mask/gas/explorer = 1)
 	crate_name = "Snowmobile kit"
 	crate_type = /obj/structure/closet/crate/large
-
+*/
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Chef, Botanist, Bartender ////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -484,12 +484,12 @@
 
 //Part of the peacekeeper enclave stuff, adjust values as needed.
 /obj/item/clothing/head/helmet/f13/power_armor/x02helmet
-	name = "/improper APA Mk II helmet"
+	name = "\improper APA Mk II helmet"
 	desc = "The Enclave Mark II Powered Combat Armor helmet."
 	icon_state = "advanced"
 	item_state = "advanced"
 	slowdown = 0.1
-	armor = list("melee" = 65, "bullet" = 65, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/x02
 

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -482,7 +482,7 @@
 	armor = list("melee" = 85, "bullet" = 85, "laser" = 87, "energy" = 37, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 100)
 
 
-//Part of the peacekeeper enclave stuff, adjust values as needed.
+//Part of the Enclave stuff, adjust values as needed.
 /obj/item/clothing/head/helmet/f13/power_armor/x02helmet
 	name = "\improper APA Mk II helmet"
 	desc = "The Enclave Mark II Powered Combat Armor helmet."
@@ -493,6 +493,14 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/x02
 
+/obj/item/clothing/head/helmet/f13/power_armor/tesla
+	name = "\improper APA-T Mk II helmet"
+	desc = "The Enclave Mark II Powered Combat Armor helmet, rigged with heavy electronics."
+	icon_state = "tesla"
+	item_state = "tesla"
+	slowdown = 0.1
+	armor = list("melee" = 75, "bullet" = 75, "laser" = 95, "energy" = 95, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 //Generic Tribal - For Wayfarer specific, see f13factionhead.dm
 

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -102,10 +102,10 @@
 
 // X-02
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/x02
-	name = "salvaged Enclave helmet"
+	name = "\improper salvaged APA Mk II helmet"
 	desc = "It's a salvaged X-02 power armor helmet."
 	icon_state = "advanced"
 	item_state = "advanced"
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	armor = list("melee" = 75, "bullet" = 75, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 	slowdown = 0.1
 	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEYES|HIDEEARS|HIDEHAIR|HIDESNOUT

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -686,12 +686,12 @@
 
 //Peacekeeper armor adjust as needed
 /obj/item/clothing/suit/armor/f13/power_armor/x02
-	name = "/improper APA Mk II"
+	name = "\improper APA Mk II"
 	desc = "Upgraded pre-war power armor design used by the Enclave."
 	icon_state = "advanced"
 	item_state = "advanced"
 	slowdown = 0.3
-	armor = list("melee" = 65, "bullet" = 65, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 	salvaged_type = /obj/item/clothing/suit/armored/heavy/salvaged_pa/x02 // Oh the misery
 
 /obj/item/clothing/suit/armor/f13/enclave/armorvest

--- a/code/modules/clothing/suits/f13armor.dm
+++ b/code/modules/clothing/suits/f13armor.dm
@@ -684,15 +684,31 @@
 	item_state = "advpowerarmor1"
 	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 35, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 
-//Peacekeeper armor adjust as needed
+//Enclave armor adjust as needed
 /obj/item/clothing/suit/armor/f13/power_armor/x02
 	name = "\improper APA Mk II"
 	desc = "Upgraded pre-war power armor design used by the Enclave."
 	icon_state = "advanced"
 	item_state = "advanced"
-	slowdown = 0.3
+	slowdown = 0.3//Worst slowdown of all combat sets.
 	armor = list("melee" = 80, "bullet" = 80, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 	salvaged_type = /obj/item/clothing/suit/armored/heavy/salvaged_pa/x02 // Oh the misery
+
+/obj/item/clothing/suit/armor/f13/power_armor/tesla
+	name = "\improper APA-T Mk II"
+	desc = "Upgraded pre-war power armor used by the Enclave, rigged with heavy electronics."
+	icon_state = "tesla"
+	item_state = "tesla"
+	slowdown = 0.3//Worst slowdown of all combat sets.
+	armor = list("melee" = 75, "bullet" = 75, "laser" = 95, "energy" = 95, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	var/hit_reflect_chance = 35
+
+/obj/item/clothing/suit/armor/f13/power_armor/tesla/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
+	if(is_energy_reflectable_projectile(object) && (attack_type == ATTACK_TYPE_PROJECTILE) && (def_zone in protected_zones))
+		if(prob(hit_reflect_chance))
+			block_return[BLOCK_RETURN_REDIRECT_METHOD] = REDIRECT_METHOD_DEFLECT
+			return BLOCK_SHOULD_REDIRECT | BLOCK_REDIRECTED | BLOCK_SUCCESS | BLOCK_PHYSICAL_INTERNAL
+	return ..()
 
 /obj/item/clothing/suit/armor/f13/enclave/armorvest
 	name = "armored vest"

--- a/code/modules/clothing/suits/heavy_armor.dm
+++ b/code/modules/clothing/suits/heavy_armor.dm
@@ -160,11 +160,11 @@
 
 // X-02
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/x02
-	name = "/improper salvaged APA Mk II"
+	name = "\improper salvaged APA Mk II"
 	desc = "X-02 power armor with servomotors and all valuable components stripped out of it."
 	icon_state = "advanced_salvaged"
 	item_state = "advanced_salvaged"
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
+	armor = list("melee" = 75, "bullet" = 75, "laser" = 85, "energy" = 85, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 50, "wound" = 50)
 	slowdown = 0.85
 
 ////////////

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -456,8 +456,6 @@ Star Paladin
 
 /datum/outfit/loadout/spaladine
 	name = "Gatling Head Paladin"
-	suit = /obj/item/clothing/suit/armor/f13/power_armor/midwest/hardened
-	head = /obj/item/clothing/head/helmet/f13/power_armor/midwest/hardened
 	backpack_contents = list(
 		/obj/item/encminigunpack=1,
 	)

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -479,8 +479,8 @@
 /datum/job/enclave/f13BDUTY
 	title = "Enclave Bunker Duty"
 	flag = F13USBDUTY
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 6
+	spawn_positions = 6
 	description = "You're a small garrison within a side entrance of a far larger complex. This complex sits within the Casper mountain range. You're a non-combatant, skilled in a field outside of exterior operations. Given your value, you aren't permitted to engage in conflict."
 	enforces = "You are not permited to leave the base. You are a non-combatant. You cannot join any raids or battles on the surface."
 	supervisors = "Everyone else."

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -1,4 +1,3 @@
-//It looks like var/faction controls what becomes visible on setup. Should likely be fixed or something, but I'm not doing it.
 /datum/job/enclave
 	department_flag = ENCLAVE
 	selection_color = "#434944"
@@ -149,8 +148,8 @@
 /datum/outfit/job/enclave/peacekeeper/f13gysergeant
 	name = "Enclave Platoon Sergeant"
 	jobtype = /datum/job/enclave/f13gysergeant
-	head = /obj/item/clothing/head/helmet/f13/power_armor/x02helmet
-	suit = /obj/item/clothing/suit/armor/f13/power_armor/x02
+	head = /obj/item/clothing/head/helmet/f13/power_armor/tesla
+	suit = /obj/item/clothing/suit/armor/f13/power_armor/tesla
 	accessory = /obj/item/clothing/accessory/enclave/sergeant_firstclass
 	ears = /obj/item/radio/headset/headset_enclave/command
 	l_pocket = /obj/item/clothing/mask/chameleon

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -231,8 +231,8 @@ Raider
 	head_announce = list("Security")
 	faction = FACTION_WASTELAND
 	social_faction = FACTION_RAIDERS
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 6
+	spawn_positions = 6
 	description = "You are an undesirable figure of some kind- perhaps a corrupt official, or a cannibalistic bartender, or a devious conman, to name a few examples. You have more freedom than anyone else in the wastes, and are not bound by the same moral code as others, but though you may only be interested in self-gain, you still have a responsibility to make your time here interesting, fun, and engaging for others- this means that whatever path you pursue should be more nuanced and flavorful than simple highway robbery or slavery. (Adminhelp if you require help setting up your character for the round.)"
 	supervisors = "Your desire to make things interesting and fun"
 	selection_color = "#dddddd"


### PR DESCRIPTION
- - -
Enclave:
 - Returns PA values to about where they were prior. I'll be reworking PA entirely, but I'm afraid it'll have to sit here for now. It's only two suits at the moment, with the following change.
 - A specialised tesla suit given to the Gunnery Sergeant, slightly weaker in ballistic and melee protection, but near immune to energy and lasers.
 - Bunker Duty jumped from two slots to six, to mirror BoS off-duty.
- - -
Wasteland:
 - Outlaw/Raider dropped from infinite slots to six. We don't get folks using it for anything other than Wastelander+, so we'll be nipping that in the bud. We'll likely go back to infinite soon.
- - -
Other:
 - It is no longer possible to buy ATV/Snowmobile packages.
 - Removal of Hardened PA from Brotherhood Marshal. This was unintended.
- - -