### PR TITLE
Various Map Corrections | Pass #1

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -152,7 +152,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "agC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -221,7 +221,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "akh" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -235,7 +235,7 @@
 	width = 4
 	},
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "alf" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/barber{
@@ -260,7 +260,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "amV" = (
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/structure/rack,
@@ -418,7 +418,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "aya" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -456,7 +456,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "aAh" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/f13/inside/mountain,
@@ -707,7 +707,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "aSq" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
@@ -754,20 +754,15 @@
 	},
 /area/f13/bunker)
 "aUJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/structure/nest/tunneler{
+	max_mobs = 2
 	},
-/area/f13/bunker/bighornbunker)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "aVs" = (
 /obj/item/reagent_containers/food/snacks/f13/steak,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aVI" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "aVQ" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper,
@@ -777,7 +772,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "aVW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -814,7 +809,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "aZc" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -898,7 +893,7 @@
 /obj/effect/decal/waste,
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "bgE" = (
 /obj/machinery/light{
 	dir = 1;
@@ -1037,7 +1032,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "bpz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1113,7 +1108,7 @@
 "bst" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "btw" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -1161,10 +1156,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
-"bxP" = (
-/obj/structure/reagent_dispensers/barrel/four,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "byG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -1365,7 +1356,7 @@
 "bMW" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier5,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "bNh" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -1479,7 +1470,7 @@
 /obj/structure/spider/stickyweb,
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "bSQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1512,7 +1503,7 @@
 	},
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "bUv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1691,7 +1682,7 @@
 "ceB" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/wall/r_wall/f13/vault,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "cfn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -1730,7 +1721,7 @@
 "cgW" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "chx" = (
 /obj/machinery/light{
 	dir = 1
@@ -1844,11 +1835,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "cqu" = (
-/obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/bundle/f13/armor/combat,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "cqI" = (
@@ -1941,8 +1932,8 @@
 	},
 /area/f13/bunker)
 "cyA" = (
-/obj/structure/closet/decay,
 /obj/effect/spawner/bundle/f13/armor/combat,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "cyQ" = (
@@ -2037,21 +2028,11 @@
 /obj/structure/timeddoor,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
-"cEK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/radiation)
 "cFz" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"cFH" = (
-/obj/structure/reagent_dispensers/barrel/old,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "cGA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/radroach,
@@ -2243,12 +2224,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "cQy" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
+/mob/living/simple_animal/hostile/trog/tunneler,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/underground/cave)
 "cQM" = (
 /turf/open/floor/plasteel/barber{
 	icon_state = "platingdmg3"
@@ -2287,13 +2265,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/dirt,
 /area/f13/bunker)
-"cRC" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "cTL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2427,7 +2398,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dae" = (
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table,
@@ -2460,7 +2431,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dcJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/energybar,
@@ -2537,12 +2508,6 @@
 "dfi" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/bunker)
-"dfC" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/radiation)
 "dfE" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -2565,7 +2530,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dgo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2620,7 +2585,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "diI" = (
 /obj/effect/decal/remains/human,
 /obj/structure/closet,
@@ -2629,11 +2594,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "diM" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "djm" = (
 /obj/item/cultivator,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2652,12 +2617,8 @@
 	},
 /area/f13/underground/cave)
 "djt" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/underground/cave)
 "djN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2724,7 +2685,7 @@
 "dnq" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "doa" = (
 /obj/structure/chair/booth{
 	dir = 8
@@ -2737,7 +2698,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "doi" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/plush,
@@ -2782,7 +2743,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "drj" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -2831,9 +2792,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "dtc" = (
-/obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "dty" = (
@@ -2990,7 +2951,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dEH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3126,7 +3087,7 @@
 "dJM" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dJU" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -3221,10 +3182,6 @@
 "dPd" = (
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
-"dPn" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
 "dQd" = (
 /obj/structure/sign/warning/radiation{
 	pixel_y = -30
@@ -3234,7 +3191,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dQf" = (
 /obj/structure/closet/crate/footchest,
 /obj/item/t_scanner/adv_mining_scanner,
@@ -3327,7 +3284,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dWx" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -3373,14 +3330,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
 "dZx" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/surgicaldrill,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "dZX" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -3400,17 +3353,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ebv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ebD" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/radiation)
 "eca" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plasteel/barber{
@@ -3587,13 +3534,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "eiw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ejd" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -3612,7 +3556,7 @@
 /area/f13/vault)
 "ekT" = (
 /turf/closed/mineral/random/low_chance,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ela" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -3692,7 +3636,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "epH" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	name = "Conscripted Engineer"
@@ -3807,7 +3751,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "eyk" = (
 /obj/effect/decal/cleanable/salt,
 /turf/open/floor/plasteel/f13{
@@ -3956,7 +3900,7 @@
 	},
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "eGc" = (
 /obj/effect/decal/remains/human,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -4155,12 +4099,12 @@
 	},
 /area/f13/underground/cave)
 "eUV" = (
-/obj/structure/chair/f13chair2,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ad1b1b"
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/bunker)
 "eVh" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
@@ -4246,15 +4190,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/bunker)
 "eZS" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/cautery,
-/obj/item/razor,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/bunker)
 "fbg" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -4264,7 +4203,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fbT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/blood/radaway,
@@ -4383,12 +4322,12 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fjH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fkd" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 4
@@ -4434,7 +4373,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fmA" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -4535,7 +4474,7 @@
 "fsV" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fti" = (
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -4548,7 +4487,7 @@
 "ftT" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fup" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 30
@@ -4577,8 +4516,12 @@
 	},
 /area/f13/caves)
 "fwX" = (
-/obj/item/kirbyplants,
-/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating"
+	},
 /area/f13/bunker)
 "fxg" = (
 /obj/effect/decal/waste{
@@ -4676,18 +4619,20 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fDW" = (
 /obj/structure/fireaxecabinet,
 /turf/closed/wall/mineral/wood,
 /area/f13/city)
 "fEp" = (
-/obj/structure/timeddoor,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/structure/barricade/wooden/strong{
+	icon_state = "boarded";
+	opacity = 1
 	},
-/area/f13/bunker/bighornbunker)
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "fEq" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
@@ -4710,7 +4655,7 @@
 "fFa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fFb" = (
 /obj/structure/flora/ausbushes,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -4983,7 +4928,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "fVh" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5080,7 +5025,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "fYi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -5225,7 +5170,7 @@
 "gfp" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "gfJ" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -5271,7 +5216,7 @@
 "gix" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "giT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5378,7 +5323,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "gtL" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13{
@@ -5409,15 +5354,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "gyj" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/blood/gibs/human/body,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+	icon_state = "plating"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "gyu" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirtcorner"
@@ -5497,14 +5439,11 @@
 	},
 /area/f13/bunker)
 "gEK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+	icon_state = "plating"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "gFc" = (
 /obj/item/reagent_containers/food/snacks/f13/canned/borscht,
 /turf/open/indestructible/ground/inside/mountain,
@@ -5647,7 +5586,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "gLv" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
@@ -6062,7 +6001,7 @@
 "hoe" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hou" = (
 /obj/structure/closet/fridge/meat,
 /turf/open/floor/f13/wood,
@@ -6174,7 +6113,7 @@
 /obj/structure/rack,
 /obj/item/grenade/empgrenade,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "huB" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6202,7 +6141,7 @@
 "hvq" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hvr" = (
 /obj/structure/chair/bench,
 /obj/machinery/light{
@@ -6232,7 +6171,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hwA" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/structure/window/reinforced/tinted,
@@ -6271,14 +6210,8 @@
 	},
 /area/f13/bunker)
 "hyL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/bunker)
 "hAx" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/barber{
@@ -6293,13 +6226,15 @@
 	},
 /area/f13/underground/cave)
 "hAF" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/obj/machinery/light/small{
+	light_color = "#ad1b1b"
 	},
-/area/f13/bunker/bighornbunker)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "hAL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
@@ -6392,7 +6327,7 @@
 "hGv" = (
 /obj/structure/simple_door/bunker,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hHG" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
@@ -6430,12 +6365,12 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "hKh" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hKJ" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/ash,
@@ -6476,7 +6411,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hNT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6557,7 +6492,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hSj" = (
 /obj/machinery/light{
 	dir = 8
@@ -6572,13 +6507,13 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hTb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = 93
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hTF" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/darkpurple/side{
@@ -6628,12 +6563,12 @@
 /turf/open/floor/plasteel,
 /area/f13/vault)
 "hWo" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+	icon_state = "plating"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "hWX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility/full/engi,
@@ -6694,7 +6629,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "iax" = (
 /obj/machinery/light{
 	dir = 1;
@@ -6734,7 +6669,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "icE" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/vault{
@@ -6834,7 +6769,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "iks" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/dirt{
@@ -7076,7 +7011,7 @@
 /obj/structure/barricade/bars,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "ixM" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13{
@@ -7099,7 +7034,7 @@
 	},
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "izE" = (
 /obj/effect/landmark/poster_spawner/prewar,
 /turf/closed/indestructible/f13vaultrusted,
@@ -7387,7 +7322,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "iRc" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -7397,7 +7332,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/seeds/tower/steel,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "iSf" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -7410,12 +7345,11 @@
 	},
 /area/f13/wasteland)
 "iSJ" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
+/mob/living/simple_animal/hostile/trog/tunneler,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/underground/cave)
 "iTP" = (
 /obj/structure/chair{
 	dir = 8
@@ -7530,7 +7464,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jaX" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable{
@@ -7552,7 +7486,7 @@
 "jbS" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jcd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/obstacle/barbedwire{
@@ -7627,7 +7561,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jfd" = (
 /turf/open/floor/f13/wood,
 /area/f13/vault)
@@ -7638,7 +7572,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jfQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -7688,7 +7622,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/box/donkpockets,
@@ -7729,7 +7663,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jlG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -7854,7 +7788,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jvY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
@@ -7867,11 +7801,11 @@
 	},
 /area/f13/bunker)
 "jwq" = (
-/obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "jwJ" = (
@@ -7894,7 +7828,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "jxR" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -8032,7 +7966,7 @@
 /area/f13/vault)
 "jHa" = (
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jHr" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small,
@@ -8221,7 +8155,7 @@
 "jPN" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jQi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -8249,7 +8183,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jSK" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
@@ -8296,11 +8230,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jXb" = (
 /obj/structure/reagent_dispensers/barrel/old,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "jXe" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
@@ -8576,12 +8510,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
 "koF" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
+/obj/structure/nest/tunneler,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/underground/cave)
 "koI" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
@@ -8635,9 +8566,6 @@
 /obj/item/target/alien,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"kqZ" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/bunker/bighornbunker)
 "krp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -8706,7 +8634,6 @@
 	},
 /area/f13/bunker)
 "kuu" = (
-/obj/machinery/light/small,
 /obj/machinery/computer/shuttle/southbunkerelevator{
 	dir = 4
 	},
@@ -8864,7 +8791,7 @@
 "kCW" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "kDh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -8907,13 +8834,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/city)
-"kGB" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "kGU" = (
 /obj/machinery/computer/upload/ai,
 /turf/open/floor/plasteel/dark,
@@ -9019,7 +8939,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "kLq" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/debris/v1{
@@ -9144,7 +9064,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "kVk" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -9269,12 +9189,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
-"kYU" = (
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "kZb" = (
 /obj/structure/chair/f13foldupchair,
 /obj/machinery/light{
@@ -9380,7 +9294,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "leL" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -9440,7 +9354,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "lix" = (
 /turf/closed/wall/f13/store,
 /area/f13/mountain_bunker)
@@ -9498,7 +9412,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "lmS" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/structure/closet/secure_closet/goodies{
@@ -9509,7 +9423,7 @@
 	req_one_access_txt = "150"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "lnj" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/underground/cave)
@@ -9597,7 +9511,7 @@
 "lrE" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "lrQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -9633,9 +9547,9 @@
 	},
 /area/f13/bunker)
 "lxk" = (
-/obj/structure/closet/crate/rcd,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/radiation)
 "lxB" = (
@@ -9744,7 +9658,7 @@
 /obj/effect/decal/waste,
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "lDs" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -10068,7 +9982,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "lXc" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water,
@@ -10322,7 +10236,7 @@
 "mow" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "moH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
@@ -10404,7 +10318,6 @@
 	dir = 1;
 	light_color = "#ad1b1b"
 	},
-/obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
 "mtj" = (
@@ -10549,7 +10462,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "mAN" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
@@ -10703,7 +10616,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "mMO" = (
 /turf/closed/wall/r_wall,
 /area/f13/bunker)
@@ -10744,7 +10657,7 @@
 "mOY" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "mOZ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "stockpilebunker";
@@ -10768,7 +10681,7 @@
 /area/f13/vault)
 "mRq" = (
 /turf/closed/wall/r_wall/f13/vault,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "mRs" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -10794,13 +10707,13 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "mSR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "mTm" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/command.dmi';
@@ -10852,7 +10765,7 @@
 "mWk" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "mWt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -11091,7 +11004,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "nlT" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -11194,7 +11107,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "nrT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/blamco,
@@ -11287,7 +11200,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "nxB" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -11334,10 +11247,10 @@
 	},
 /area/f13/city)
 "nzU" = (
-/obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "nzY" = (
@@ -11372,14 +11285,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/bunker)
-"nBk" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "nBF" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -11510,11 +11415,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"nHm" = (
-/obj/effect/decal/waste,
-/obj/item/reagent_containers/glass/bottle/FEV_solution,
-/turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
 "nHv" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11540,13 +11440,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"nKk" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "nKE" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plasteel/f13{
@@ -11657,12 +11550,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/f13/bunker)
-"nRz" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/bunker/bighornbunker)
 "nRY" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -11904,12 +11791,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
-"ocQ" = (
-/turf/closed/indestructible/opshuttle,
-/area/f13/bunker/bighornbunker)
-"ocU" = (
-/turf/closed/indestructible/fakeglass,
-/area/f13/bunker/bighornbunker)
 "odI" = (
 /obj/machinery/light{
 	dir = 8
@@ -11921,6 +11802,7 @@
 "oek" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating"
 	},
@@ -11938,11 +11820,11 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ofW" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/f13/vault,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ofZ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -12043,7 +11925,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/power/rtg/abductor,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -12076,6 +11958,11 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	icon_state = "trails_1"
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "stockpilebunker";
+	max_integrity = 1000;
+	name = "Military Stockpile Shutters"
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/bunker)
 "oon" = (
@@ -12090,14 +11977,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/f13/bunker)
-"ope" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "opi" = (
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/mineral/random/low_chance,
@@ -12108,15 +11987,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
-"opz" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "opF" = (
 /obj/machinery/shower{
 	pixel_y = 22
@@ -12391,7 +12261,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "oFS" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/broken,
@@ -12418,7 +12288,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "oGD" = (
 /obj/structure/rack,
 /obj/machinery/button/door{
@@ -12600,7 +12470,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "oQl" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -12629,7 +12499,7 @@
 "oRF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "oRH" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -12864,7 +12734,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "pcV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
@@ -12917,13 +12787,13 @@
 	req_one_access_txt = "150"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "pfp" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "pfq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13069,9 +12939,6 @@
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/darkpurple/side,
 /area/f13/vault)
-"pmN" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/bunker/bighornbunker)
 "pmZ" = (
 /obj/structure/sink{
 	dir = 1;
@@ -13093,9 +12960,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
-"pno" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
 "pnM" = (
 /obj/item/stack/crafting/electronicparts/five,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -13151,7 +13015,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "prq" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -13365,7 +13229,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "pGg" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/robot_debris/down,
@@ -13441,7 +13305,7 @@
 	amount = 5
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "pMy" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -13744,15 +13608,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/bunker)
-"qaS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "qbd" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
@@ -13824,7 +13679,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qgk" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
@@ -13992,7 +13847,7 @@
 /area/f13/bunker)
 "qpP" = (
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qpU" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light/small{
@@ -14113,13 +13968,13 @@
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qyz" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/gloves/combat,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qyB" = (
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate,
@@ -14239,11 +14094,6 @@
 "qFG" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault)
-"qGo" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/radiation)
 "qGH" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -14402,7 +14252,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qQz" = (
 /obj/structure/debris/v3{
 	layer = 2;
@@ -14446,11 +14296,11 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qSC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "qSM" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14510,7 +14360,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "qUH" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -14542,10 +14392,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
 "qWZ" = (
-/obj/structure/closet/decay,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/bundle/f13/trenchshotgun,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "qXZ" = (
@@ -14571,10 +14421,10 @@
 	},
 /area/f13/bunker)
 "rbm" = (
-/obj/structure/closet/decay,
 /obj/item/flashlight{
 	icon_state = "seclite"
 	},
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "rbP" = (
@@ -14938,7 +14788,7 @@
 	name = "assaultron dominator"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "rBB" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -14993,7 +14843,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "rEK" = (
 /turf/open/floor/f13{
 	icon_state = "dark"
@@ -15098,7 +14948,7 @@
 /obj/effect/decal/waste,
 /obj/item/reagent_containers/glass/bottle/FEV_solution,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "rOp" = (
 /obj/machinery/light{
 	dir = 4
@@ -15298,7 +15148,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "sbL" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/f13/wood,
@@ -15358,7 +15208,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sfF" = (
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plasteel/barber{
@@ -15372,7 +15222,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sfQ" = (
 /obj/machinery/computer{
 	desc = "Some kind of machine.Seems broken and useless.";
@@ -15599,6 +15449,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/buyable,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/bunker)
 "sub" = (
@@ -15613,7 +15464,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "svk" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/outside/dirt,
@@ -15651,7 +15502,7 @@
 	req_one_access_txt = "150"
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "swM" = (
 /obj/effect/decal/waste,
 /obj/structure/spider/stickyweb,
@@ -15659,7 +15510,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "sxc" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/bunker)
@@ -15728,7 +15579,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sAM" = (
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -15838,19 +15689,12 @@
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
-"sIJ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "sIR" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "sIX" = (
 /obj/structure/table/wood,
 /obj/item/storage/book,
@@ -15907,7 +15751,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sQz" = (
 /turf/open/floor/f13,
 /area/f13/city)
@@ -15979,7 +15823,7 @@
 "sUR" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sVl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/botany,
@@ -16052,7 +15896,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "sZm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16112,7 +15956,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "tcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16173,7 +16017,7 @@
 "tfC" = (
 /obj/structure/nest/supermutant,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tfE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -16183,7 +16027,7 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tgh" = (
 /obj/structure/table,
 /obj/item/clothing/head/hardhat/cakehat,
@@ -16217,7 +16061,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tij" = (
 /obj/machinery/light{
 	dir = 1;
@@ -16232,7 +16076,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tir" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -16324,7 +16168,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tpP" = (
 /obj/structure/decoration/vent,
 /obj/structure/curtain,
@@ -16350,7 +16194,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tqF" = (
 /obj/structure/sign/poster/prewar/corporate_espionage,
 /turf/closed/wall/r_wall/f13vault{
@@ -16455,7 +16299,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "tyH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -16567,7 +16411,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tGJ" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -16670,7 +16514,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tLA" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -16707,12 +16551,12 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tNZ" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/small,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "tOS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -16761,7 +16605,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "tTZ" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
@@ -16854,7 +16698,7 @@
 /obj/item/clothing/under/syndicate,
 /obj/item/storage/belt/military/assault,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "uaa" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/mattress,
@@ -16864,7 +16708,7 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "uaR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -16951,7 +16795,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ugp" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/barber{
@@ -16961,7 +16805,7 @@
 "ugw" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ugX" = (
 /turf/closed/indestructible/opshuttle,
 /area/f13/bunker)
@@ -17092,7 +16936,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "ukL" = (
 /obj/structure/table,
 /obj/item/retractor,
@@ -17138,7 +16982,7 @@
 "uok" = (
 /mob/living/simple_animal/hostile/supermutant,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "uoW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -17228,7 +17072,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "usv" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/f13/wood,
@@ -17413,7 +17257,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "uCj" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17518,7 +17362,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "uHR" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/barber{
@@ -17684,7 +17528,7 @@
 	},
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "uRG" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -17695,7 +17539,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "uRK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/low_tools,
@@ -17771,7 +17615,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "uUV" = (
 /obj/machinery/light{
 	dir = 4
@@ -17836,7 +17680,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "uYg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17936,13 +17780,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/bunker)
-"vff" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "vfh" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -18071,7 +17908,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vjU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18082,7 +17919,7 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "vkp" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/greenglow,
@@ -18125,7 +17962,7 @@
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vmL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -18173,7 +18010,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18188,7 +18025,7 @@
 "vqH" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vqM" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -18377,7 +18214,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vBa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18433,7 +18270,7 @@
 "vFp" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/wall/f13/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vGa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes,
@@ -18564,7 +18401,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "vPN" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -18622,13 +18459,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/underground/cave)
-"vUU" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "vVk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
@@ -18768,7 +18598,7 @@
 "wbP" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wbU" = (
 /turf/open/floor/f13,
 /area/f13/wasteland)
@@ -18848,7 +18678,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wiK" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/brown,
@@ -18880,13 +18710,13 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "wlO" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wmg" = (
 /obj/machinery/light/small{
 	light_color = "#ad1b1b"
@@ -18898,7 +18728,7 @@
 "wmI" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wmW" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18951,7 +18781,7 @@
 "wow" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "woI" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/barber{
@@ -19121,7 +18951,7 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "wBf" = (
 /obj/structure/reagent_dispensers/barrel,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -19258,7 +19088,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wKb" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -19315,9 +19145,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "wOd" = (
-/obj/structure/closet/crate/secure/engineering,
 /obj/effect/spawner/bundle/f13/armor/t51b,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bunker)
 "wOM" = (
@@ -19354,9 +19184,6 @@
 	},
 /area/f13/bunker)
 "wQG" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/structure/timeddoor,
 /turf/open/floor/plasteel/f13/vault_floor/green/corner,
@@ -19456,7 +19283,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wVx" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	color = "#75705a";
@@ -19484,7 +19311,7 @@
 /obj/effect/decal/waste,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/area/f13/bunker)
 "wWn" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
@@ -19559,7 +19386,7 @@
 	},
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "wYb" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small/broken{
@@ -19593,7 +19420,7 @@
 "wYM" = (
 /obj/item/clothing/head/helmet/f13/raidermetal,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/radiation)
+/area/f13/bunker)
 "wZW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -19725,8 +19552,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault)
 "xko" = (
-/obj/structure/closet/decay,
 /obj/effect/spawner/bundle/f13/m1911,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "xkr" = (
@@ -19750,7 +19577,7 @@
 /obj/effect/spawner/lootdrop/trash,
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "xmu" = (
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -19957,7 +19784,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "xBb" = (
 /obj/machinery/chem_master/primitive,
 /obj/effect/decal/cleanable/dirt{
@@ -20028,7 +19855,7 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "xGJ" = (
 /obj/structure/table,
 /obj/item/paper,
@@ -20085,8 +19912,8 @@
 	},
 /area/f13/bunker)
 "xLr" = (
-/obj/structure/closet/decay,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/obj/structure/closet/secure_closet/goodies,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/bunker)
 "xLF" = (
@@ -20172,7 +19999,7 @@
 "xQm" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plating/tunnel,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "xQF" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/barber{
@@ -20217,7 +20044,7 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/radiation)
+/area/f13/bunker)
 "xSZ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
@@ -20358,17 +20185,6 @@
 	},
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault)
-"yfw" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/bunker/bighornbunker)
 "yfZ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -20395,7 +20211,7 @@
 "yia" = (
 /obj/structure/spider/stickyweb,
 /turf/closed/mineral/random/low_chance,
-/area/f13/bunker/bighornbunker)
+/area/f13/bunker)
 "yip" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/caution{
@@ -59782,10 +59598,10 @@ shC
 shC
 shC
 shC
-shC
-shC
-oqm
-eUV
+cQy
+djt
+dZx
+dPd
 jZk
 jZk
 dlc
@@ -60038,11 +59854,11 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-oqm
-fwX
+wgF
+wgF
+djt
+eiw
+dPd
 qIY
 qLK
 wKJ
@@ -60294,9 +60110,9 @@ shC
 (156,1,1) = {"
 shC
 shC
-shC
-shC
-shC
+wgF
+wgF
+wgF
 shC
 oqm
 lxE
@@ -60317,7 +60133,7 @@ kyn
 oqm
 ruF
 qem
-bgL
+eZS
 mmR
 oqm
 aOJ
@@ -60551,8 +60367,8 @@ shC
 (157,1,1) = {"
 shC
 shC
-shC
-shC
+aUJ
+wgF
 shC
 shC
 oqm
@@ -63158,9 +62974,9 @@ oqm
 sor
 sor
 sor
-gcp
+fwX
 sor
-wmg
+hAF
 sor
 shC
 shC
@@ -63416,8 +63232,8 @@ xjm
 nLh
 ugp
 oek
-qer
-gcp
+gEK
+hWo
 sor
 shC
 shC
@@ -63673,8 +63489,8 @@ sor
 sor
 oqm
 qer
-sor
-sor
+dZx
+hyL
 sor
 shC
 shC
@@ -63930,9 +63746,9 @@ shC
 shC
 sor
 peg
-sor
-shC
-shC
+hyL
+iSJ
+djt
 shC
 shC
 shC
@@ -64188,8 +64004,8 @@ shC
 sor
 uiA
 sor
-shC
-shC
+djt
+koF
 shC
 shC
 shC
@@ -64443,7 +64259,7 @@ oqm
 shC
 shC
 sor
-qer
+fEp
 sor
 shC
 shC
@@ -64957,7 +64773,7 @@ oqm
 qer
 uRK
 etj
-qer
+gyj
 sor
 shC
 shC
@@ -74695,11 +74511,11 @@ shC
 shC
 shC
 shC
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
 shC
 shC
 shC
@@ -74952,11 +74768,11 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 pfp
 wYM
-ebD
-kqZ
+ukD
+sor
 shC
 shC
 shC
@@ -74974,14 +74790,14 @@ shC
 shC
 shC
 ekT
-kqZ
-kqZ
+sor
+sor
 ekT
 ekT
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
 shC
 shC
 shC
@@ -75209,20 +75025,20 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 suQ
 fsV
 fsV
-kqZ
+sor
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 shC
 shC
-kqZ
+sor
 shC
 shC
 shC
@@ -75238,7 +75054,7 @@ bst
 jPN
 fjH
 wYa
-kqZ
+sor
 shC
 shC
 shC
@@ -75466,9 +75282,9 @@ mRq
 shC
 shC
 shC
-kqZ
+sor
 hSv
-dPn
+qSC
 ekT
 ekT
 shC
@@ -75476,18 +75292,18 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 shC
 shC
-kqZ
-shC
-shC
-shC
+sor
 shC
 shC
 shC
 shC
-kqZ
+shC
+shC
+shC
+sor
 ekT
 ekT
 ekT
@@ -75495,7 +75311,7 @@ jPN
 oRF
 eER
 hoe
-kqZ
+sor
 shC
 shC
 shC
@@ -75727,16 +75543,16 @@ ekT
 ekT
 ekT
 ekT
-kqZ
+sor
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 ukD
 shC
-kqZ
+sor
 shC
 shC
 shC
@@ -75744,7 +75560,7 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 ekT
 ekT
 mow
@@ -75752,7 +75568,7 @@ jHa
 sUR
 pMf
 bUo
-kqZ
+sor
 shC
 shC
 shC
@@ -75973,27 +75789,27 @@ shC
 shC
 mRq
 wAS
-dfC
+dod
 qSC
 mAA
 mRq
 shC
 shC
 shC
-kqZ
-dPn
+sor
+qSC
 dod
 ekT
-kqZ
+sor
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 tNV
 jlt
-kqZ
+sor
 shC
 shC
 shC
@@ -76009,7 +75825,7 @@ szO
 xAg
 hNR
 prg
-kqZ
+sor
 shC
 shC
 shC
@@ -76237,9 +76053,9 @@ mRq
 mRq
 shC
 shC
-kqZ
+sor
 ekT
-dPn
+qSC
 hSv
 ekT
 shC
@@ -76258,15 +76074,15 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 ekT
-kqZ
-kqZ
+sor
+sor
 fmf
 fDJ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
 shC
 shC
 shC
@@ -76488,7 +76304,7 @@ mRq
 qSC
 rOh
 cgW
-dfC
+dod
 bSO
 qSC
 mRq
@@ -76518,10 +76334,10 @@ shC
 shC
 shC
 shC
-kqZ
-kYU
+sor
+kVk
 dQd
-kqZ
+sor
 shC
 shC
 shC
@@ -76743,22 +76559,22 @@ shC
 shC
 mRq
 uRc
-aVI
-bxP
+wmI
+vqH
 wlk
 qSC
 swM
 mRq
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
 jew
 ekT
 ekT
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
 pfp
 qpP
 jHa
@@ -76766,19 +76582,19 @@ jHa
 kCW
 diM
 jbS
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
+sor
 shC
-kqZ
-kqZ
-kqZ
-djt
-kYU
-kqZ
+sor
+sor
+sor
+aRv
+kVk
+sor
 shC
 shC
 shC
@@ -77013,7 +76829,7 @@ uaq
 urK
 ekT
 ekT
-dPn
+qSC
 dod
 hSv
 jHa
@@ -77032,10 +76848,10 @@ ekT
 shC
 ekT
 qPV
-cRC
-kYU
-aUJ
-kqZ
+iRb
+kVk
+hyK
+sor
 shC
 shC
 shC
@@ -77256,14 +77072,14 @@ shC
 (222,1,1) = {"
 shC
 mRq
-cFH
+jXb
 qSC
 qSC
-dfC
+dod
 tZp
 xSG
 iRb
-cEK
+gLj
 lWA
 fsV
 fsV
@@ -77271,7 +77087,7 @@ jHa
 ekT
 ekT
 ekT
-dPn
+qSC
 jHa
 mow
 jHa
@@ -77289,10 +77105,10 @@ ekT
 shC
 ekT
 ekT
-cRC
+iRb
 qPV
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -77515,21 +77331,21 @@ shC
 mRq
 sbG
 vjX
-pno
+qpP
 jwW
 wWg
 tNZ
 mRq
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
 vFp
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
 boT
 jHa
 ftT
@@ -77537,19 +77353,19 @@ tNV
 kCW
 mow
 jbS
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
+sor
 shC
-kqZ
-kqZ
-kqZ
-kYU
-kYU
-kqZ
+sor
+sor
+sor
+kVk
+kVk
+sor
 shC
 shC
 shC
@@ -77803,10 +77619,10 @@ shC
 shC
 ekT
 ekT
-kqZ
-kYU
+sor
+kVk
 qPV
-kqZ
+sor
 shC
 shC
 shC
@@ -78057,13 +77873,13 @@ ekT
 ekT
 ekT
 ekT
-kqZ
+sor
 ekT
 ekT
 ekT
 qpP
 qPV
-kqZ
+sor
 shC
 shC
 shC
@@ -78288,7 +78104,7 @@ mRq
 fVb
 sIR
 qSC
-qGo
+tNV
 mRq
 shC
 shC
@@ -78303,24 +78119,24 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 qyz
 jHa
-kqZ
+sor
 ekT
-kqZ
+sor
 shC
 ekT
 ekT
 xAg
 ekT
 ekT
-kqZ
-kqZ
-kqZ
-hyL
-aUJ
-kqZ
+sor
+sor
+sor
+cTQ
+hyK
+sor
 shC
 shC
 shC
@@ -78550,22 +78366,22 @@ mRq
 shC
 shC
 shC
-kqZ
+sor
 fsV
 hQX
 ekT
-kqZ
+sor
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 wia
 jlt
-kqZ
+sor
 ekT
-kqZ
+sor
 shC
 ekT
 aVQ
@@ -78574,10 +78390,10 @@ juH
 ekT
 ekT
 jHa
-cRC
+iRb
 ufP
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -78807,22 +78623,22 @@ mRq
 shC
 shC
 shC
-kqZ
+sor
 wbP
 fsV
 hSv
-kqZ
+sor
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 szO
 wbP
 ekT
 ekT
-kqZ
+sor
 shC
 ekT
 qfY
@@ -78831,10 +78647,10 @@ urK
 ekT
 wbP
 tNV
-cRC
+iRb
 qPV
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -79074,24 +78890,24 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 tNV
 hKh
-kqZ
+sor
 ekT
-kqZ
+sor
 shC
 ugw
 mSR
 vje
 ekT
 ekT
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
 oQi
 oQi
-kqZ
+sor
 shC
 shC
 shC
@@ -79331,10 +79147,10 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 wbP
 mWk
-kqZ
+sor
 ekT
 ekT
 shC
@@ -79342,13 +79158,13 @@ ekT
 ugw
 ekT
 ekT
-kqZ
+sor
 ekT
 ekT
-kqZ
-kYU
-kYU
-kqZ
+sor
+kVk
+kVk
+sor
 shC
 shC
 shC
@@ -79580,32 +79396,32 @@ shC
 mRq
 mRq
 alK
-qaS
+mrP
 qSv
 mRq
 mRq
 shC
 shC
 shC
-kqZ
-kqZ
+sor
+sor
 oFO
 fFa
-kqZ
+sor
 ekT
 ekT
 shC
-kqZ
+sor
 ekT
 ekT
-kqZ
+sor
 ekT
 ekT
 ekT
-kqZ
-kYU
+sor
+kVk
 qpP
-kqZ
+sor
 shC
 shC
 shC
@@ -79836,34 +79652,34 @@ shC
 shC
 mRq
 fYh
-kYU
+kVk
 qPV
-kYU
+kVk
 aRy
 mRq
-kqZ
-kqZ
+sor
+sor
 ekT
-kqZ
+sor
 wbP
 vmk
 tNV
-kqZ
+sor
 ekT
-kqZ
+sor
 shC
-kqZ
+sor
 ekT
 ekT
 ekT
-kqZ
-kqZ
-kqZ
-kqZ
-gyj
+sor
+sor
+sor
+sor
+rLF
 sfO
-kqZ
-kqZ
+sor
+sor
 shC
 shC
 shC
@@ -80093,11 +79909,11 @@ shC
 shC
 mRq
 gtE
-kYU
+kVk
 fbg
 oQi
-vff
-cRC
+lMo
+iRb
 hTb
 mWk
 wbP
@@ -80115,12 +79931,12 @@ urK
 ekT
 ekT
 qPV
-kYU
-cRC
-kYU
-kYU
-kYU
-kYU
+kVk
+iRb
+kVk
+kVk
+kVk
+kVk
 shC
 shC
 shC
@@ -80350,19 +80166,19 @@ shC
 shC
 mRq
 jfj
-vUU
+hAx
 fjB
-kYU
-kYU
-cRC
+kVk
+kVk
+iRb
 hTb
 uok
 mMz
 qpP
 mWk
 wlO
-nRz
-cRC
+xSG
+iRb
 jHa
 ekT
 shC
@@ -80372,11 +80188,11 @@ gLj
 ekT
 ekT
 ekT
-djt
-cRC
-kYU
+aRv
+iRb
+kVk
 dbP
-kYU
+kVk
 shC
 shC
 shC
@@ -80607,34 +80423,34 @@ shC
 shC
 mRq
 fYh
-vff
-kYU
-kYU
+lMo
+kVk
+kVk
 tTk
 mRq
-kqZ
+sor
 ekT
-kqZ
+sor
 ekT
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
 ekT
-kqZ
+sor
 shC
 shC
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kYU
+sor
+sor
+sor
+sor
+sor
+sor
+sor
+kVk
 ekT
-kqZ
-kqZ
+sor
+sor
 shC
 shC
 shC
@@ -80864,9 +80680,9 @@ shC
 shC
 mRq
 mRq
-kYU
+kVk
 pcH
-kYU
+kVk
 mRq
 mRq
 mRq
@@ -80887,10 +80703,10 @@ shC
 shC
 shC
 shC
-kqZ
+sor
 ekT
 ekT
-kqZ
+sor
 shC
 shC
 shC
@@ -81122,8 +80938,8 @@ shC
 mRq
 mRq
 mRq
-cRC
-cRC
+iRb
+iRb
 mRq
 mRq
 dpy
@@ -81132,22 +80948,22 @@ lmG
 gtE
 azC
 ofW
-ocQ
-ocQ
-ocQ
-ocQ
-ocQ
-ocQ
+ugX
+ugX
+ugX
+ugX
+ugX
+ugX
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 sfu
 ekT
-kqZ
+sor
 shC
 shC
 shC
@@ -81378,33 +81194,33 @@ shC
 shC
 vqH
 mRq
-sIJ
-kYU
+fYH
+kVk
 qPV
-kYU
-cRC
-kYU
-kYU
-vff
-nKk
-nKk
+kVk
+iRb
+kVk
+kVk
+lMo
+smS
+smS
 ofW
-ocQ
-pmN
-pmN
-pmN
-pmN
-ocQ
+ugX
+fPw
+fPw
+fPw
+fPw
+ugX
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
-kYU
+sor
+kVk
 vPA
-kqZ
+sor
 shC
 shC
 shC
@@ -81632,36 +81448,36 @@ shC
 shC
 shC
 shC
-nHm
+rOh
 gfp
 mRq
 akg
 qPV
-hWo
+gKm
 tKQ
 ceB
 ikl
-kYU
-vff
-kYU
+kVk
+lMo
+kVk
 nlO
 ofW
-ocQ
-pmN
-pmN
-pmN
-pmN
-ocQ
+ugX
+fPw
+fPw
+fPw
+fPw
+ugX
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
-hyL
-aUJ
-kqZ
+sor
+cTQ
+hyK
+sor
 shC
 shC
 shC
@@ -81892,33 +81708,33 @@ shC
 gfp
 qxZ
 fDJ
-kYU
-kYU
-vff
+kVk
+kVk
+lMo
 dhY
 mRq
 mRq
 mRq
 mRq
-cRC
+iRb
 mRq
 ofW
-ocQ
-pmN
-pmN
+ugX
+fPw
+fPw
 akB
-pmN
-ocQ
+fPw
+ugX
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 qpP
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -82149,33 +81965,33 @@ exM
 pMf
 qpP
 mRq
-hyL
+cTQ
 oGx
-hAF
+jcV
 pGf
 mRq
-eZS
+wpj
 wVj
-sIJ
-kYU
+fYH
+kVk
 azC
 ofW
-ocQ
-ocU
-cQy
-cQy
-ocU
-ocQ
+ugX
+dfi
+nJJ
+nJJ
+dfi
+ugX
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
+sor
 hvq
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -82407,32 +82223,32 @@ tfC
 lDm
 mRq
 oQi
-kYU
-opz
-yfw
+kVk
+rxL
+qIK
 mRq
-dZx
-kYU
-vff
+wWn
+kVk
+lMo
 aYe
-koF
+jIK
 ofW
 izm
-fEp
-fEp
-fEp
-fEp
-fEp
+tED
+tED
+tED
+tED
+tED
 ofW
 shC
 shC
 shC
 shC
 shC
-kqZ
-kYU
-kYU
-kqZ
+sor
+kVk
+kVk
+sor
 shC
 shC
 shC
@@ -82664,32 +82480,32 @@ xQm
 bgC
 mRq
 qUf
-vff
+lMo
 qPV
-kYU
-cRC
+kVk
+iRb
 cqb
-vff
+lMo
 oQi
 vAZ
-nBk
+jBu
 mRq
-kYU
-kYU
-iSJ
-kYU
-kYU
+kVk
+kVk
+cQU
+kVk
+kVk
 rEE
 mRq
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
+sor
 oQi
-kYU
-kqZ
+kVk
+sor
 shC
 shC
 shC
@@ -82921,8 +82737,8 @@ lmS
 tqt
 mRq
 mRq
-cRC
-cRC
+iRb
+iRb
 mRq
 mRq
 mRq
@@ -82931,22 +82747,22 @@ nxd
 nxd
 nxd
 mRq
-hyL
+cTQ
 oQi
-kYU
-kYU
-kYU
-kYU
-cRC
-kYU
-kYU
+kVk
+kVk
+kVk
+kVk
+eUV
+kVk
+kVk
 qpP
-kYU
+kVk
 ekT
 ekT
-kYU
+kVk
 ufP
-kqZ
+sor
 shC
 shC
 shC
@@ -83178,32 +82994,32 @@ mRq
 mRq
 mRq
 mRS
-vff
-kYU
-kYU
-eiw
-kGB
-kYU
-kYU
-kYU
-kYU
+lMo
+kVk
+kVk
+bha
+iUB
+kVk
+kVk
+kVk
+kVk
 mRq
-kYU
+kVk
 uUP
 eao
 eao
 jRw
-kYU
-cRC
-kYU
+kVk
+eUV
+kVk
 ekT
-nKk
-gEK
-kYU
-kYU
-djt
-aUJ
-kqZ
+smS
+iBK
+kVk
+kVk
+aRv
+hyK
+sor
 shC
 shC
 shC
@@ -83429,38 +83245,38 @@ shC
 shC
 shC
 shC
-ope
-kYU
-iSJ
-kYU
+pXR
+kVk
+cQU
+kVk
 mRq
 axy
 oQi
-kYU
-kYU
-cRC
-nKk
-kYU
-kYU
-vff
-kYU
-cRC
-nKk
-kYU
-iSJ
+kVk
+kVk
+iRb
+smS
+kVk
+kVk
+lMo
+kVk
+eUV
+smS
+kVk
+cQU
 qPV
 til
 rEE
 mRq
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
-kqZ
+sor
+sor
+sor
+sor
+sor
+sor
+sor
+sor
+sor
 shC
 shC
 shC
@@ -83686,28 +83502,28 @@ shC
 shC
 shC
 shC
-kYU
-iSJ
-iSJ
-kYU
-cRC
-kYU
+kVk
+cQU
+cQU
+kVk
+iRb
+kVk
 qPV
-kYU
+kVk
 aRy
-eiw
+bha
 lim
 uUP
 eao
 jRw
 rEE
 mRq
-hyL
+cTQ
 uUP
 eao
 eao
 jRw
-kYU
+kVk
 mRq
 shC
 shC
@@ -83944,27 +83760,27 @@ shC
 shC
 shC
 shC
-kYU
+kVk
 diI
-kYU
+kVk
 mRq
 jWi
 wJR
-kYU
-kYU
-cRC
-kYU
-kYU
+kVk
+kVk
+iRb
+kVk
+kVk
 qPV
 kUn
-kYU
-cRC
-hWo
-kYU
-kYU
-kYU
-djt
-kYU
+kVk
+eUV
+gKm
+kVk
+kVk
+kVk
+aRv
+kVk
 mRq
 shC
 shC
@@ -84206,22 +84022,22 @@ mRq
 mRq
 mRq
 jid
-kYU
-vff
-kYU
-eiw
+kVk
+lMo
+kVk
+bha
 dhY
-kYU
-kYU
+kVk
+kVk
 hvX
-kYU
+kVk
 mRq
-kYU
-iSJ
-kYU
-kYU
-kYU
-iSJ
+kVk
+cQU
+kVk
+kVk
+kVk
+cQU
 mRq
 shC
 shC
@@ -84468,9 +84284,9 @@ mRq
 mRq
 mRq
 mRq
-cRC
-eiw
-eiw
+iRb
+bha
+bha
 oGx
 mRq
 dgi
@@ -84725,10 +84541,10 @@ shC
 shC
 mRq
 tib
-kYU
+kVk
 qPV
-vff
-opz
+lMo
+rxL
 mRq
 mRq
 mRq
@@ -84983,9 +84799,9 @@ shC
 mRq
 sZe
 oQi
-kYU
-vff
-kYU
+kVk
+lMo
+kVk
 mRq
 shC
 shC

--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -599,7 +599,7 @@
 /area/f13/building)
 "fS" = (
 /obj/effect/decal/remains/human,
-/obj/structure/timeddoor,
+/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -1493,7 +1493,8 @@
 	},
 /area/f13/tunnel)
 "mO" = (
-/obj/machinery/autolathe/hacked,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/bundle/f13/needler,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "mV" = (
@@ -1725,7 +1726,7 @@
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/mountain_area)
 "oF" = (
-/obj/structure/timeddoor,
+/obj/structure/timeddoor/onetwozerominutes,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "oG" = (
@@ -1763,7 +1764,7 @@
 	},
 /area/f13/mountain_area)
 "oU" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/item/pda,
 /obj/item/pda,
 /obj/item/pda,
@@ -1821,7 +1822,7 @@
 "pa" = (
 /obj/machinery/door/airlock/hatch{
 	req_access = null;
-	req_access_txt = "134"
+	req_access_txt = "256"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
@@ -2217,7 +2218,7 @@
 	},
 /area/f13/tunnel)
 "sn" = (
-/obj/structure/timeddoor,
+/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -2596,8 +2597,9 @@
 /turf/open/floor/f13,
 /area/f13/enclave)
 "uY" = (
+/obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
-/obj/machinery/base_dispenser/enclave,
+/obj/effect/spawner/bundle/f13/ionrifle,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "va" = (
@@ -2816,6 +2818,11 @@
 /obj/machinery/light,
 /obj/structure/closet/crate/mortar_shells,
 /obj/item/mortar_kit,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave)
+"wU" = (
+/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "wV" = (
@@ -3157,7 +3164,7 @@
 /area/f13/enclave)
 "zK" = (
 /obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "zN" = (
 /obj/structure/barricade/wooden/snowed,
@@ -3331,7 +3338,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "Bh" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -3963,12 +3970,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "GZ" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/item/gun/energy/laser/plasma/pistol/worn,
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/energy/laser/plasma/pistol/remnant/is,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "Hb" = (
@@ -3989,7 +3992,7 @@
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
 	},
-/obj/structure/timeddoor,
+/obj/structure/timeddoor/onetwozerominutes,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -4163,8 +4166,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ix" = (
-/obj/structure/debris/v1,
-/turf/open/indestructible/ground/outside/snow_plating,
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/obj/effect/landmark/vertibird{
+	name = "Casper NE"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/mountain_area)
 "Iy" = (
 /obj/machinery/light{
@@ -4442,6 +4452,7 @@
 /area/f13/enclave)
 "Ld" = (
 /obj/machinery/ammobench,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "Lf" = (
@@ -4509,6 +4520,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "LJ" = (
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "LN" = (
@@ -4618,12 +4630,6 @@
 /obj/structure/dresser,
 /turf/open/floor/f13,
 /area/f13/enclave)
-"MX" = (
-/obj/item/flag/enclave/alt{
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/snow,
-/area/f13/mountain_area)
 "Nc" = (
 /obj/effect/decal/marking,
 /obj/structure/car/rubbish3,
@@ -4681,12 +4687,11 @@
 	},
 /turf/open/indestructible/ground/outside/snow_plating,
 /area/f13/mountain_area)
-"NL" = (
-/obj/item/flag/enclave/alt{
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/snow_plating,
-/area/f13/mountain_area)
+"NE" = (
+/obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave)
 "NM" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -4721,7 +4726,7 @@
 /turf/open/floor/wood/wood_fancy,
 /area/f13/building)
 "NX" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/suit/armor/f13/combat/enclave,
@@ -4847,7 +4852,9 @@
 /turf/open/floor/f13,
 /area/f13/enclave)
 "OX" = (
-/obj/structure/debris/v3,
+/obj/effect/landmark/vertibird{
+	name = "External Landing"
+	},
 /turf/open/indestructible/ground/outside/snow_plating,
 /area/f13/mountain_area)
 "OZ" = (
@@ -4964,6 +4971,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/enclave)
+"Qz" = (
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/enclave)
 "QA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
@@ -4993,10 +5005,6 @@
 /obj/item/clothing/under/burial,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
-"QP" = (
-/obj/structure/debris/v2,
-/turf/open/indestructible/ground/outside/snow_plating,
-/area/f13/mountain_area)
 "QS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -5007,10 +5015,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/tunnel)
-"QU" = (
-/obj/structure/debris/v4,
-/turf/open/indestructible/ground/outside/snow_plating,
-/area/f13/mountain_area)
 "QX" = (
 /obj/effect/spawner/lootdrop/ammo/civilian,
 /turf/open/indestructible/ground/outside/road{
@@ -5128,7 +5132,7 @@
 /turf/open/floor/f13,
 /area/f13/enclave)
 "RG" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
 /obj/item/gun/energy/laser/complianceregulator,
 /obj/item/gun/energy/laser/complianceregulator,
@@ -5402,7 +5406,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "TJ" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
 /obj/item/melee/baton/stunsword,
 /obj/item/melee/baton/stunsword,
@@ -5547,7 +5551,8 @@
 /turf/open/indestructible/ground/outside/snow_plating,
 /area/f13/mountain_area)
 "Vm" = (
-/obj/machinery/workbench/advanced,
+/obj/effect/turf_decal/bot,
+/obj/machinery/base_dispenser/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "Vp" = (
@@ -6000,7 +6005,7 @@
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/mountain_area)
 "Zu" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/effect/turf_decal/bot,
 /obj/item/gun/ballistic/automatic/assault_carbine,
 /obj/item/gun/ballistic/automatic/assault_carbine,
@@ -14966,10 +14971,10 @@ ez
 qd
 tt
 tt
-Ix
+tt
 aA
 tt
-QU
+tt
 tt
 tt
 eo
@@ -15737,7 +15742,7 @@ ez
 qd
 tt
 tt
-OX
+tt
 tt
 tt
 Iv
@@ -16253,7 +16258,7 @@ tt
 tt
 EG
 tt
-QP
+tt
 tt
 tt
 tt
@@ -21681,10 +21686,10 @@ UE
 HA
 HA
 HA
-HA
-HA
-HA
-HA
+iT
+iT
+iT
+iT
 iT
 iT
 iT
@@ -21938,11 +21943,11 @@ HA
 UE
 HA
 HA
-HA
-HA
-HA
-HA
 iT
+mA
+mA
+mA
+mA
 mA
 mA
 mA
@@ -22195,13 +22200,13 @@ HA
 HA
 HA
 UE
-HA
-HA
-HA
-HA
 iT
 mA
-LJ
+mO
+mO
+mO
+mA
+FJ
 as
 oO
 GY
@@ -22452,11 +22457,11 @@ HA
 HA
 HA
 HA
-UE
-HA
-HA
-HA
 iT
+mA
+FJ
+FJ
+rq
 mA
 Bg
 as
@@ -22709,13 +22714,13 @@ HA
 HA
 HA
 HA
-HA
-HA
-HA
-HA
 iT
 mA
-LJ
+GZ
+GZ
+FJ
+mA
+FJ
 as
 oO
 oO
@@ -22966,11 +22971,11 @@ HA
 HA
 HA
 HA
-HA
-HA
-HA
-HA
 iT
+mA
+mA
+mA
+pa
 mA
 pa
 mA
@@ -23223,13 +23228,13 @@ HA
 HA
 HA
 HA
-HA
-HA
-HA
+iT
 iT
 iT
 AW
-LJ
+FJ
+FJ
+FJ
 jI
 NT
 Xa
@@ -23481,17 +23486,17 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
 AW
 Bg
-LJ
-LJ
-LJ
-LJ
-LJ
+FJ
+FJ
+FJ
+FJ
+FJ
+FJ
+FJ
 pa
 FJ
 FJ
@@ -23738,16 +23743,16 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
 Ld
-LJ
+FJ
+FJ
+FJ
 Zu
-LJ
+FJ
 oU
-LJ
+FJ
 DT
 LS
 FJ
@@ -23995,16 +24000,16 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
 LJ
-LJ
+FJ
+FJ
+FJ
 uY
-LJ
+FJ
 NX
-LJ
+FJ
 VZ
 TK
 FJ
@@ -24252,16 +24257,16 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
 og
-LJ
+FJ
+FJ
+FJ
 TJ
-LJ
+FJ
 RG
-LJ
+FJ
 zK
 tV
 FJ
@@ -24509,17 +24514,17 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
-mO
-LJ
-LJ
-LJ
-LJ
-LJ
-LJ
+NE
+FJ
+FJ
+FJ
+FJ
+FJ
+FJ
+FJ
+FJ
 RE
 FJ
 FJ
@@ -24766,12 +24771,12 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
-GZ
-LJ
+Qz
+FJ
+gV
+FJ
 sg
 cf
 fu
@@ -25023,10 +25028,10 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 AW
+AW
+wU
 AW
 Vm
 AW
@@ -25280,10 +25285,10 @@ HA
 HA
 HA
 HA
-HA
-HA
 iT
 iT
+AW
+AW
 AW
 AW
 AW
@@ -25538,8 +25543,8 @@ HA
 HA
 UE
 HA
-HA
-HA
+iT
+iT
 iT
 AW
 sF
@@ -60566,13 +60571,13 @@ ez
 ez
 ez
 gH
-MX
+ez
 Zb
 Ry
 Sg
 sB
 wK
-MX
+ez
 Vr
 Vr
 Vr
@@ -61486,7 +61491,7 @@ ez
 ez
 Uj
 Uj
-NL
+Vr
 uH
 tt
 tt
@@ -69043,7 +69048,7 @@ mV
 mV
 oT
 rt
-Tj
+Ix
 oT
 mV
 mV

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -55,13 +55,13 @@
 /area/f13/tunnel)
 "aap" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "aaq" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "aar" = (
 /obj/machinery/light/small{
@@ -73,7 +73,7 @@
 /obj/structure/barricade/bars{
 	layer = 5
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "aat" = (
 /obj/machinery/light/small{
@@ -173,7 +173,7 @@
 /area/f13/tunnel)
 "aaK" = (
 /obj/structure/ore_box,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "aaL" = (
 /obj/machinery/mineral/ore_redemption,
@@ -244,7 +244,7 @@
 	},
 /area/f13/tunnel)
 "aba" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel/southwestbighorn)
 "abb" = (
 /obj/structure/barricade/bars{
@@ -436,7 +436,7 @@
 /turf/closed/wall/rust,
 /area/f13/tunnel/southeastbighorn)
 "aby" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel/southeastbighorn)
 "abz" = (
 /obj/structure/handrail/g_central{
@@ -520,8 +520,9 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "ahM" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/ore/blackpowder/fifty,
+/obj/structure/rack/shelf_metal,
+/obj/item/m2flamethrowertank,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aig" = (
@@ -573,10 +574,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "akK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "alc" = (
 /turf/open/floor/f13/wood,
@@ -617,10 +617,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "amO" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "amT" = (
 /obj/structure/table/wood,
@@ -648,6 +647,16 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"anv" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/drain,
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/tunnel)
 "anI" = (
 /obj/structure/girder,
 /turf/open/indestructible/ground/inside/mountain,
@@ -666,12 +675,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aob" = (
-/obj/machinery/door/unpowered/securedoor{
-	max_integrity = 800;
-	name = "Store Backroom";
-	obj_integrity = 800;
-	req_one_access_txt = "34"
+/obj/structure/railing/corner{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aod" = (
@@ -698,15 +705,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aoy" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Store Bedroom";
-	req_one_access_txt = "34"
-	},
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/bomb/tier3,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aoK" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/floor/plating,
+/obj/machinery/workbench,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aoO" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -720,7 +738,7 @@
 	},
 /area/f13/building/massfusion)
 "aoV" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "aoY" = (
 /obj/structure/rack,
@@ -732,20 +750,10 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
-"ape" = (
-/obj/machinery/button/door{
-	id = "shoplower";
-	name = "lower shutters";
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/tunnel)
 "apf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "apg" = (
 /turf/closed/wall/r_wall/f13/vault,
@@ -777,7 +785,7 @@
 /area/f13/tunnel)
 "apy" = (
 /obj/structure/railing/corner,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "apz" = (
 /obj/structure/closet/crate/large,
@@ -786,11 +794,10 @@
 	},
 /area/f13/tunnel)
 "aqg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/bomb/tier1,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aqo" = (
 /obj/item/kirbyplants{
@@ -800,30 +807,30 @@
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/offices1st)
 "aqv" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aqw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light/floor,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aqO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/item/restraints/handcuffs/fake/kinky{
+	desc = "Imitation handcuffs meant for erotic roleplay. This pair appears to have an engraving along the inside, with the initials 'SS'. What's that mean?"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "aqP" = (
-/obj/machinery/workbench/advanced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "aqQ" = (
@@ -896,7 +903,7 @@
 "axw" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "azk" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -1387,7 +1394,7 @@
 /area/f13/building/massfusion)
 "bjZ" = (
 /obj/effect/spawner/lootdrop/f13/medical/random_fev,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "bkj" = (
 /obj/machinery/light{
@@ -1475,7 +1482,7 @@
 /area/f13/tunnel)
 "boM" = (
 /obj/structure/railing,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "boR" = (
 /obj/structure/table,
@@ -1509,7 +1516,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "bpO" = (
 /obj/structure/nest/scorpion{
@@ -1791,7 +1798,7 @@
 /area/f13/tunnel)
 "bDj" = (
 /mob/living/simple_animal/hostile/deathclaw,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "bDk" = (
 /mob/living/simple_animal/hostile/supermutant,
@@ -2496,7 +2503,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "bJq" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "bJr" = (
 /obj/structure/showcase/horrific_experiment,
@@ -3906,7 +3913,7 @@
 /area/f13/tunnel)
 "bOm" = (
 /obj/structure/barricade/bars,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "bOn" = (
 /turf/closed/wall/rust,
@@ -5004,9 +5011,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "bWv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bWH" = (
 /obj/structure/closet/cabinet,
@@ -5987,7 +5993,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cqO" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "csU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6425,11 +6431,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cST" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "cTf" = (
 /turf/open/floor/f13{
@@ -6466,7 +6471,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "cXk" = (
 /obj/structure/table/reinforced,
@@ -6852,7 +6857,7 @@
 /area/f13/brotherhood/archives)
 "dwF" = (
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "dxj" = (
 /obj/structure/handrail/g_central{
@@ -7749,7 +7754,7 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "eId" = (
 /obj/structure/sign/warning/docking{
@@ -8120,7 +8125,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "foM" = (
 /obj/structure/table/glass,
@@ -8260,10 +8265,8 @@
 	},
 /area/f13/bunker)
 "fwm" = (
-/obj/machinery/light/broken,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/stairs/south,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fxU" = (
 /obj/structure/railing{
@@ -8281,10 +8284,10 @@
 	},
 /area/f13/tunnel)
 "fyq" = (
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/structure/railing{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fyQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8316,17 +8319,16 @@
 	},
 /area/f13/tunnel)
 "fDv" = (
-/obj/machinery/door/unpowered/celldoor,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fDF" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/decoration/rag,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLowMid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fDN" = (
 /obj/structure/chair/booth{
@@ -8367,8 +8369,9 @@
 /turf/open/floor/plating,
 /area/f13/building/museum)
 "fGV" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/closet/crate/mortar_shells,
+/obj/item/mortar_kit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "fGZ" = (
 /turf/open/floor/f13{
@@ -9199,10 +9202,10 @@
 	},
 /area/f13/brotherhood)
 "gYM" = (
-/obj/item/storage/trash_stack{
-	layer = 2
-	},
-/turf/open/floor/plating,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/armor/tier5,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "haa" = (
 /obj/structure/table,
@@ -9416,6 +9419,11 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"hry" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "hrS" = (
 /obj/structure/railing{
 	dir = 8
@@ -9691,9 +9699,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "hLC" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "hMi" = (
 /obj/structure/fermenting_barrel,
@@ -10139,7 +10147,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
 /obj/structure/sign/poster/contraband/pinup_vixen{
 	pixel_y = 32
@@ -10231,10 +10238,15 @@
 	},
 /area/f13/tunnel)
 "iBh" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "shopladder"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iBq" = (
@@ -10414,9 +10426,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iKY" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
+/obj/item/stack/sheet/prewar,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iLR" = (
@@ -10487,7 +10501,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "iRM" = (
-/obj/item/kirbyplants/random,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "iRN" = (
@@ -11021,7 +11044,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "jCI" = (
 /obj/structure/table,
@@ -11313,7 +11336,7 @@
 /area/f13/brotherhood)
 "keE" = (
 /obj/structure/wreck/trash/halftire,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "kfr" = (
 /obj/structure/barricade/wooden,
@@ -11561,7 +11584,7 @@
 /area/f13/building/massfusion)
 "kAF" = (
 /obj/structure/barricade/sandbags,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "kBD" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -11575,7 +11598,7 @@
 /obj/structure/barricade/bars{
 	layer = 3.5
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "kCX" = (
 /obj/structure/sign/warning,
@@ -11599,6 +11622,11 @@
 "kEf" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"kEq" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "kFp" = (
 /obj/structure/handrail/g_central{
@@ -11641,16 +11669,11 @@
 	},
 /area/f13/brotherhood/medical)
 "kIO" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLowMid,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kJf" = (
 /obj/structure/handrail/g_central{
@@ -11839,9 +11862,9 @@
 	},
 /area/f13/tunnel)
 "kVp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/unique,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/armor/random_high,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "kVs" = (
@@ -11931,7 +11954,7 @@
 /area/f13/tunnel)
 "lbA" = (
 /obj/structure/nest/deathclaw,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "lcf" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -11997,7 +12020,7 @@
 /area/f13/brotherhood)
 "lfB" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "lgh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12033,7 +12056,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
 "lhz" = (
-/obj/machinery/base_dispenser/ammo,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lii" = (
@@ -12041,11 +12070,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "ljp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
-/obj/item/stack/sheet/prewar,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ljv" = (
@@ -12203,16 +12232,14 @@
 	},
 /area/f13/brotherhood/armory)
 "lpF" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lqA" = (
@@ -12312,14 +12339,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/offices1st)
 "lwl" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
+/obj/structure/rack/shelf_metal,
+/obj/item/minigunpack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lym" = (
@@ -12441,11 +12462,8 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood/medical)
 "lEZ" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
-/obj/item/stack/sheet/plastic/fifty,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lGi" = (
@@ -12594,9 +12612,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lPr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/stack/sheet/cloth/ten,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lQa" = (
@@ -12614,8 +12635,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "lQx" = (
-/obj/structure/table/wood/poker,
-/obj/item/storage/box/dice,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lRl" = (
@@ -12764,13 +12793,25 @@
 	},
 /area/f13/bunker)
 "lZs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
+/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "lZt" = (
 /obj/structure/railing/corner{
@@ -13523,7 +13564,7 @@
 /area/f13/tunnel)
 "nmK" = (
 /obj/machinery/light/small,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "nnk" = (
 /obj/effect/turf_decal/caution{
@@ -13766,7 +13807,7 @@
 	pixel_x = 12;
 	pixel_y = 0
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "nHe" = (
 /obj/machinery/hydroponics/soil,
@@ -14283,14 +14324,18 @@
 	},
 /area/f13/tunnel)
 "oqJ" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
+/obj/item/stack/sheet/leather/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oqL" = (
@@ -14318,7 +14363,7 @@
 /area/f13/building/massfusion)
 "orG" = (
 /obj/structure/simple_door/metal/barred,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "osG" = (
 /obj/item/flashlight{
@@ -14402,7 +14447,7 @@
 /area/f13/brotherhood)
 "oxK" = (
 /obj/effect/decal/remains/human,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "oyj" = (
 /obj/machinery/light/small{
@@ -14507,16 +14552,12 @@
 	},
 /area/f13/brotherhood)
 "oGo" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oGw" = (
@@ -14717,24 +14758,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "oUp" = (
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/bundle/f13/grenadelauncher,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "oUx" = (
@@ -14819,13 +14845,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "pcA" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
-/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/machinery/door/unpowered/securedoor{
+	max_integrity = 800;
+	name = "Store Backroom";
+	obj_integrity = 800;
+	req_one_access_txt = "34"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pcF" = (
@@ -15125,29 +15151,8 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices1st)
 "pvU" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/stack/f13Cash/random/high,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/rack/shelf_metal,
+/obj/item/minigunpackbal5mm,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pwh" = (
@@ -15486,13 +15491,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/offices1st)
 "pPX" = (
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/machinery/workbench/forge,
+/obj/item/traumapack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "pQk" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -15506,11 +15507,6 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"pSB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/f13/tunnel)
 "pSP" = (
 /turf/open/floor/plasteel/darkpurple/side{
 	dir = 9
@@ -16062,9 +16058,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "qDF" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "qDU" = (
 /turf/open/floor/f13{
@@ -16380,15 +16375,22 @@
 /turf/closed/wall/f13/sunset/brick_small,
 /area/f13/tunnel)
 "rdE" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rdK" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/stack/sheet/hay/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rdL" = (
 /obj/structure/table/reinforced,
@@ -16765,12 +16767,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/offices1st)
 "rID" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/item/stack/sheet/hay/fifty,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rIR" = (
@@ -16875,7 +16878,7 @@
 /area/f13/tunnel)
 "rRt" = (
 /obj/item/storage/trash_stack,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "rRw" = (
 /obj/structure/rack/shelf_metal,
@@ -16885,7 +16888,7 @@
 "rSn" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "rSF" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -16913,19 +16916,36 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"rVd" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/structure/mirror{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/f13/tunnel)
 "rVs" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
-/obj/item/stack/sheet/leather/twenty,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier1,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier2,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
+/obj/effect/spawner/lootdrop/f13/gunparts/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "rVv" = (
@@ -17028,51 +17048,29 @@
 /area/f13/tunnel)
 "saE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "saZ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "sbd" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "sbk" = (
-/obj/structure/rack,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/receiver,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/alloys,
-/obj/item/advanced_crafting_components/assembly,
-/obj/item/advanced_crafting_components/conductors,
-/obj/item/advanced_crafting_components/flux,
-/obj/item/advanced_crafting_components/lenses,
-/obj/item/advanced_crafting_components/receiver,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
 /area/f13/tunnel)
 "sbr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17222,8 +17220,34 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "smC" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/battlecoat,
+/obj/structure/rack/shelf_metal,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/receiver,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/alloys,
+/obj/item/advanced_crafting_components/assembly,
+/obj/item/advanced_crafting_components/conductors,
+/obj/item/advanced_crafting_components/flux,
+/obj/item/advanced_crafting_components/lenses,
+/obj/item/advanced_crafting_components/receiver,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "smT" = (
@@ -17629,7 +17653,7 @@
 "sOr" = (
 /obj/item/storage/trash_stack,
 /obj/item/mine/explosive,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "sQl" = (
 /obj/structure/chair,
@@ -17767,7 +17791,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "tao" = (
 /obj/item/bighorn_flag,
@@ -17956,6 +17980,11 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/tunnel)
+"tlk" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "tls" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18041,13 +18070,9 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood/medical)
 "tso" = (
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/item/stack/sheet/hay/fifty,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tsu" = (
@@ -18099,7 +18124,18 @@
 /area/f13/building/museum)
 "ttr" = (
 /obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tuP" = (
@@ -18259,7 +18295,7 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "tIQ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -18345,10 +18381,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tQC" = (
-/obj/structure/junk/jukebox,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "tRK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18511,10 +18547,8 @@
 	},
 /area/f13/brotherhood/offices1st)
 "ufI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "ufM" = (
 /obj/structure/table,
@@ -18730,11 +18764,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uxh" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shoplower"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uxK" = (
@@ -18880,19 +18911,12 @@
 	},
 /area/f13/building/museum)
 "uIg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/machinery/door/unpowered/securedoor{
+	max_integrity = 800;
+	name = "Store Backroom";
+	obj_integrity = 800;
+	req_one_access_txt = "34"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uIB" = (
@@ -18902,19 +18926,8 @@
 	},
 /area/f13/tunnel)
 "uKE" = (
-/obj/structure/rack,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/crafting/abraxo,
-/obj/item/assembly/prox_sensor,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/radio,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/crafting,
-/obj/effect/spawner/lootdrop/f13/crafting,
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uLz" = (
@@ -18932,9 +18945,7 @@
 	},
 /area/f13/tunnel)
 "uMX" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/minigunpackbal5mm,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uNI" = (
@@ -18950,10 +18961,8 @@
 	},
 /area/f13/tunnel)
 "uNL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/tools{
-	pixel_x = 32
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uPv" = (
@@ -18965,10 +18974,11 @@
 	},
 /area/f13/tunnel)
 "uPA" = (
-/obj/structure/junk/small,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+/obj/machinery/door/unpowered/securedoor{
+	name = "Store Bedroom";
+	req_one_access_txt = "34"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "uPJ" = (
 /obj/structure/closet/crate/secure/weapon{
@@ -19061,7 +19071,7 @@
 	dir = 1;
 	light_color = "red"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "uXv" = (
 /turf/closed/indestructible/f13vaultrusted{
@@ -19418,7 +19428,7 @@
 /obj/structure/handrail/g_central{
 	pixel_y = -16
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "vzF" = (
 /obj/machinery/photocopier,
@@ -19651,7 +19661,13 @@
 /area/f13/followers)
 "vOh" = (
 /obj/item/mine/explosive,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/tunnel)
+"vOj" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "vOB" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -19737,7 +19753,7 @@
 /obj/structure/handrail/g_central{
 	pixel_y = -16
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "vTf" = (
 /obj/structure/simple_door/metal/barred,
@@ -19824,7 +19840,7 @@
 /area/f13/brotherhood)
 "vYI" = (
 /obj/structure/barricade/wooden,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "vZb" = (
 /obj/structure/simple_door/bunker,
@@ -19876,9 +19892,14 @@
 	},
 /area/f13/tunnel)
 "wdz" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/obj/item/stack/f13Cash/random/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "wer" = (
 /obj/structure/nest/spider{
@@ -19896,8 +19917,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
 "weO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "wfu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20165,11 +20191,8 @@
 /turf/open/floor/plasteel/darkpurple,
 /area/f13/brotherhood/archives)
 "wCO" = (
-/obj/structure/junk/small/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "wDj" = (
 /obj/structure/chair/comfy/black{
@@ -20336,11 +20359,10 @@
 	},
 /area/f13/tunnel)
 "wOa" = (
-/obj/structure/barricade/wooden{
-	layer = 2.5
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/f13/bomb/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "wOH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20630,6 +20652,12 @@
 	dir = 6
 	},
 /area/f13/brotherhood)
+"xns" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/tunnel)
 "xnw" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
@@ -20807,20 +20835,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "xCt" = (
-/obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/effect/spawner/lootdrop/f13/resourcespawner,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/obj/item/reagent_containers/glass/bottle/blackpowder,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/floorgrime,
 /area/f13/tunnel)
 "xCN" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -20992,10 +21009,17 @@
 	},
 /area/f13/building/massfusion)
 "xOk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/f13Cash/random/aureus/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/tunnel)
 "xPK" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
@@ -21208,7 +21232,7 @@
 	pixel_x = 12;
 	pixel_y = 0
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/tunnel)
 "ydq" = (
 /obj/structure/lattice/catwalk,
@@ -36996,7 +37020,7 @@ uXv
 uXv
 uXv
 dzm
-hLC
+anq
 mVE
 mby
 mVE
@@ -37768,7 +37792,7 @@ mVE
 uXv
 dzm
 anq
-kIO
+anq
 mVE
 oiF
 mby
@@ -39051,14 +39075,14 @@ uXv
 uXv
 uXv
 uXv
-dzm
-dzm
-dzm
-dzm
-dzm
-dzm
-dzm
-dzm
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
 bPR
 bKb
 bKb
@@ -39304,18 +39328,18 @@ aaa
 aaa
 aae
 aae
-aae
-aae
-aae
-eUS
-bKb
-bKb
-wuC
-fyq
-bKb
-bKb
-cGQ
-bKb
+uXv
+eET
+dFQ
+fwm
+uXv
+uXv
+iBh
+dFQ
+lPr
+dFQ
+rdK
+uXv
 gck
 bPR
 bKb
@@ -39561,18 +39585,18 @@ aak
 aae
 aae
 aae
-aaa
-aae
-apz
-bPR
-gck
-uDL
-bPR
-bKb
-bKb
-fyq
-bKb
-bKb
+uXv
+uIg
+uXv
+uXv
+uXv
+uXv
+iKY
+dFQ
+lQx
+dFQ
+smC
+uXv
 ybw
 bKb
 bKb
@@ -39818,17 +39842,17 @@ aak
 aak
 aak
 aak
-aaa
-aae
-gck
-gck
 uXv
+wid
+wid
+dFQ
+dFQ
 uXv
-uXv
-uXv
-uXv
-uXv
-uXv
+iRM
+dFQ
+lZs
+dFQ
+ttr
 uXv
 uXv
 uXv
@@ -40075,20 +40099,20 @@ aak
 aaa
 aaa
 aak
-aak
-bOn
-bPR
-bJq
+uXv
+akK
+aqv
+wid
+fDv
 uXv
 dFQ
-wid
-ciE
-wid
-wid
 dFQ
+oGo
 dFQ
-dFQ
-eET
+rID
+uXv
+wdz
+xOk
 lhz
 uXv
 hZU
@@ -40332,21 +40356,21 @@ aak
 aaa
 aak
 aak
-aak
-bOn
-bKb
-bJq
 gQP
+amO
+aqw
+mVE
+aqw
+uXv
 dFQ
-kVp
-wid
+dFQ
 oqJ
-wid
+dFQ
 rID
+uXv
 dFQ
-bWv
 dFQ
-tso
+wid
 gQP
 bPR
 bPR
@@ -40589,20 +40613,20 @@ aaa
 aak
 aak
 aak
-aaa
-bOn
-rSF
-fwm
+uXv
+amO
+bWv
+mVE
+bWv
 uXv
 dFQ
-ljp
-wid
-oGo
-wid
-rVs
 dFQ
-bWv
 wid
+dFQ
+rVs
+uXv
+dFQ
+tso
 tso
 uXv
 bPR
@@ -40846,21 +40870,21 @@ aaa
 aae
 aae
 aae
-aaa
-orl
-bKb
-bKb
 uXv
-iBh
+amO
+aqw
+mVE
+aqw
+uXv
 lpF
+ljp
 wid
-oUp
 wid
 sbd
-dFQ
+uXv
 uIg
-wid
-tso
+uXv
+uXv
 uXv
 bPR
 fze
@@ -41103,21 +41127,21 @@ aaa
 aaa
 aaa
 aaa
-aae
-orl
-bKb
+uXv
+aob
+fyq
 fyq
 uXv
-dFQ
-lwl
-wid
+uXv
+uXv
+sbk
 pcA
-wid
+sbk
+sbk
 sbk
 wid
-uKE
 wid
-xBM
+xns
 uXv
 bPR
 bKb
@@ -41360,21 +41384,21 @@ aae
 aaa
 aaa
 aaa
-aaa
-bOn
-cGQ
-bPR
 gQP
+wid
+wid
 dFQ
+uXv
+gYM
 lEZ
-dFQ
-pvU
-dFQ
-smC
+lEZ
 wid
-uMX
+rdE
 wid
-xCt
+wid
+wid
+wid
+wid
 gQP
 bPR
 bKb
@@ -41617,20 +41641,20 @@ aae
 aaa
 aaa
 aaa
-aaa
-orl
-vdJ
-hZU
+uXv
+wid
+wid
+dFQ
 uXv
 dFQ
 dFQ
-lPr
 dFQ
 wid
 wid
+tQC
 wid
 uNL
-qMz
+dFQ
 aqP
 uXv
 bKb
@@ -41874,21 +41898,21 @@ aaa
 aaa
 aaa
 aaa
-aae
-bOn
-bJq
-bPR
 uXv
+wid
+wid
+wid
 uXv
-aob
-uXv
-uXv
-uXv
-uXv
-uXv
-uXv
-uXv
-uXv
+wid
+wid
+wid
+wid
+wid
+tQC
+wid
+uNL
+dFQ
+tlk
 uXv
 bKb
 bKb
@@ -42131,22 +42155,22 @@ aaa
 aaa
 aae
 aae
-aaa
-orl
-bJq
-bKb
 uXv
-iKX
-dFQ
+wid
+wid
+wid
+uXv
+wid
+wid
 ahM
-uXv
-iRM
+oUp
+wid
 dFQ
-ttr
+dFQ
+wid
+dFQ
+dFQ
 uXv
-bKb
-wuC
-fDF
 bKb
 bKb
 wZj
@@ -42388,22 +42412,22 @@ aaa
 aaa
 aae
 aae
-aae
-bOn
-bJq
-fze
 uXv
 dFQ
 dFQ
+wid
+uXv
+wid
+wid
+wid
+wid
+wid
 dFQ
-aob
 dFQ
 dFQ
 dFQ
-uxh
-bKb
-bKb
-bKb
+hry
+uXv
 bKb
 bPR
 bPR
@@ -42645,22 +42669,22 @@ aaa
 aae
 aae
 aae
-wOa
-bKb
-bPR
-bPR
-uXv
-iKY
-dFQ
-kgL
 uXv
 dFQ
-ape
-dFQ
+cST
+wid
+pcA
+wid
+wid
+lwl
+pvU
+wid
 uxh
-bKb
-bKb
-fDF
+uxh
+uxh
+dFQ
+vOj
+uXv
 bKb
 bPR
 bKb
@@ -42902,16 +42926,16 @@ aaa
 aaa
 aae
 aae
-aae
-bKb
-bPR
-bKb
-uXv
-dFQ
-kgL
-lQx
 uXv
 uXv
+uXv
+uIg
+uXv
+uXv
+uXv
+uXv
+uXv
+pcA
 uXv
 uXv
 uXv
@@ -43159,21 +43183,21 @@ aaa
 aae
 aae
 aae
-wOa
-bPR
 uXv
-fDv
+aoy
+apf
+wid
+fDF
+fDF
+kIO
 uXv
-dFQ
-uXv
-uXv
-uXv
-uXv
-uXv
-apz
-bKb
-wdz
-weO
+pPX
+wid
+wid
+uPA
+mVE
+mVE
+mVE
 uXv
 bPR
 bPR
@@ -43416,22 +43440,22 @@ aaa
 aae
 aae
 aae
-aae
-bPR
+uXv
+apf
+wid
+wid
+wid
+fDF
+wid
 uXv
 dFQ
-aob
-dFQ
-aoy
-mVE
-mVE
-rdE
+wid
+wid
 uXv
-tQC
 aqO
-pSB
-xOk
-qDF
+mVE
+mVE
+uXv
 gck
 gck
 bPR
@@ -43673,22 +43697,22 @@ aaa
 aaa
 aae
 aae
-orl
-amO
 uXv
+wid
+wid
+wid
+wid
+wid
+wid
 uXv
-uXv
-iRM
+wid
+wid
+dFQ
 uXv
 omG
-pPX
-rdK
-uXv
-ufI
-aqg
 weO
-bPR
-bsC
+kEq
+uXv
 edG
 bPR
 bPR
@@ -43930,22 +43954,22 @@ aaa
 aaa
 aae
 aae
-aae
-rZN
-rZN
-akK
+uXv
+wid
+wid
+wid
+wid
+wid
+wid
+uIg
+wid
+wid
+ufI
 uXv
 uXv
 uXv
 uXv
 uXv
-uXv
-uXv
-gYM
-aqv
-weO
-bPR
-bsC
 gEN
 bCt
 bsC
@@ -44187,22 +44211,22 @@ aae
 aaa
 aae
 aae
-aae
+uXv
 wOa
-cST
-fGV
-fGV
-fGV
-apf
-lZs
-pSB
-apf
-apf
-pSB
-aqw
+wid
+wid
+wid
+wid
+wid
+uXv
+xBM
+dFQ
+dFQ
+uIg
+bHK
 wCO
-orl
-bsC
+anv
+uXv
 qEb
 qEb
 xWb
@@ -44444,22 +44468,22 @@ aae
 aaa
 aae
 aae
-aae
-aae
+uXv
 wOa
-fXj
-gYM
-bPR
-bPR
-gck
+wid
+wid
+wid
+hLC
+wid
+uXv
 aoK
-bKb
-apx
-bKb
-uPA
-wOa
-aae
-bCt
+dFQ
+uKE
+uXv
+pyu
+bHK
+bHK
+uXv
 pcF
 ros
 huG
@@ -44701,22 +44725,22 @@ aaa
 aaa
 aaa
 aae
-aae
-aae
-bOn
-aae
-orl
-orl
-wOa
-bOn
-aae
-orl
-wOa
-bOn
-aae
-aae
-aae
-bsC
+uXv
+aqg
+wid
+wid
+fGV
+hLC
+kVp
+uXv
+qDF
+dFQ
+uMX
+uXv
+xCt
+rVd
+tTY
+uXv
 ros
 wid
 hYP
@@ -44958,22 +44982,22 @@ aaa
 aaa
 aaa
 aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bsC
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
+uXv
 ugE
 ugE
 mna

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -78,11 +78,11 @@
 	max_integrity = 800;
 	obj_integrity = 800
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "aaw" = (
 /mob/living/simple_animal/hostile/mirelurk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "aax" = (
 /obj/structure/barricade/bars,
@@ -498,7 +498,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "abP" = (
 /turf/closed/wall/f13/wood/house,
@@ -940,7 +940,7 @@
 	},
 /area/f13/radiation)
 "adv" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "adw" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -1942,9 +1942,13 @@
 	},
 /area/f13/wasteland/west)
 "ahu" = (
-/obj/item/flag/bighorn,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2"
+/obj/item/trade_sign{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/west)
 "ahw" = (
@@ -1954,12 +1958,9 @@
 	},
 /area/f13/building)
 "ahx" = (
-/obj/machinery/door/poddoor{
-	id = "shopouter";
-	layer = 4
+/obj/machinery/door/poddoor/shutters{
+	id = "shopouter"
 	},
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "ahz" = (
@@ -1990,12 +1991,6 @@
 	icon_state = "wasteland33"
 	},
 /area/f13/wasteland/bighorn)
-"ahG" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shopouter"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city/bighorn)
 "ahH" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2721,7 +2716,7 @@
 	pixel_x = 37;
 	pixel_y = -3
 	},
-/turf/open/floor/wood/wood_mosaic,
+/turf/open/transparent/glass/reinforced,
 /area/f13/city/bighorn)
 "ako" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -3243,13 +3238,13 @@
 	},
 /area/f13/village)
 "amw" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	pixel_x = 17
+/obj/machinery/door/poddoor{
+	id = "shopouter";
+	layer = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2left"
-	},
+/obj/structure/barricade/bars,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "amz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3407,12 +3402,19 @@
 /turf/closed/wall/f13/wood,
 /area/f13/bar/heaven)
 "ant" = (
-/obj/structure/simple_door/house{
-	name = "Crimson Caravan"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft";
+	layer = 2
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "storeshutters";
 	name = "store shutters"
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 1200;
+	name = "reinforced metal bars";
+	obj_integrity = 1200
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
@@ -3499,14 +3501,18 @@
 	},
 /area/f13/wasteland/massfusion)
 "anN" = (
-/obj/machinery/light/sign/crimson{
+/obj/structure/noticeboard{
+	layer = 2.5;
+	pixel_y = 32
+	},
+/obj/machinery/button/door{
+	id = "shopouter";
+	name = "outer shutters";
 	pixel_y = 30
 	},
-/obj/effect/decal/fakelattice{
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/bighorn)
+/obj/effect/landmark/start/f13/shopkeeper,
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "anP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4435,7 +4441,7 @@
 /turf/open/floor/plating/rust,
 /area/f13/village)
 "arA" = (
-/obj/machinery/trading_machine/weapon,
+/obj/machinery/trading_machine,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "arB" = (
@@ -12382,7 +12388,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "aRS" = (
 /obj/structure/table,
@@ -13656,7 +13662,7 @@
 	dir = 10
 	},
 /obj/structure/pondlily_big,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "aWp" = (
 /obj/structure/billboard/cola/pristine,
@@ -14563,7 +14569,7 @@
 /area/f13/tunnel)
 "aZh" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
 "aZi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14902,7 +14908,7 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_7"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
 "bae" = (
 /obj/structure/closet,
@@ -16206,14 +16212,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"beG" = (
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/structure/rack,
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "beH" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -17244,14 +17242,9 @@
 	},
 /area/f13/building/nanotrasen)
 "bis" = (
-/obj/item/trade_sign{
-	pixel_x = -6;
-	pixel_y = -7
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/west)
+/obj/machinery/base_dispenser/ammo,
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "bit" = (
 /obj/structure/decoration/cctv{
 	pixel_x = -30
@@ -18602,7 +18595,7 @@
 /area/f13/wasteland/bighorn)
 "bmQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
 "bmR" = (
 /obj/machinery/light/small{
@@ -18673,11 +18666,11 @@
 /area/f13/wasteland/bighorn)
 "bnb" = (
 /obj/structure/wreck/trash/halftire,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
 "bne" = (
 /obj/structure/wreck/trash/brokenvendor,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
 "bng" = (
 /obj/effect/decal/cleanable/dirt{
@@ -18741,11 +18734,14 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bnp" = (
 /obj/structure/wreck/trash/engine,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/bighorn)
 "bnq" = (
 /obj/structure/stone_tile/block{
@@ -18763,7 +18759,7 @@
 /area/f13/city/bighorn)
 "bns" = (
 /obj/structure/wreck/trash/bus_door,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "bnt" = (
 /obj/structure/bed/mattress{
@@ -18835,13 +18831,10 @@
 /area/f13/city/bighorn)
 "bnJ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bnK" = (
@@ -18854,10 +18847,12 @@
 /area/f13/building)
 "bnL" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bnP" = (
@@ -18959,15 +18954,11 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city/bighorn)
 "boj" = (
-/obj/structure/noticeboard{
-	layer = 2.5;
-	pixel_y = 32
-	},
-/obj/machinery/button/door{
-	id = "shopouter";
-	name = "outer shutters";
-	pixel_y = 30
-	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/rack,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bok" = (
@@ -18995,11 +18986,9 @@
 	},
 /area/f13/wasteland/bighorn)
 "bom" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "shopouter"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top"
 	},
-/obj/structure/decoration/rag,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "bon" = (
 /obj/item/clothing/shoes/combat,
@@ -19495,9 +19484,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
 "bqR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/transparent/openspace,
-/area/f13/wasteland/bighorn)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "bqX" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -19527,7 +19518,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/hospital)
 "bre" = (
-/obj/machinery/trading_machine/armor,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bri" = (
@@ -19758,12 +19750,10 @@
 	},
 /area/f13/wasteland/bighorn)
 "btu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = 8
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/wood/wood_mosaic,
+/turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "bty" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
@@ -19986,10 +19976,6 @@
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/f13/store,
 /area/f13/brotherhood/leisure)
-"bvh" = (
-/obj/effect/landmark/start/f13/shopkeeper,
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "bvi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -20090,9 +20076,6 @@
 /area/f13/city/bighorn)
 "bwj" = (
 /obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "office3"
 	},
@@ -20660,8 +20643,10 @@
 	},
 /area/f13/building/firestation)
 "bzQ" = (
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/wood/wood_mosaic,
+/area/f13/city/bighorn)
 "bzT" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	layer = 3
@@ -20721,9 +20706,11 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "bAl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/wood/wood_mosaic,
+/obj/machinery/door/unpowered/securedoor{
+	name = "Crimson Caravan Backroom";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "bAr" = (
 /obj/structure/simple_door/glass,
@@ -20977,11 +20964,13 @@
 	},
 /area/f13/wasteland/bighornbunker)
 "bFL" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "shopladder"
+/obj/structure/table/wood,
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters"
 	},
-/turf/open/floor/wood/wood_mosaic,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "bFO" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -21039,7 +21028,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "bIo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21611,20 +21600,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city/bighorn)
 "bVT" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Crimson Caravan Backroom";
-	req_one_access_txt = "34"
+/obj/structure/window/fulltile/house{
+	icon_state = "storewindowright";
+	layer = 2
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/obj/structure/barricade/bars{
+	max_integrity = 1200;
+	name = "reinforced metal bars";
+	obj_integrity = 1200
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "bVW" = (
-/obj/structure/table/wood,
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters"
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/trading_machine/ammo,
+/turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "bWj" = (
 /mob/living/simple_animal/hostile/wolf{
@@ -22343,7 +22336,7 @@
 "cfW" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/pondlily_small,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "cgy" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -23158,7 +23151,7 @@
 /area/f13/building)
 "cqs" = (
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "cqC" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -23259,7 +23252,7 @@
 /area/f13/village)
 "crr" = (
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "crs" = (
 /obj/structure/bed,
@@ -23924,7 +23917,7 @@
 	},
 /area/f13/building/trainstation)
 "cEd" = (
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "cEo" = (
 /obj/structure/window/fulltile/house/broken,
@@ -23936,13 +23929,8 @@
 /turf/closed/wall/mineral/concrete,
 /area/f13/wasteland/west)
 "cEy" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/fakelattice{
-	pixel_x = 17
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
+/obj/machinery/trading_machine/armor,
+/turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "cEF" = (
 /obj/structure/extinguisher_cabinet{
@@ -24035,7 +24023,9 @@
 	},
 /area/f13/wasteland/bighorn)
 "cHs" = (
-/obj/machinery/trading_machine,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "cHw" = (
@@ -24287,7 +24277,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "cPW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24677,7 +24667,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/chair/stool,
 /obj/item/fishingrod,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "deq" = (
 /obj/machinery/vending/medical,
@@ -25086,7 +25076,7 @@
 	},
 /area/f13/wasteland/hospital)
 "dtF" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "dtH" = (
 /obj/structure/closet,
@@ -25836,7 +25826,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "dQT" = (
 /turf/open/indestructible/ground/outside/road{
@@ -26135,7 +26125,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "ecc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26146,7 +26136,7 @@
 /obj/structure/fluff/railing{
 	dir = 10
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/mall)
 "ecn" = (
 /obj/structure/bed/mattress/pregame,
@@ -26392,7 +26382,7 @@
 	obj_integrity = 800
 	},
 /obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "emO" = (
 /obj/structure/bonfire,
@@ -26401,9 +26391,7 @@
 	},
 /area/f13/wasteland/east)
 "ena" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/trading_machine/weapon,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "enf" = (
@@ -26712,7 +26700,7 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "exx" = (
 /turf/open/indestructible/ground/outside/road{
@@ -26962,7 +26950,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "eGL" = (
 /obj/structure/chair/stool{
@@ -27045,7 +27033,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "eIN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28095,7 +28083,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "fpS" = (
 /obj/item/candle/tribal_torch,
@@ -29030,7 +29018,7 @@
 	dir = 9
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "fSy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29402,7 +29390,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "geF" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
 "geJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29588,11 +29576,14 @@
 	},
 /area/f13/building/mall)
 "gmd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard{
-	pixel_x = -32
+/obj/structure/simple_door/house{
+	name = "Crimson Caravan"
 	},
-/turf/open/floor/wood/wood_common,
+/obj/machinery/door/poddoor/shutters{
+	id = "storeshutters";
+	name = "store shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
 "gml" = (
 /obj/structure/railing{
@@ -29785,7 +29776,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "gtE" = (
 /obj/structure/flora/grass/jungle,
@@ -30197,9 +30188,9 @@
 	},
 /area/f13/building/massfusion)
 "gJi" = (
-/obj/structure/sink/deep_water,
-/turf/open/water,
-/area/f13/caves)
+/obj/structure/chalkboard,
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "gJt" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/wood/settler,
@@ -30324,9 +30315,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
 "gMb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/bookshelf{
+	icon_state = "book-4"
+	},
+/turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "gMc" = (
 /obj/item/storage/trash_stack,
@@ -30404,7 +30396,7 @@
 /area/f13/building)
 "gNQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "gNS" = (
 /obj/structure/barricade/sandbags,
@@ -30920,7 +30912,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hcq" = (
 /turf/open/indestructible/ground/outside/road{
@@ -31518,7 +31510,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "hAT" = (
 /obj/structure/closet/crate/bin,
@@ -31804,7 +31796,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "hNx" = (
 /obj/effect/decal/cleanable/oil{
@@ -31926,7 +31918,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hRI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32060,7 +32052,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "hVk" = (
 /obj/structure/barricade/wooden,
@@ -32201,7 +32193,7 @@
 	dir = 8;
 	pixel_x = -20
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "ibe" = (
 /turf/open/indestructible/ground/outside/road,
@@ -32495,18 +32487,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ilV" = (
-/obj/structure/noticeboard{
-	pixel_y = -32
+/obj/structure/bookshelf{
+	icon_state = "book-5"
 	},
-/obj/item/storage/briefcase{
-	anchored = 1;
-	pixel_y = -32
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland/bighorn)
+/turf/open/floor/wood/wood_common,
+/area/f13/city/bighorn)
 "imm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -32917,7 +32902,7 @@
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
 "ixZ" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -34714,7 +34699,7 @@
 /obj/structure/fluff/railing{
 	dir = 9
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/mall)
 "jyU" = (
 /obj/structure/barricade/tent,
@@ -35267,7 +35252,7 @@
 	dir = 1
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "jSK" = (
 /obj/effect/decal/cleanable/blood,
@@ -35289,12 +35274,8 @@
 	},
 /area/f13/building/massfusion)
 "jTC" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "office1"
+/obj/structure/chair/wood{
+	dir = 4
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
@@ -36376,7 +36357,7 @@
 /area/f13/building/massfusion)
 "kGv" = (
 /obj/structure/flora/wasteplant/wild_punga,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "kGU" = (
 /obj/structure/flora/junglebush,
@@ -36584,10 +36565,6 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/village)
-"kMD" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
-/area/f13/caves)
 "kNk" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37062,7 +37039,7 @@
 /obj/structure/fluff/railing{
 	dir = 6
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/mall)
 "lbX" = (
 /obj/structure/simple_door/metal/store{
@@ -37157,7 +37134,7 @@
 	dir = 9
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "lfi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37503,7 +37480,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "lqE" = (
 /obj/effect/decal/remains{
@@ -38038,12 +38015,6 @@
 	icon_state = "outerpavementcorner"
 	},
 /area/f13/wasteland/massfusion)
-"lHK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "lIb" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -38090,7 +38061,7 @@
 	name = "strong metal bars";
 	obj_integrity = 800
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "lJm" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -38637,11 +38608,7 @@
 	},
 /area/f13/followers)
 "lWL" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/turf/open/floor/wood/wood_mosaic,
+/turf/open/transparent/glass/reinforced,
 /area/f13/city/bighorn)
 "lWN" = (
 /obj/structure/window/fulltile/store{
@@ -41011,10 +40978,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "nxz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/toy/plush/lizardplushie,
-/turf/open/floor/wood/wood_mosaic,
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "nxA" = (
 /obj/effect/decal/marking,
@@ -41132,7 +41099,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "nBI" = (
 /obj/structure/chair/stool/retro,
@@ -41180,7 +41147,7 @@
 	dir = 5
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "nDn" = (
 /obj/effect/decal/cleanable/dirt{
@@ -41945,14 +41912,6 @@
 "oeb" = (
 /turf/open/floor/carpet/cyan,
 /area/f13/building/mall)
-"oei" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/secure/safe{
-	pixel_x = -22;
-	pixel_y = -6
-	},
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "oev" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -42037,11 +41996,6 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
-"ofN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "oga" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -42054,7 +42008,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "ogp" = (
 /obj/structure/table,
@@ -42714,18 +42668,6 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/east)
-"oAX" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	layer = 2
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city/bighorn)
 "oBf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -42805,7 +42747,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "oDX" = (
 /obj/structure/table/wood,
@@ -42971,7 +42913,7 @@
 /area/f13/wasteland/east)
 "oJI" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "oJM" = (
 /obj/structure/chair/booth{
@@ -43051,11 +42993,11 @@
 	dir = 9
 	},
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/junglebush/large,
+/obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 9
+	dir = 6
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "oMf" = (
 /obj/effect/landmark/poster_spawner/prewar,
@@ -43299,7 +43241,7 @@
 	dir = 10
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "oQI" = (
 /turf/open/floor/f13{
@@ -44096,7 +44038,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "ptf" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -44924,10 +44866,7 @@
 	},
 /area/f13/wasteland/nanotrasen)
 "pTN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "pUh" = (
@@ -44944,7 +44883,7 @@
 "pUp" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "pVl" = (
 /turf/closed/indestructible/f13/matrix/transition{
@@ -44994,7 +44933,7 @@
 /area/f13/building/massfusion)
 "pXp" = (
 /obj/structure/flora/wasteplant/wild_punga,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "pXv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -45012,16 +44951,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pXT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_y = 2;
+	termtag = "Business"
 	},
-/obj/machinery/button/door{
-	id = "office1";
-	name = "privacy shutters";
-	pixel_x = -27
-	},
-/turf/open/floor/wood/wood_mosaic,
+/turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
 "pYi" = (
 /turf/open/indestructible/ground/outside/road{
@@ -45531,9 +45467,6 @@
 	icon_state = "outermaincornerinner"
 	},
 /area/f13/wasteland/bighorn)
-"qoU" = (
-/turf/open/water,
-/area/f13/wasteland/bighorn)
 "qoX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/retro,
@@ -46001,7 +45934,7 @@
 /area/f13/wasteland/bighorn)
 "qDT" = (
 /mob/living/simple_animal/opossum,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/west)
 "qEh" = (
 /obj/structure/chair/f13chair2{
@@ -46012,10 +45945,8 @@
 	},
 /area/f13/building/hospital)
 "qEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/greyscale{
-	dir = 4;
-	pixel_x = 13
+/obj/structure/chair/wood{
+	dir = 8
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/city/bighorn)
@@ -46393,7 +46324,9 @@
 	},
 /area/f13/wasteland/nanotrasen)
 "qQq" = (
-/obj/machinery/trading_machine/ammo,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
 "qQz" = (
@@ -46511,7 +46444,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "qVJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46629,7 +46562,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "qZM" = (
 /turf/open/indestructible/ground/outside/road{
@@ -47022,7 +46955,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "rlU" = (
 /turf/open/indestructible/ground/outside/road{
@@ -47093,7 +47026,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "rnk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -47119,7 +47052,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "rnJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47194,7 +47127,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "rqE" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -47477,12 +47410,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
-"ryN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/water,
-/area/f13/caves)
 "rzt" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -48164,7 +48091,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "rVu" = (
 /obj/effect/decal/cleanable/dirt{
@@ -48305,7 +48232,7 @@
 /area/f13/wasteland/firestation)
 "rXA" = (
 /mob/living/simple_animal/hostile/mirelurk/hunter,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "rXB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48448,7 +48375,7 @@
 /obj/structure/fluff/railing{
 	dir = 5
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/mall)
 "sdK" = (
 /obj/structure/sign/map/left{
@@ -48507,7 +48434,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "sgr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48530,7 +48457,7 @@
 "sha" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/pondlily_big,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "shs" = (
 /obj/machinery/door/unpowered/securedoor{
@@ -49320,7 +49247,7 @@
 	dir = 6
 	},
 /obj/structure/pondlily_big,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "sGk" = (
 /turf/closed/indestructible/f13/matrix,
@@ -49370,7 +49297,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "sKy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -49765,7 +49692,7 @@
 "sXb" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock/pile/largejungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "sXv" = (
 /turf/open/indestructible/ground/outside/road{
@@ -50819,7 +50746,7 @@
 	pixel_y = -11
 	},
 /obj/effect/decal/waste,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
 "tDy" = (
 /obj/structure/table/wood,
@@ -51224,7 +51151,7 @@
 /area/f13/wasteland/east)
 "tQk" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "tQu" = (
 /obj/machinery/light/small/broken{
@@ -51354,17 +51281,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/firestation)
-"tTS" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	layer = 2
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "storeshutters";
-	name = "store shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/city/bighorn)
 "tTV" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
@@ -51390,7 +51306,7 @@
 /area/f13/building/mall)
 "tUB" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "tUJ" = (
 /obj/structure/table/reinforced,
@@ -51452,7 +51368,7 @@
 	},
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/large,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "tWH" = (
 /obj/effect/decal/cleanable/dirt{
@@ -51587,12 +51503,6 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland/museum)
-"uca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/camera,
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "ucd" = (
 /obj/item/storage/crayons,
 /obj/structure/table/wood,
@@ -52061,18 +51971,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"urn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "office2";
-	name = "privacy shutters";
-	pixel_x = -27
-	},
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "urA" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -52100,7 +51998,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/building/massfusion)
 "urW" = (
 /obj/structure/flora/grass/wasteland{
@@ -52201,7 +52099,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "uuT" = (
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
@@ -52851,12 +52749,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/mall)
-"uOW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/water,
-/area/f13/caves)
 "uPC" = (
 /obj/structure/showcase/cyborg/old,
 /obj/effect/decal/cleanable/dirt,
@@ -53618,7 +53510,7 @@
 /obj/structure/handrail/g_central{
 	pixel_y = -16
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "vlN" = (
 /obj/effect/decal/remains/human,
@@ -54164,13 +54056,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vFd" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Crimson Caravan Backroom";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood/wood_mosaic,
-/area/f13/city/bighorn)
 "vGp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -54627,7 +54512,7 @@
 /area/f13/brotherhood/leisure)
 "vUy" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "vUN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -54744,7 +54629,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "vYZ" = (
 /obj/structure/closet/cabinet,
@@ -55644,12 +55529,6 @@
 /obj/item/storage/belt,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"wAI" = (
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/turf/open/floor/wood/wood_common,
-/area/f13/city/bighorn)
 "wAK" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -56111,7 +55990,7 @@
 	dir = 1;
 	pixel_y = 23
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "wOD" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56364,7 +56243,7 @@
 	obj_integrity = 800
 	},
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "wVG" = (
 /obj/structure/obstacle/barbedwire/end{
@@ -56844,7 +56723,7 @@
 /area/f13/tunnel)
 "xkw" = (
 /obj/structure/barricade/wooden,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xkV" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -57232,7 +57111,7 @@
 	dir = 6
 	},
 /obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/water,
 /area/f13/wasteland/valley)
 "xzW" = (
 /obj/structure/fence,
@@ -57624,16 +57503,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"xKC" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "office2"
-	},
-/turf/open/floor/wood/wood_common,
-/area/f13/city/bighorn)
 "xKL" = (
 /obj/structure/rack,
 /obj/item/melee/onehanded/knife/hunting,
@@ -57871,7 +57740,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "xSv" = (
 /obj/structure/barricade/wooden,
@@ -58381,17 +58250,6 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/west)
-"yiK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/item/storage/briefcase{
-	anchored = 1;
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/bighorn)
 "yiM" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /obj/structure/table/wood,
@@ -73855,13 +73713,13 @@ ydE
 ydE
 puU
 bjq
-qVJ
+bka
 pXT
-oei
-bjq
+lUX
+jTC
 btu
-urn
-qVJ
+lUX
+lUX
 ykl
 bUV
 puU
@@ -73879,7 +73737,7 @@ ydE
 ydE
 bYI
 xoV
-bqR
+xoV
 bxg
 ydE
 sub
@@ -74111,15 +73969,15 @@ sub
 sub
 sub
 puU
-jTC
-bvi
+bUh
+lUX
 nxz
-ofN
-bjq
-rbE
-bvi
-uca
-xKC
+lUX
+pTN
+lUX
+jTC
+lUX
+bUh
 puU
 bUV
 jJU
@@ -74135,7 +73993,7 @@ yjm
 ydE
 ydE
 alh
-bqR
+xoV
 xoV
 rMX
 sub
@@ -74368,15 +74226,15 @@ ydE
 ydE
 ydE
 gVu
-jTC
-bwc
-bwc
-snk
-bjq
-snk
-bwc
-bwc
-xKC
+bUh
+lUX
+lUX
+lUX
+lUX
+lUX
+pTN
+lUX
+bUh
 puU
 puU
 lsP
@@ -74626,13 +74484,13 @@ ydE
 ydE
 gVu
 bjq
-snk
-snk
-brD
-bjq
-brD
-snk
-snk
+gJi
+lUX
+lUX
+lUX
+lUX
+lUX
+lUX
 bjq
 bUV
 wob
@@ -74883,13 +74741,13 @@ ydE
 ydE
 puU
 bjq
-bjq
-shs
-bjq
-bjq
-bjq
-shs
-bjq
+lUX
+lUX
+lUX
+lUX
+lUX
+pTN
+lUX
 bjq
 bqN
 uXo
@@ -75140,15 +74998,15 @@ ydE
 ydE
 hBi
 bjq
+gMb
 lUX
-blj
-gmd
+lUX
 pTN
-wAI
-blj
-blj
+lUX
+qEm
+lUX
 bjq
-yiK
+sub
 puU
 yjm
 lEV
@@ -75397,13 +75255,13 @@ sub
 ydE
 hXc
 bjq
-blj
-blj
-blj
+ilV
+lUX
+lUX
 qEm
-blj
-blj
-blj
+bVv
+lUX
+lUX
 bxb
 mAf
 mAG
@@ -76161,12 +76019,12 @@ pat
 pat
 pat
 pat
-cEy
-amw
-gMb
+pat
+pat
+pat
 ydE
 ydE
-ilV
+puU
 bjq
 blj
 lUX
@@ -76413,15 +76271,15 @@ pPr
 jYk
 ygj
 eus
+aaW
+aaW
 mig
-mig
-mig
-bAl
 pat
+bVW
+cHs
+ena
 pat
-pat
-pat
-anN
+ydE
 ydE
 puU
 bjq
@@ -76671,14 +76529,14 @@ jYk
 ygj
 eus
 bno
-mig
-mig
+bqR
 mig
 pat
-cHs
+cEy
+mig
 arA
 pat
-arE
+ydE
 iQa
 wgT
 bjq
@@ -76918,7 +76776,7 @@ sEB
 wEd
 wEd
 wEd
-uki
+ahu
 rma
 kyv
 bOA
@@ -76927,11 +76785,11 @@ pPr
 jYk
 ygj
 eus
-bnJ
+wOa
 mig
-bvh
 mig
-bVT
+bAl
+mig
 mig
 mig
 ant
@@ -77184,14 +77042,14 @@ nzp
 jYk
 ygj
 eus
-bnL
-mig
+wOa
 mig
 mig
 pat
-ena
 mig
-pat
+mig
+mig
+bVT
 wXY
 qAk
 bop
@@ -77439,16 +77297,16 @@ ifg
 mbv
 nzp
 pak
-ygj
-pZd
+ahx
+amw
 lWL
+lWL
+lWL
+bFL
 mig
 mig
 mig
-bVW
-mig
-mig
-oAX
+pat
 haK
 qAk
 imF
@@ -77696,16 +77554,16 @@ ifg
 ifg
 aod
 pak
-ygj
-pZd
-beG
+ahx
+amw
+lWL
+lWL
+lWL
+bFL
 mig
 mig
-bvh
-bVW
 mig
-mig
-tTS
+pat
 haK
 qAk
 iGB
@@ -77953,16 +77811,16 @@ aat
 ifg
 nuM
 pak
-ygj
-pZd
-lHK
-mig
+ahx
+amw
+lWL
+lWL
 akn
 bFL
-pat
+mig
 qQq
-bre
-pat
+mig
+gmd
 puU
 qAk
 jCv
@@ -78212,8 +78070,8 @@ aod
 pak
 ygj
 pZd
-pat
-vFd
+anN
+mig
 bvj
 pat
 pat
@@ -78256,9 +78114,9 @@ pat
 bmF
 bmX
 bnl
-qoU
-qoU
-qoU
+nUK
+nUK
+nUK
 sUG
 eus
 ygj
@@ -78469,11 +78327,11 @@ nzp
 pak
 ygj
 pZd
-mig
+bis
 mig
 skt
 pat
-bjq
+pat
 aio
 fBf
 bzB
@@ -78512,10 +78370,10 @@ pat
 pat
 xEV
 bmZ
-qoU
-qoU
-qoU
-qoU
+nUK
+nUK
+nUK
+nUK
 peG
 eus
 ygj
@@ -78726,10 +78584,10 @@ nzp
 pak
 ygj
 eus
+bnJ
 mig
-mig
-wOa
-pat
+bre
+ant
 bXh
 auT
 snk
@@ -78770,8 +78628,8 @@ blV
 ueP
 bna
 bnp
-qoU
-qoU
+nUK
+nUK
 qwd
 nub
 eus
@@ -78983,10 +78841,10 @@ nzp
 pak
 ygj
 eus
-lHK
+bnL
 mig
-wOa
-pat
+bzQ
+bVT
 lTY
 snk
 snk
@@ -79025,10 +78883,10 @@ eus
 eus
 urI
 iUu
-qoU
+nUK
 bmQ
-qoU
-qoU
+nUK
+nUK
 nWp
 oiD
 eus
@@ -79284,7 +79142,7 @@ ueP
 bmJ
 bnb
 bns
-qoU
+nUK
 ict
 pyF
 oGK
@@ -79493,15 +79351,15 @@ ycB
 tKu
 lVn
 aeq
-bis
+nzp
 azr
 ygj
 ygj
-ahx
-ahx
 ygj
-pat
-pat
+ygj
+ygj
+ygj
+ygj
 bzB
 pat
 pat
@@ -79538,7 +79396,7 @@ sub
 aZj
 jYk
 bmj
-qoU
+nUK
 dtF
 kGv
 gNQ
@@ -79753,11 +79611,11 @@ uxj
 eup
 uEj
 agO
-ygj
 bom
-ahG
-ygj
-ygj
+bom
+bom
+bom
+bom
 ygj
 ygj
 ygj
@@ -80010,7 +79868,7 @@ qHt
 wzC
 wzC
 ahe
-ahu
+wzC
 wzC
 lKy
 daa
@@ -104235,7 +104093,7 @@ aae
 aae
 aae
 aae
-bzQ
+lTe
 emN
 lTe
 lTe
@@ -104490,9 +104348,9 @@ aae
 aae
 aae
 giH
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 xkw
 lTe
 lTe
@@ -104746,8 +104604,8 @@ aae
 aae
 aae
 aae
-bzQ
-bzQ
+lTe
+lTe
 abO
 abO
 mya
@@ -105002,8 +104860,8 @@ aaa
 aae
 aae
 ahz
-uOW
-bzQ
+xpV
+lTe
 hcn
 aaB
 aae
@@ -105259,7 +105117,7 @@ aaa
 aae
 aae
 afn
-uOW
+xpV
 hcn
 aaB
 aae
@@ -106030,8 +105888,8 @@ aaa
 aae
 aae
 sYT
-uOW
-kMD
+xpV
+nkd
 xli
 aae
 aaa
@@ -106288,7 +106146,7 @@ xet
 aaB
 oDV
 tUB
-kMD
+nkd
 aaB
 aae
 aae
@@ -106543,9 +106401,9 @@ aaa
 aaa
 kXT
 hOR
-uOW
-bzQ
-kMD
+xpV
+lTe
+nkd
 sYT
 aae
 aae
@@ -106800,9 +106658,9 @@ aaa
 aaa
 nZz
 aaB
-uOW
+xpV
 rXA
-kMD
+nkd
 weZ
 aaB
 aae
@@ -107058,8 +106916,8 @@ aaa
 aae
 aYf
 xSh
-gJi
-kMD
+bfy
+nkd
 aaB
 aaB
 aae
@@ -107315,8 +107173,8 @@ aaa
 aae
 hCD
 sYT
-uOW
-kMD
+xpV
+nkd
 rQG
 aaB
 aae
@@ -107572,8 +107430,8 @@ aaa
 aae
 xet
 aaB
-uOW
-kMD
+xpV
+nkd
 aaB
 aaB
 aae
@@ -107830,7 +107688,7 @@ nZz
 kXT
 aaB
 xSh
-kMD
+nkd
 aaB
 dna
 aaB
@@ -108087,7 +107945,7 @@ aae
 xfY
 xfY
 aae
-uOW
+xpV
 sKb
 aaB
 aaB
@@ -108345,8 +108203,8 @@ xfY
 aae
 aak
 nBF
-bzQ
-ryN
+lTe
+kdn
 sKb
 aaB
 mRB
@@ -108604,7 +108462,7 @@ aae
 aae
 vYX
 abO
-bzQ
+lTe
 sgp
 mRB
 cUS
@@ -110289,7 +110147,7 @@ crr
 qVE
 crr
 wOA
-bzQ
+lTe
 aae
 aae
 aae
@@ -110795,14 +110653,14 @@ cwh
 cwh
 cwh
 aae
-bzQ
-bzQ
+lTe
+lTe
 ewK
 crr
 ded
 crr
 hZK
-bzQ
+lTe
 cqs
 aae
 aae
@@ -111053,13 +110911,13 @@ agk
 agk
 aae
 cqs
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
 aae
 aae
 aae
@@ -111175,7 +111033,7 @@ aae
 aae
 aae
 rqr
-bzQ
+lTe
 aae
 wPK
 awq
@@ -111311,11 +111169,11 @@ agk
 aae
 aae
 tUB
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
+lTe
 tUB
 aae
 aae
@@ -111430,7 +111288,7 @@ aae
 ahz
 aae
 oDV
-ryN
+kdn
 hRF
 abO
 aae
@@ -111686,8 +111544,8 @@ aae
 aae
 aae
 ahz
-uOW
-kMD
+xpV
+nkd
 aaB
 aaB
 aae
@@ -111943,8 +111801,8 @@ aae
 aae
 aae
 afn
-uOW
-kMD
+xpV
+nkd
 hCD
 aaB
 aae
@@ -112457,8 +112315,8 @@ aae
 aae
 aae
 aae
-bzQ
-bzQ
+lTe
+lTe
 aaa
 aaa
 aae
@@ -112714,8 +112572,8 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
+lTe
+lTe
 aaB
 aaa
 aae
@@ -112971,7 +112829,7 @@ aae
 aae
 aaB
 aaB
-bzQ
+lTe
 aaB
 aae
 aaa
@@ -113227,8 +113085,8 @@ aae
 aae
 aae
 aaB
-gJi
-bzQ
+bfy
+lTe
 afn
 aae
 aaa
@@ -113484,8 +113342,8 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
+lTe
+lTe
 aae
 aae
 aaa
@@ -113497,7 +113355,7 @@ aae
 aae
 aae
 aae
-bzQ
+lTe
 acW
 wPK
 wPK
@@ -113741,8 +113599,8 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
+lTe
+lTe
 aae
 aae
 aae
@@ -113752,9 +113610,9 @@ aae
 aae
 afn
 amp
-bzQ
+lTe
 aaw
-bzQ
+lTe
 aaB
 abt
 aae
@@ -113998,8 +113856,8 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
+lTe
+lTe
 aaB
 aaB
 aae
@@ -114010,9 +113868,9 @@ aae
 ahz
 abt
 aaB
-bzQ
+lTe
 aaB
-bzQ
+lTe
 aae
 aae
 aae
@@ -114255,9 +114113,9 @@ aae
 aae
 aae
 aae
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 aaB
 aaB
 aae
@@ -114268,7 +114126,7 @@ aae
 aae
 aaB
 abt
-bzQ
+lTe
 afn
 aae
 aae
@@ -114513,10 +114371,10 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
 afn
 ahz
 afn
@@ -114771,13 +114629,13 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 lJl
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 afn
 aaa
 aaa
@@ -115028,13 +114886,13 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 aav
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 afn
 aae
 aae
@@ -115290,9 +115148,9 @@ aae
 aae
 afn
 aaB
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 aaB
 aae
 aae
@@ -115548,8 +115406,8 @@ aae
 aae
 afn
 aaB
-bzQ
-bzQ
+lTe
+lTe
 aaB
 afn
 aae
@@ -115805,9 +115663,9 @@ aae
 aae
 ahz
 aaB
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
 aaB
 aae
 aae
@@ -116062,9 +115920,9 @@ aae
 aae
 aae
 afn
-bzQ
-bzQ
-gJi
+lTe
+lTe
+bfy
 aaB
 afn
 aae
@@ -120163,10 +120021,10 @@ aaa
 (241,1,1) = {"
 aaa
 aae
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
 aae
 aae
 aae
@@ -120419,18 +120277,18 @@ aaa
 "}
 (242,1,1) = {"
 aaa
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
 aae
 aae
-bzQ
-bzQ
+lTe
+lTe
 gNG
 qKg
 wOu
@@ -120676,18 +120534,18 @@ aaa
 "}
 (243,1,1) = {"
 aaa
-bzQ
-bzQ
+lTe
+lTe
 aae
 aae
-bzQ
-gJi
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+bfy
+lTe
+lTe
+lTe
+lTe
+lTe
+lTe
 aae
 adg
 mdh
@@ -120940,10 +120798,10 @@ aae
 aae
 aae
 aae
-bzQ
-bzQ
-bzQ
-bzQ
+lTe
+lTe
+lTe
+lTe
 aae
 aae
 aae

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -229,7 +229,7 @@
 "afS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/simple_animal/opossum,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "afX" = (
 /turf/closed/wall/f13/supermart,
@@ -1092,7 +1092,7 @@
 "aWP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/fulltile/house/broken,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "aWV" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -1148,7 +1148,7 @@
 "aZv" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "aZx" = (
 /obj/item/storage/bag/trash,
@@ -1391,7 +1391,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "bkB" = (
 /obj/item/kirbyplants{
@@ -2067,7 +2067,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "bSR" = (
 /obj/structure/barricade/wooden/strong,
@@ -2304,7 +2304,7 @@
 	pixel_x = -32
 	},
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "cdj" = (
 /obj/structure/barricade/bars,
@@ -2324,7 +2324,7 @@
 /obj/structure/decoration/shock{
 	pixel_y = -32
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "ceg" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -2523,7 +2523,7 @@
 /obj/structure/barricade/wooden/planks{
 	icon_state = "board-2"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "cmB" = (
 /obj/effect/overlay/junk/toilet,
@@ -2637,7 +2637,7 @@
 "csN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "ctG" = (
 /obj/structure/chair/f13chair2{
@@ -3013,7 +3013,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "cLw" = (
 /turf/open/indestructible/ground/outside/savannah,
@@ -3497,7 +3497,7 @@
 "djB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "djC" = (
 /obj/structure/table,
@@ -3806,7 +3806,7 @@
 /area/f13/ncr)
 "dwp" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "dwr" = (
 /obj/structure/table/booth,
@@ -3955,7 +3955,7 @@
 "dGv" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "dHl" = (
 /obj/machinery/light{
@@ -4086,7 +4086,7 @@
 /obj/structure/decoration/shock{
 	pixel_y = -32
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "dOf" = (
 /obj/structure/window/fulltile/house{
@@ -4624,7 +4624,7 @@
 /area/f13/ncr)
 "evr" = (
 /obj/item/stack/ore/iron,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "ewp" = (
 /obj/effect/decal/fakelattice,
@@ -4683,7 +4683,7 @@
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "eyU" = (
 /obj/structure/closet/crate/radiation,
@@ -5691,7 +5691,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
 /obj/structure/wreck/trash/engine,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "fuI" = (
 /mob/living/simple_animal/hostile/renegade/grunt,
@@ -5790,7 +5790,7 @@
 "fxN" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "fxS" = (
 /obj/structure/barricade/bars,
@@ -5893,7 +5893,7 @@
 /area/f13/city)
 "fDN" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "fED" = (
 /obj/structure/closet/crate/freezer{
@@ -6536,7 +6536,7 @@
 	},
 /area/f13/ncr)
 "gkF" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "glh" = (
 /obj/structure/window/fulltile/store{
@@ -7121,7 +7121,7 @@
 "gJd" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "gJX" = (
 /obj/effect/overlay/turfs/cliff{
@@ -7648,7 +7648,7 @@
 "hnK" = (
 /obj/structure/flora/grass/jungle/b,
 /mob/living/simple_animal/hostile/mirelurk/hunter,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "hop" = (
 /obj/structure/table,
@@ -7950,7 +7950,7 @@
 "hzo" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/mirelurk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "hAK" = (
 /obj/structure/chair/booth{
@@ -8496,7 +8496,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/warren)
 "ice" = (
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "icS" = (
 /obj/structure/sign/poster/ncr/keep_to_myself{
@@ -9788,7 +9788,7 @@
 /area/f13/wasteland/ncr)
 "jrc" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "jrt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9988,7 +9988,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
 /obj/structure/wreck/trash/five_tires,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "jDH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -10431,7 +10431,7 @@
 "jWH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "jWX" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -10444,7 +10444,7 @@
 /area/f13/wasteland/ncr)
 "jXz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "jXK" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
@@ -10692,7 +10692,7 @@
 "koU" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "koX" = (
 /obj/structure/closet/cabinet,
@@ -10840,7 +10840,7 @@
 "kzw" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/junglebush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "kzz" = (
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -11680,14 +11680,14 @@
 /area/f13/city)
 "ljV" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "lkg" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "lkv" = (
 /obj/item/stack/ore/slag,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "lky" = (
 /obj/structure/chair/f13foldupchair{
@@ -11877,7 +11877,7 @@
 /obj/effect/decal/riverbank{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "luW" = (
 /turf/open/indestructible/ground/outside/graveldirt{
@@ -12610,7 +12610,7 @@
 /area/f13/wasteland/warren)
 "meD" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "mfw" = (
 /obj/structure/bonfire,
@@ -12961,7 +12961,7 @@
 "mzv" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "mzI" = (
 /turf/open/floor/plating/f13/outside/road{
@@ -13720,7 +13720,7 @@
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "neY" = (
 /obj/structure/flora/grass/wasteland{
@@ -14144,7 +14144,7 @@
 "nzx" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "nzA" = (
 /obj/structure/junk/cabinet,
@@ -14276,7 +14276,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "nJz" = (
 /obj/structure/car/rubbish1,
@@ -14520,7 +14520,7 @@
 /obj/structure/disposalpipe/broken{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "nXA" = (
 /obj/effect/overlay/turfs/cliff{
@@ -15135,7 +15135,7 @@
 /area/f13/city)
 "oCX" = (
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "oEu" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -15158,7 +15158,7 @@
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "oEP" = (
 /obj/structure/barricade/sandbags,
@@ -15549,7 +15549,7 @@
 /area/f13/ncr)
 "oYp" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "oYA" = (
 /obj/machinery/light{
@@ -15652,7 +15652,7 @@
 "pdK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/machinepiletwo,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "pdP" = (
 /obj/effect/overlay/turfs/cliff/alt{
@@ -15857,7 +15857,7 @@
 /area/f13/wasteland/warren)
 "poH" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "poQ" = (
 /obj/structure/obstacle/jammed_door,
@@ -15881,7 +15881,7 @@
 /area/f13/city)
 "pqV" = (
 /obj/structure/simple_door/metal/ventilation,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "prm" = (
 /obj/structure/closet/crate/wicker,
@@ -15922,7 +15922,7 @@
 "pwm" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "pwC" = (
 /obj/structure/simple_door/metal/barred,
@@ -16421,7 +16421,7 @@
 /area/f13/wasteland/ncr)
 "pSr" = (
 /obj/structure/flora/junglebush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "pSP" = (
 /obj/effect/overlay/turfs/cliff{
@@ -16530,7 +16530,7 @@
 /area/f13/city)
 "pWR" = (
 /mob/living/simple_animal/hostile/mirelurk/baby,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "pWT" = (
 /obj/structure/barricade/wooden/strong,
@@ -16561,7 +16561,7 @@
 /area/f13/wasteland/warren)
 "pXz" = (
 /obj/item/stack/ore/lead,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "pXD" = (
 /obj/structure/table/reinforced{
@@ -16786,7 +16786,7 @@
 "qkd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "qkf" = (
 /obj/structure/closet/crate/footlocker,
@@ -16883,7 +16883,7 @@
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "qpg" = (
 /obj/structure/chair/f13chair2{
@@ -16943,7 +16943,7 @@
 "qqW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "qrv" = (
 /obj/structure/chair/booth{
@@ -18355,7 +18355,7 @@
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "rAa" = (
 /obj/structure/junk/small/table,
@@ -18949,7 +18949,7 @@
 	},
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/junk/jukebox,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "sfe" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19110,7 +19110,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "soJ" = (
 /obj/structure/fence{
@@ -19319,9 +19319,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/city)
-"sxM" = (
-/turf/open/water,
-/area/f13/wasteland/warren)
 "sxO" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19477,7 +19474,7 @@
 "sEN" = (
 /obj/structure/flora/grass/jungle,
 /mob/living/simple_animal/hostile/mirelurk/hunter,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "sFb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19813,7 +19810,7 @@
 /area/f13/wasteland/warren)
 "sUC" = (
 /obj/structure/flora/junglebush/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/ncr)
 "sUD" = (
 /obj/structure/fence{
@@ -20154,7 +20151,7 @@
 /area/f13/city)
 "toX" = (
 /mob/living/simple_animal/hostile/trog/sporecarrier,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "tpC" = (
 /obj/effect/decal/remains/human,
@@ -20223,7 +20220,7 @@
 "ttN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "tuI" = (
 /obj/structure/chair/sofa/right{
@@ -20601,7 +20598,7 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "tMY" = (
 /obj/structure/junk/locker,
@@ -20885,7 +20882,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "tZf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20975,7 +20972,7 @@
 /area/f13/wasteland/warren)
 "ucA" = (
 /obj/structure/flora/grass/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "ucE" = (
 /obj/effect/overlay/turfs/cliff{
@@ -21590,7 +21587,7 @@
 "uDz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/machinepile,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "uDJ" = (
 /obj/structure/simple_door/interior{
@@ -22358,7 +22355,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "voO" = (
 /obj/structure/barricade/wooden,
@@ -22411,7 +22408,7 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "vro" = (
 /obj/structure/obstacle/barbedwire/end{
@@ -22909,7 +22906,7 @@
 "vIH" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/remains/human,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "vIN" = (
 /obj/structure/junk/small/bed2,
@@ -23018,7 +23015,7 @@
 /area/f13/city)
 "vOU" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "vPk" = (
 /obj/structure/cargocrate,
@@ -23854,7 +23851,7 @@
 "wFI" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/simple_door/metal/ventilation,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "wFO" = (
 /obj/structure/closet/crate{
@@ -23879,7 +23876,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "wIM" = (
 /obj/structure/barricade/wooden/strong,
@@ -23910,7 +23907,7 @@
 /area/f13/ncr)
 "wJt" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "wJJ" = (
 /obj/item/stack/cable_coil/random,
@@ -24041,7 +24038,7 @@
 	dir = 4
 	},
 /obj/structure/flora/grass/jungle/b,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "wOb" = (
 /obj/effect/turf_decal/stripes/line,
@@ -24444,7 +24441,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "xhd" = (
 /obj/structure/wreck/trash/three_barrels,
@@ -24496,7 +24493,7 @@
 "xjg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "xjr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24784,7 +24781,7 @@
 "xtH" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "xuf" = (
 /obj/machinery/door/poddoor/gate{
@@ -24846,7 +24843,7 @@
 /area/f13/city)
 "xvH" = (
 /obj/structure/lattice/catwalk,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "xwS" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
@@ -25559,7 +25556,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 "yfy" = (
 /obj/effect/turf_decal/loading_area,
@@ -25715,7 +25712,7 @@
 "ylv" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
-/turf/open/water,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/city)
 
 (1,1,1) = {"
@@ -43310,7 +43307,7 @@ xvH
 dwp
 xvH
 oCX
-sxM
+hLa
 oCX
 jWH
 inl
@@ -43567,7 +43564,7 @@ ucA
 jrc
 pwm
 ylv
-sxM
+hLa
 hwO
 xvH
 jWH
@@ -43820,7 +43817,7 @@ inl
 xvH
 xvH
 koU
-sxM
+hLa
 jrc
 xvH
 xvH
@@ -44588,7 +44585,7 @@ jLg
 qZx
 xra
 xra
-sxM
+hLa
 gkF
 gkF
 aWP
@@ -46137,7 +46134,7 @@ pwm
 gkF
 qkd
 mzv
-sxM
+hLa
 xvH
 xvH
 iAy

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -46,7 +46,7 @@
 /obj/item/projectile/bullet/dart/syringe/dart
 	name = "Smartdart"
 	icon_state = "dartproj"
-	damage = 0
+	damage = 5
 	var/emptrig = FALSE
 
 /obj/item/projectile/bullet/dart/syringe/dart/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -444,8 +444,8 @@ Uranium, Contaminated
 /obj/item/projectile/bullet/needle
 	name = "needle"
 	icon_state = "cbbolt"
-	damage = 0
-	armour_penetration = 0.8 //rare AP pistol ammo
+	damage = 25
+	armour_penetration = 1//Low damage, 100% pen.
 	var/piercing = FALSE
 
 


### PR DESCRIPTION
- - -
Bighorn:
 - Shopkeep's store positioned in a far better way, given much more loot and overall made into an actual warehouse with absurd stuff. As we don't permit raiding on the store normally, this shouldn't be an issue.
 - Lower bar lost its drink machines, to give more attention to the upper location. It's likely that I'll just gut this area altogether soon.
 - Schoolhouse for Followers replaced near entirety of the three offices.
- - -
Enclave:
 - Enclave bunker given a minor touchup. Only Command roles can access the Armory by default now. This is an identical access requirement to the reactor.
 - Armory updated to provide three needlers, two combat rifles and an ion rifle.
 - Additional landing locations added within the Mountain Range. One outside and one far north-east.
- - -
Balance:
 - Water within areas outside of Rock Springs returned to irradiated state. This was oversight, but actually effects how some areas are navigated. Thus, balance section.
 - South Bunker redone slightly with higher loot yield. Made more difficult in return, especially for our current balance.
 - Smartdarts now do five damage on impact.
 - Needler darts do 25 damage and have guaranteed pen, making them one of the few anti-armor weapons you can get in a compact form.
- - -