### PR TITLE
5.56 rebalance + supereffective ammo

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -351,6 +351,8 @@
 	spread = 4
 	recoil = 0.5
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
+	extra_damage = 9
+	extra_penetration = 0.08
 
 
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -39,22 +39,23 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 
 /obj/item/projectile/bullet/a556
 	name = "5.56 FMJ bullet"
-	damage = 32
-	wound_bonus = 24
-	bare_wound_bonus = 18
+	damage = 26
+	wound_bonus = 18
+	bare_wound_bonus = 24
+	var/extra_speed = 200
 
 /obj/item/projectile/bullet/a556/match
 	name = "5.56 match bullet"
-	damage = 28
-	armour_penetration = 0.21
+	damage = 20
+	armour_penetration = 0.35
 	wound_bonus = 18
 	bare_wound_bonus = 0
-	var/extra_speed = 200
+	var/extra_speed = 500
 
 /obj/item/projectile/bullet/a556/sport
 	name = ".223 FMJ bullet"
-	damage = 28
-	wound_bonus = 32
+	damage = 24
+	wound_bonus = 18
 	bare_wound_bonus = 32//Gives a reason to actually use this round.
 
 /obj/item/projectile/bullet/a556/rubber

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -56,7 +56,9 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	name = ".223 FMJ bullet"
 	damage = 24
 	wound_bonus = 18
-	bare_wound_bonus = 32//Gives a reason to actually use this round.
+	bare_wound_bonus = 32 //Gives a reason to actually use this round.
+	supereffective_damage = 15
+	supereffective_faction = list("hostile", "ant", "deathclaw", "cazador", "china", "gecko", "radscorpion") //5.56 being effective against the Chinese is a funny code joke that someone will look at like 4 years from now on and cry about.
 
 /obj/item/projectile/bullet/a556/rubber
 	name = "5.56 rubber bullet"
@@ -107,6 +109,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 28
 	wound_bonus = 32
 	bare_wound_bonus = 32
+	supereffective_damage = 14
+	supereffective_faction = list("hostile", "ant", "deathclaw", "cazador", "gecko", "radscorpion")
 
 /obj/item/projectile/bullet/a762/rubber
 	name = "7.62 rubber bullet"
@@ -148,6 +152,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	zone_accuracy_factor = 100
 	wound_bonus = 60
 	bare_wound_bonus = 80//Same as the HMG.
+	supereffective_damage = 125
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = 60
@@ -305,6 +311,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	bare_wound_bonus = 10
 	armour_penetration = 0.45
 	var/extra_speed = 200
+	supereffective_damage = 10
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/m5mm/simple //for simple mobs, separate to allow balancing
 	name = "5mm bullet"
@@ -338,6 +346,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 52
 	armour_penetration = 0.9
 	pixels_per_second = TILES_TO_PIXELS(100)
+	supereffective_damage = 58
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/c2mm/blender //welcome to pain town
 	name = "2mm blender projectile"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -50,7 +50,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	armour_penetration = 0.35
 	wound_bonus = 18
 	bare_wound_bonus = 0
-	var/extra_speed = 500
+	extra_speed = 500
 
 /obj/item/projectile/bullet/a556/sport
 	name = ".223 FMJ bullet"


### PR DESCRIPTION
Lowered overall damage of 5.56 and lowered armored wound bonus, at the cost of increasing the round's default speed.

Also buffs 5.56 pistol to stay relevant with these changes.

### SUPEREFFECTIVE DAMAGE
Added supereffective damage against animals to "Hunting" rounds, and gave generalized supereffective damage against simplemobs to high caliber/powerful ammo like .50 BMG and 2mm