### PR TITLE
Custom loadout

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -241,3 +241,15 @@
 	new /obj/item/clothing/mask/scarecrow/baghead(src)
 	new /obj/item/melee/onehanded/knife/ritualdagger/baghead(src)
 	new /obj/item/book/granter/trait/chemistry(src)
+	
+/datum/gear/donator/kits/emma
+	name = "Emma's Equipment"
+	path = /obj/item/storage/box/large/custom_kit/garner
+	ckeywhitelist = list ("potatoperson993")
+
+/obj/item/storage/box/large/custom_kit/garner/PopulateContents()
+	new /obj/item/gun/energy/laser/wattz/recharger(src)
+	new /obj/item/clothing/under/f13/recon/outcast(src)
+	new /obj/item/clothing/head/f13/combat/brotherhood/outcast(src)
+	new /obj/item/clothing/suit/armor/f13/combat/brotherhood/outcast(src)
+	

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -244,7 +244,7 @@
 	
 /datum/gear/donator/kits/emma
 	name = "Emma's Equipment"
-	path = /obj/item/storage/box/large/custom_kit/garner
+	path = /obj/item/storage/box/large/custom_kit/emma
 	ckeywhitelist = list ("potatoperson993")
 
 /obj/item/storage/box/large/custom_kit/garner/PopulateContents()

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -250,6 +250,6 @@
 /obj/item/storage/box/large/custom_kit/emma/PopulateContents()
 	new /obj/item/gun/energy/laser/wattz/recharger(src)
 	new /obj/item/clothing/under/f13/recon/outcast(src)
-	new /obj/item/clothing/head/f13/combat/brotherhood/outcast(src)
+	new /obj/item/clothing/head/helmet/f13/combat/brotherhood/outcast(src)
 	new /obj/item/clothing/suit/armor/f13/combat/brotherhood/outcast(src)
 	

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -247,7 +247,7 @@
 	path = /obj/item/storage/box/large/custom_kit/emma
 	ckeywhitelist = list ("potatoperson993")
 
-/obj/item/storage/box/large/custom_kit/garner/PopulateContents()
+/obj/item/storage/box/large/custom_kit/emma/PopulateContents()
 	new /obj/item/gun/energy/laser/wattz/recharger(src)
 	new /obj/item/clothing/under/f13/recon/outcast(src)
 	new /obj/item/clothing/head/f13/combat/brotherhood/outcast(src)


### PR DESCRIPTION
Custom loadout, mostly for convenience; it's quite literally the outcast loadout with a recharger pistol instead of the AEP7, blueprint, and frags (oof), but I've gotten this so many times in game that I'd prefer to just have it since it makes sense the character would keep it.