### PR TITLE
comments out the AMR, Gauss and Bozar blueprints

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2184,11 +2184,11 @@
 	icon_state = "blueprint_loot"
 	lootcount = 1
 	loot = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/gauss,
-		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
+// 		/obj/item/book/granter/crafting_recipe/blueprint/gauss,
+//		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
 		/obj/item/book/granter/crafting_recipe/blueprint/citykiller,
 		/obj/item/book/granter/crafting_recipe/blueprint/rangemaster,
-		/obj/item/book/granter/crafting_recipe/blueprint/bozar
+//		/obj/item/book/granter/crafting_recipe/blueprint/bozar
 	)
 
 /obj/effect/spawner/lootdrop/f13/blueprintVHighPartsWeighted


### PR DESCRIPTION

## About The Pull Request

This comments out the AMR, Gauss Rifle and Bozar blueprints from loot tables, making them no longer up to chance to spawn.

## Why It's Good For The Game

This should help balancing, stopping mass-production of incredibly unique weapons, and giving them more importance rather than them being a common sight.

## Changelog

:cl:
balance: removed the AMR, Gauss Rifle and Bozar blueprints from the loot tables
/:cl:
