### PR TITLE
Pistol/revolver caliber guns balancing

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -202,7 +202,7 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_HEAVY //Automatic fire and onehanded use mix poorly.
-	slowdown = 0.4
+	slowdown = 0.25
 	fire_delay = 3.75
 	burst_shot_delay = 3
 	spread = 10
@@ -215,7 +215,6 @@
 	desc = "An integrally suppressed submachinegun chambered in the common .22 long rifle. Top loaded drum magazine."
 	icon_state = "smg22"
 	item_state = "shotgun"
-	slowdown = 0.25
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/m22smg
 	can_unsuppress = FALSE
@@ -238,6 +237,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/smg14
 	is_automatic = TRUE
+	extra_damage = -9
 	automatic = 1
 	autofire_shot_delay = 2.15 //It's so awfully inaccurate now that it's more of a gimmick than a buff
 	spread = 10
@@ -258,6 +258,7 @@
 	slowdown = 0.3
 	burst_shot_delay = 2.75
 	is_automatic = TRUE
+	extra_damage = -1
 	automatic = 1
 	autofire_shot_delay = 2.5
 	can_attachments = TRUE
@@ -384,9 +385,9 @@
 	fire_delay = 3
 	burst_shot_delay = 2.2
 	is_automatic = TRUE
+	extra_damage = -3
 	automatic = 1
-	slowdown = 0.3
-	autofire_shot_delay = 2
+	autofire_shot_delay = 1.80
 	spread = 16
 	can_suppress = TRUE
 	can_attachments = TRUE
@@ -427,8 +428,9 @@
 	item_state = "cg45"
 	mag_type = /obj/item/ammo_box/magazine/cg45
 	is_automatic = TRUE
+	extra_damage = 2
 	automatic = 1
-	slowdown = 0.35
+	slowdown = 0.3
 	autofire_shot_delay = 2.5
 	spread = 12
 	fire_delay = 3.5
@@ -444,8 +446,9 @@
 	item_state = "cg45"
 	mag_type = /obj/item/ammo_box/magazine/cg45_two
 	is_automatic = TRUE
+	extra_damage = -2
 	automatic = 1
-	slowdown = 0.35
+	slowdown = 0.3
 	autofire_shot_delay = 3
 	spread = 18
 	fire_delay = 3.5
@@ -465,6 +468,7 @@
 	init_mag_type = /obj/item/ammo_box/magazine/tommygunm45/stick
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	is_automatic = TRUE
+	extra_damage = -5
 	automatic = 1
 	autofire_shot_delay = 2.25
 	burst_shot_delay = 2.75
@@ -478,8 +482,9 @@
 	desc = "A recovered ancient Thompson from an armory far up North. Commonly used by raiders of the White Legs tribe."
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
 	init_mag_type = /obj/item/ammo_box/magazine/tommygunm45/stick
-	fire_delay = 3.75
-	spread = 19
+	fire_delay = 3.9
+	spread = 20
+	extra_damage = -7
 
 //P90				Keywords: 10mm, Automatic, 50 rounds. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/smg/p90
@@ -494,7 +499,7 @@
 	spread = 14
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 2
+	autofire_shot_delay = 1.9
 	burst_shot_delay = 2.5
 	recoil = 0.25
 	can_suppress = TRUE
@@ -502,6 +507,7 @@
 	suppressor_x_offset = 29
 	suppressor_y_offset = 16
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
+	extra_damage = -1
 	slowdown = 0.2
 
 /obj/item/gun/ballistic/automatic/smg/p90/worn
@@ -510,6 +516,7 @@
 	autofire_shot_delay = 2.25
 	spread = 16
 	slowdown = 0.35
+	extra_damage = -3
 
 
 //MP-5 SD				Keywords: 9mm, Automatic, 32 rounds, Suppressed
@@ -519,12 +526,13 @@
 	icon_state = "mp5"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
+	extra_damage = 1
 	spread = 6
 	fire_delay = 3.5
 	slowdown = 0.25
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 2.15
+	autofire_shot_delay = 2.2
 	burst_shot_delay = 2
 	suppressed = 1
 	recoil = 0.05
@@ -539,6 +547,7 @@
 	name = "Ppsh-41"
 	desc = "An extremely fast firing, inaccurate submachine gun from World War 2. Low muzzle velocity. Uses 9mm rounds."
 	icon_state = "pps"
+	extra_damage = 3
 	slowdown = 0.3
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/pps9mm
@@ -569,6 +578,8 @@
 	icon_state = "m1carbine"
 	item_state = "rifle"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv
+	extra_speed = 100
+	extra_penetration = 0.5
 	burst_size = 1
 	fire_delay = 3
 	spread = 2
@@ -600,6 +611,7 @@
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	icon_state = "ncr-m1carbine"
 	item_state = "rifle"
+	extra_damage = 2
 
 
 //M1A1 Carbine				Keywords: 10mm, Semi-auto, 12/24 rounds, Long barrel, Folding stock.
@@ -697,6 +709,8 @@
 	icon_state = "delisle"
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
+	extra_damage = 1
+	extra_penetration = 0.5
 	slowdown = 0.05
 	fire_delay = 4
 	burst_size = 1
@@ -713,6 +727,8 @@
 	icon_state = "commando"
 	item_state = "commando"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
+	extra_damage = -5
+	extra_penetration = 0.2
 	can_scope = TRUE
 	semi_auto = TRUE
 	automatic_burst_overlay = FALSE
@@ -762,6 +778,7 @@
 	burst_size = 1
 	spread = 1
 	slowdown = 0.25
+	extra_damage = -5
 	extra_penetration = 0.1
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -205,7 +205,7 @@
 	slowdown = 0.25
 	fire_delay = 3.75
 	burst_shot_delay = 3
-	spread = 10
+	spread = 14
 	force = 12
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 
@@ -241,7 +241,7 @@
 	extra_damage = -9
 	automatic = 1
 	autofire_shot_delay = 2.15 //It's so awfully inaccurate now that it's more of a gimmick than a buff
-	spread = 10
+	spread = 17
 	recoil = 0.85
 	can_attachments = TRUE
 	can_suppress = FALSE
@@ -255,13 +255,14 @@
 	icon_state = "grease_gun"
 	item_state = "smg9mm"
 	mag_type = /obj/item/ammo_box/magazine/greasegun
-	spread = 8
+	spread = 10
+	recoil = 0.4
 	slowdown = 0.3
 	burst_shot_delay = 2.75
 	is_automatic = TRUE
-	extra_damage = -1
+	extra_damage = -2
 	automatic = 1
-	autofire_shot_delay = 2.5
+	autofire_shot_delay = 2.7
 	can_attachments = TRUE
 	suppressor_state = "uzi_suppressor"
 	suppressor_x_offset = 26
@@ -297,7 +298,7 @@
 	desc = "What was once an inexpensive, but reliable submachine gun is now an inexpensive piece of shit. It's impressive this thing still fires at all."
 	can_attachments = FALSE
 	spread = 16.5
-	recoil = 0.3
+	recoil = 0.5
 
 /obj/item/gun/ballistic/automatic/smg/greasegun/worn/auto_select()
 	var/mob/living/carbon/human/user = usr
@@ -334,10 +335,11 @@
 	init_mag_type = /obj/item/ammo_box/magazine/m10mm_adv/ext
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 2.35
-	spread = 12
+	autofire_shot_delay = 2
+	extra_damage = -2
+	spread = 14
 	slowdown = 0.3
-	recoil = 0.5
+	recoil = 0.7
 	fire_delay = 3.25
 	can_attachments = TRUE
 	suppressor_state = "10mm_suppressor" //activate if sprited
@@ -386,10 +388,11 @@
 	fire_delay = 3
 	burst_shot_delay = 2.2
 	is_automatic = TRUE
-	extra_damage = -3
+	extra_damage = -5
 	automatic = 1
-	autofire_shot_delay = 1.80
-	spread = 16
+	autofire_shot_delay = 1.70
+	recoil - 1
+	spread = 17
 	can_suppress = TRUE
 	can_attachments = TRUE
 	suppressor_state = "uzi_suppressor"
@@ -429,10 +432,9 @@
 	item_state = "cg45"
 	mag_type = /obj/item/ammo_box/magazine/cg45
 	is_automatic = TRUE
-	extra_damage = 2
 	automatic = 1
 	slowdown = 0.3
-	autofire_shot_delay = 2.5
+	autofire_shot_delay = 2.4
 	spread = 12
 	fire_delay = 3.5
 	recoil = 0.1
@@ -469,9 +471,9 @@
 	init_mag_type = /obj/item/ammo_box/magazine/tommygunm45/stick
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	is_automatic = TRUE
-	extra_damage = -5
+	extra_damage = -6
 	automatic = 1
-	autofire_shot_delay = 2.25
+	autofire_shot_delay = 2.1
 	burst_shot_delay = 2.75
 	fire_delay = 3.75
 	spread = 15
@@ -485,7 +487,7 @@
 	init_mag_type = /obj/item/ammo_box/magazine/tommygunm45/stick
 	fire_delay = 3.9
 	spread = 20
-	extra_damage = -7
+	extra_damage = -9
 
 //P90				Keywords: 10mm, Automatic, 50 rounds. Special modifiers: damage +1
 /obj/item/gun/ballistic/automatic/smg/p90
@@ -497,27 +499,27 @@
 	mag_type = /obj/item/ammo_box/magazine/m10mm_p90
 	burst_size = 1
 	fire_delay = 3
-	spread = 14
+	spread = 15
 	is_automatic = TRUE
 	automatic = 1
 	autofire_shot_delay = 1.9
 	burst_shot_delay = 2.5
-	recoil = 0.25
+	recoil = 0.35
 	can_suppress = TRUE
 	suppressor_state = "pistol_suppressor"
 	suppressor_x_offset = 29
 	suppressor_y_offset = 16
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
-	extra_damage = -1
+	extra_damage = -2
 	slowdown = 0.35
 
 /obj/item/gun/ballistic/automatic/smg/p90/worn
 	name = "Worn FN P90c"
 	desc = "A FN P90 manufactured by Fabrique Nationale. This one is beat to hell but still works."
 	autofire_shot_delay = 2.25
-	spread = 16
+	spread = 17
 	slowdown = 0.35
-	extra_damage = -3
+	extra_damage = -4
 
 
 //MP-5 SD				Keywords: 9mm, Automatic, 32 rounds, Suppressed
@@ -527,16 +529,15 @@
 	icon_state = "mp5"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
-	extra_damage = 1
 	spread = 6
 	fire_delay = 3.5
 	slowdown = 0.25
 	is_automatic = TRUE
 	automatic = 1
-	autofire_shot_delay = 2.2
+	autofire_shot_delay = 2.3
 	burst_shot_delay = 2
 	suppressed = 1
-	recoil = 0.05
+	recoil = 0.1
 	can_attachments = TRUE
 	can_suppress = FALSE
 	can_unsuppress = FALSE
@@ -548,7 +549,7 @@
 	name = "Ppsh-41"
 	desc = "An extremely fast firing, inaccurate submachine gun from World War 2. Low muzzle velocity. Uses 9mm rounds."
 	icon_state = "pps"
-	extra_damage = 3
+	extra_damage = 2
 	slowdown = 0.3
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/pps9mm

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -446,7 +446,7 @@
 	item_state = "cg45"
 	mag_type = /obj/item/ammo_box/magazine/cg45_two
 	is_automatic = TRUE
-	extra_damage = -2
+	extra_damage = -4
 	automatic = 1
 	slowdown = 0.3
 	autofire_shot_delay = 3

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -237,6 +237,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/smg14
 	is_automatic = TRUE
+	slowdown 0.35
 	extra_damage = -9
 	automatic = 1
 	autofire_shot_delay = 2.15 //It's so awfully inaccurate now that it's more of a gimmick than a buff
@@ -508,7 +509,7 @@
 	suppressor_y_offset = 16
 	fire_sound = 'sound/f13weapons/10mm_fire_03.ogg'
 	extra_damage = -1
-	slowdown = 0.2
+	slowdown = 0.35
 
 /obj/item/gun/ballistic/automatic/smg/p90/worn
 	name = "Worn FN P90c"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -391,7 +391,7 @@
 	extra_damage = -5
 	automatic = 1
 	autofire_shot_delay = 1.70
-	recoil - 1
+	recoil = 1
 	spread = 17
 	can_suppress = TRUE
 	can_attachments = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -237,7 +237,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	mag_type = /obj/item/ammo_box/magazine/smg14
 	is_automatic = TRUE
-	slowdown 0.35
+	slowdown = 0.35
 	extra_damage = -9
 	automatic = 1
 	autofire_shot_delay = 2.15 //It's so awfully inaccurate now that it's more of a gimmick than a buff

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -579,7 +579,7 @@
 	item_state = "rifle"
 	mag_type = /obj/item/ammo_box/magazine/m10mm_adv
 	extra_speed = 100
-	extra_penetration = 0.5
+	extra_penetration = 0.05
 	burst_size = 1
 	fire_delay = 3
 	spread = 2

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -710,7 +710,7 @@
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/m9mmds
 	extra_damage = 1
-	extra_penetration = 0.5
+	extra_penetration = 0.05
 	slowdown = 0.05
 	fire_delay = 4
 	burst_size = 1

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -365,7 +365,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slowdown = 0
 	fire_delay = 4
-	extra_penetration = 0.1
+	extra_penetration = 0.05
 
 /obj/item/gun/ballistic/automatic/pistol/pistol14/custom
 	name= "Custom 14mm pistol"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -341,6 +341,7 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, powerful but a little inaccurate"
 	icon_state = "pistol14"
 	mag_type = /obj/item/ammo_box/magazine/m14mm
+	slowdown = 0.05
 	force = 15
 	fire_delay = 5
 	extra_damage = 2
@@ -362,6 +363,7 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a finely tuned custom firearm from the Gunrunners."
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
+	slowdown = 0
 	fire_delay = 4
 	extra_penetration = 0.1
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -363,7 +363,7 @@
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
 	fire_delay = 4
-	extra_penetration = 0.35
+	extra_penetration = 0.1
 
 /obj/item/gun/ballistic/automatic/pistol/pistol14/custom
 	name= "Custom 14mm pistol"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -346,7 +346,7 @@
 	slowdown = 0.05
 	force = 15
 	fire_delay = 5
-	extra_damage = 2
+	extra_damage = 8
 	recoil = 2.2
 	can_suppress = FALSE
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
@@ -357,6 +357,8 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a compact model for concealed carry."
 	icon_state = "pistol14_compact"
 	w_class = WEIGHT_CLASS_SMALL
+	slowdown = 0
+	recoil = 2.5
 	spread = 5
 
 //Little Devil							Keywords: UNIQUE, 14mm, Semi-auto, Short barrel, 7 Rounds, Heavy. Special modifiers: damage +4, penetration +0.05, spread -3
@@ -367,7 +369,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slowdown = 0
 	fire_delay = 4
-	extra_penetration = 0.05
+	extra_penetration = 0.08
 
 /obj/item/gun/ballistic/automatic/pistol/pistol14/custom
 	name= "Custom 14mm pistol"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -62,7 +62,7 @@
 	can_unsuppress = FALSE
 	suppressed = 1
 	fire_sound = 'sound/f13weapons/22pistol.ogg'
-	extra_damage = 3
+	extra_damage = 7
 
 
 //N99  10mm								Keywords: 10mm, Semi-auto, 12/24 round magazine
@@ -88,7 +88,6 @@
 	attachableparts = list("internal" = new /obj/item/gunpart/BHS_Receiver, "internal2" = null, "east" = null, "west" = null, "south" = null, "north" = null)
 	//Blacklisted Parts
 	blacklistedparts = list("stock")
-	extra_damage = 3
 
 //the Executive							Keywords: UNIQUE, 10mm, Automatic, 12/24 round magazine. Special modifiers: damage +4
 /obj/item/gun/ballistic/automatic/pistol/n99/executive
@@ -98,6 +97,7 @@
 	burst_size = 2
 	semi_auto = FALSE
 	can_automatic = FALSE
+	extra_damage = 1
 
 //Crusader pistol
 /obj/item/gun/ballistic/automatic/pistol/n99/crusader
@@ -121,6 +121,7 @@
 	spread = 3
 	can_suppress = FALSE
 	fire_sound = 'sound/f13weapons/10mm_fire_02.ogg'
+	extra_damage = 2
 
 //Browning Hi-power						Keywords: 9mm, Semi-auto
 /obj/item/gun/ballistic/automatic/pistol/ninemil
@@ -150,9 +151,8 @@
 	name = "Maria"
 	desc = "An ornately-decorated pre-war Browning Hi-power 9mm pistol with pearl grips and a polished nickel finish. The firing mechanism has been upgraded, so for anyone on the receiving end, it must seem like an eighteen-karat run of bad luck."
 	icon_state = "maria"
-	fire_delay = 2
-	extra_damage = 8
-	extra_penetration = 0.05
+	extra_damage = 5
+	extra_penetration = 0.2
 
 
 //Sig Sauer P220						Keywords: 9mm, Semi-auto, 10 round magazine
@@ -183,6 +183,7 @@
 	suppressor_x_offset = 30
 	suppressor_y_offset = 20
 	fire_sound = 'sound/f13weapons/9mm.ogg'
+	extra_damage = 1
 
 //Beretta M93R							Keywords: 9mm, Automatic, 15 round magazine
 /obj/item/gun/ballistic/automatic/pistol/beretta/automatic
@@ -198,6 +199,7 @@
 	automatic_burst_overlay = TRUE
 	can_attachments = FALSE
 	semi_auto = FALSE
+	extra_damage = 1
 
 /obj/item/gun/ballistic/automatic/pistol/beretta/automatic/burst_select()
 	var/mob/living/carbon/human/user = usr
@@ -229,7 +231,6 @@
 	item_state = "pistolchrome"
 	w_class = WEIGHT_CLASS_NORMAL
 	fire_delay = 2
-	slowdown = 0.05
 	mag_type = /obj/item/ammo_box/magazine/m45
 	recoil = 0.15
 	can_attachments = TRUE
@@ -262,8 +263,8 @@
 	desc = "A very tactical pistol chambered in .45 ACP with a built in laser sight and attachment point for a seclite."
 	icon_state = "mk23"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
-	fire_delay = 2
-	slowdown = 0.07
+	recoil = 0.05
+	fire_delay = 1
 	spread = 1
 	can_flashlight = TRUE
 	gunlight_state = "flight"
@@ -293,7 +294,7 @@
 	extra_speed = 300
 	recoil = 3.5 //Debilitating
 	spread = 6
-	extra_damage = 12
+	extra_damage = 1
 	extra_penetration = 0.12
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
@@ -331,7 +332,7 @@
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
-	extra_damage = 5
+	extra_damage = 4
 
 
 //14mm Pistol		Keywords: 14mm, Semi-auto, 7 rounds, Heavy
@@ -342,7 +343,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m14mm
 	force = 15
 	fire_delay = 5
-	extra_damage = 11
+	extra_damage = 2
 	recoil = 2.2
 	can_suppress = FALSE
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
@@ -362,7 +363,6 @@
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
 	fire_delay = 4
-	extra_damage = 0
 	extra_penetration = 0.35
 
 /obj/item/gun/ballistic/automatic/pistol/pistol14/custom
@@ -370,7 +370,7 @@
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a finely tuned custom firearm. How'd this get into service?"
 	icon_state = "lildev"
 	w_class = WEIGHT_CLASS_SMALL
-	fire_delay = 4
+	fire_delay = 2
 
 /////////////////////////////////
 // TEMPORARY REMOVE AFTER BETA //

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -263,6 +263,7 @@
 	desc = "A very tactical pistol chambered in .45 ACP with a built in laser sight and attachment point for a seclite."
 	icon_state = "mk23"
 	mag_type = /obj/item/ammo_box/magazine/m45exp
+	extra_damage = -3
 	recoil = 0.05
 	fire_delay = 1
 	spread = 1
@@ -332,7 +333,8 @@
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
-	extra_damage = 2
+	extra_penetration = -0.1
+	extra_damage = 6
 
 
 //14mm Pistol		Keywords: 14mm, Semi-auto, 7 rounds, Heavy

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -295,7 +295,7 @@
 	recoil = 3.5 //Debilitating
 	spread = 6
 	extra_damage = 1
-	extra_penetration = 0.12
+	extra_penetration = 0.05
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
@@ -332,7 +332,7 @@
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
-	extra_damage = 4
+	extra_damage = 2
 
 
 //14mm Pistol		Keywords: 14mm, Semi-auto, 7 rounds, Heavy

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -2,7 +2,7 @@
 // See gun.dm for keywords and the system used for gun balance
 
 /obj/item/gun/ballistic/revolver
-	slowdown = 0.1
+	slowdown = 0.05
 	name = "revolver template"
 	desc = "should not exist."
 	icon_state = "revolver"
@@ -138,9 +138,9 @@
 	obj_flags = UNIQUE_RENAME
 	var/list/safe_calibers
 
-///////////////////
+///////////////////////
 // .45 ACP REVOLVERS //
-///////////////////
+///////////////////////
 
 
 //S&W 45						Keywords: .45, Single action, 7 rounds cylinder, Long barrel
@@ -153,8 +153,7 @@
 	fire_delay = 4.5
 	spread = 1
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
-	extra_damage = 4
-
+	extra_damage = 5
 
 
 ////////////////////
@@ -168,7 +167,7 @@
 	icon_state = "357colt"
 	item_state = "357colt"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev357
-	fire_delay = 4.5
+	fire_delay = 3.5
 	spread = 0
 	fire_sound = 'sound/f13weapons/357magnum.ogg'
 
@@ -178,6 +177,7 @@
 	icon_state = "mateba"
 	item_state = "mateba"
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
+	armour_penetration = 0.1
 
 //Lucky							Keywords: UNIQUE, .357, Double action, 6 rounds cylinder, Block chance, Fire delay -1
 /obj/item/gun/ballistic/revolver/colt357/lucky
@@ -186,7 +186,8 @@
 	icon_state = "lucky37"
 	item_state = "lucky"
 	w_class = WEIGHT_CLASS_SMALL
-	fire_delay = 3
+	fire_delay = 2.5
+	extra_damage = 3
 	block_chance = 20
 
 //Police revolver					Keywords: .357, Double action, 6 rounds cylinder, Pocket Pistol
@@ -198,7 +199,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	spread = 2
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
-	extra_damage = -5
+	slowdown = 0
+	extra_damage = -6
 
 
 
@@ -233,6 +235,7 @@
 	desc = "When you don't just need excessive force, but crave it. This .44 has a special hammer mechanism, allowing for measured powerful shots, or fanning for a flurry of inaccurate shots."
 	item_state = "m29peace"
 	icon_state = "m29peace"
+	extra_damage = 2
 	automatic = 1
 	autofire_shot_delay = 1
 	actions_types = list(/datum/action/item_action/toggle_firemode)
@@ -245,7 +248,7 @@
 	icon_state = "m29_snub"
 	w_class = WEIGHT_CLASS_SMALL
 	spread = 3
-	extra_damage = -5
+	extra_damage = -3
 
 
 //.44 single action		 			Keywords: .44, Single action, 6 rounds cylinder, Long barrel
@@ -255,6 +258,7 @@
 	item_state = "44colt"
 	icon_state = "44colt"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
+	extra_damage = 2
 	fire_delay = 4.5
 	spread = 0
 	fire_sound = 'sound/f13weapons/44revolver.ogg'
@@ -265,12 +269,14 @@
 	name = "desert ranger revolver"
 	desc = "I hadn't noticed, but there on his hip, was a really spiffy looking iron..."
 	fire_delay = 4
+	extra_damage = 2
 
 //Sheriff's revolver			Keywords: .44, Single action, 6 rounds cylinder, 5 less damage than sequoia, 20% more pen
 /obj/item/gun/ballistic/revolver/revolver44/sheriff
 	name = "Biggest Iron"
 	desc = "There was forty feet between them, when they stopped to make their play..."
 	force = 25
+	extra_penetration = 0.2
 	casing_ejector = TRUE//WHAT THE FUCK IS THIS GUN? FASTEST HAND IN THE WEST BETWEEN SHOTS, THAT'S WHAT.
 	can_scope = TRUE
 	scope_state = "revolver_scope"
@@ -290,6 +296,7 @@
 	icon_state = "sequoia"
 	item_state = "sequoia"
 	weapon_weight = WEAPON_MEDIUM
+	slowdown = 0.1
 	recoil = 0.2
 	fire_delay = 1
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev4570
@@ -312,13 +319,13 @@
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev4570
 	recoil = 0.1
+	slowdown = 0.12
 	can_scope = TRUE
 	scope_state = "revolver_scope"
 	fire_delay = 5.5
 	scope_x_offset = 9
 	scope_y_offset = 20
 	fire_sound = 'sound/f13weapons/sequoia.ogg'
-	extra_damage = -2
 
 /obj/item/gun/ballistic/revolver/hunting/klatue
 	name = "degraded hunting revolver"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -155,7 +155,7 @@
 	fire_delay = 2.25
 	recoil = 0.10
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
-	extra_penetration = 0.3
+	extra_penetration = 0.1
 
 
 ////////////////////////

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -118,7 +118,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube357
 	extra_speed = 300
 	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
-	extra_damage = 4
+	extra_damage = 1
 
 
 //Trail carbine							Keywords: .44, Lever action, 12 round internal, Long barrel
@@ -130,7 +130,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44
 	extra_speed = 200
 	fire_sound = 'sound/f13weapons/44mag.ogg'
-	extra_damage = 4
+	extra_damage = 1
 
 
 //Brush gun								Keywords: .45-70, Lever action, 10 round internal, Long barrel
@@ -144,19 +144,18 @@
 	fire_delay = 3
 	recoil = 0.15
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
-	extra_penetration = 0.12
-
+	
 //Medicine Stick						Keywords: .45-70, Lever action, 8 round internal, Long barrel, Unique
 /obj/item/gun/ballistic/rifle/repeater/brush/medistick
 	name = "medicine stick"
 	desc = "A custom-made Gun Runners brush gun with a shorter tube, featuring a sturdier frame, longer barrel, reinforced rifling, padded lever and a muzzle device. A medicine wheel is attached to one side of the stock along with two feathers."
 	icon_state = "medistick"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube4570/medicine
-	extra_speed = 150
+	extra_speed = 100
 	fire_delay = 2.25
 	recoil = 0.10
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
-	extra_penetration = 0.4
+	extra_penetration = 0.3
 
 
 ////////////////////////

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -42,14 +42,14 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c22/rubber
 	name = ".22lr rubber bullet"
-	damage = 2
+	damage = 3
 	stamina = 22
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c22/shock
 	name = ".22lr shock bullet"
-	damage = 8
+	damage = 9
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 
@@ -63,12 +63,12 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 14
+	damage = 23
 	wound_bonus = 12
 
 /obj/item/projectile/bullet/c38/rubber
 	name = ".38 rubber bullet"
-	damage = 4
+	damage = 6
 	stamina = 32
 	wound_bonus = 0
 	sharpness = SHARP_NONE
@@ -98,7 +98,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c38/incendiary
 	name = ".38 incendiary bullet"
-	damage = 4
+	damage = 11
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c38/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -116,7 +116,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm FMJ bullet"
-	damage = 16
+	damage = 20
 	wound_bonus = 10
 
 /obj/item/projectile/bullet/c9mm/op
@@ -152,7 +152,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c9mm/incendiary
 	name = "9mm incendiary bullet"
-	damage = 4
+	damage = 10
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c9mm/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -176,7 +176,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c10mm
 	name = "10mm FMJ bullet"
-	damage = 18
+	damage = 22
 	wound_bonus = 24
 
 /obj/item/projectile/bullet/c10mm/simple
@@ -194,7 +194,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c10mm/incendiary
 	name = "10mm incendiary bullet"
-	damage = 5
+	damage = 11
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c10mm/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -212,7 +212,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c45
 	name = ".45 FMJ bullet"
-	damage = 24
+	damage = 30
 	wound_bonus = 15
 
 /obj/item/projectile/bullet/c45/simple
@@ -227,14 +227,14 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c45/rubber
 	name = ".45 rubber bullet"
-	damage = 6
-	stamina = 24
+	damage = 10
+	stamina = 28
 	sharpness = SHARP_NONE
 	wound_bonus = 0
 
 /obj/item/projectile/bullet/c45/incendiary
 	name = ".45 incendiary bullet"
-	damage = 6
+	damage = 15
 	var/fire_stacks = 1
 
 /obj/item/projectile/bullet/c45/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -251,14 +251,14 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357
 	name = ".357 FMJ bullet"
-	damage = 28
+	damage = 35
 	wound_bonus = 20
 	bare_wound_bonus = -14
 
 // 3 ricochets, more than enough to kill anything that moves
 /obj/item/projectile/bullet/a357/ricochet
 	name = ".357 ricochet bullet"
-	damage = 24
+	damage = 35
 	ricochets_max = 3
 	ricochet_chance = 140
 	ricochet_auto_aim_angle = 50
@@ -286,7 +286,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/a357/incendiary
 	name = ".357 incendiary bullet"
-	damage = 12
+	damage = 17
 	var/fire_stacks = 2
 
 /obj/item/projectile/bullet/a357/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -306,7 +306,8 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/m44
 	name = ".44 FMJ bullet"
-	damage = 32
+	damage = 38
+	armour_penetration = 0.1
 	wound_bonus = 24
 	bare_wound_bonus = -20
 
@@ -317,7 +318,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/m44/incendiary
 	name = ".44 incendiary bullet"
-	damage = 16
+	damage = 18
 	var/fire_stacks = 2
 
 /obj/item/projectile/bullet/m44/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -333,7 +334,8 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c4570
 	name = ".45-70 FMJ bullet"
-	damage = 42
+	damage = 43
+	armour_penetration = 0.15
 	wound_bonus = 32
 	bare_wound_bonus = -24
 
@@ -367,7 +369,7 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/c4570/knockback
 	name = ".45-70 ultradense bullet"
-	damage = 18
+	damage = 27
 	wound_bonus = 0
 	sharpness = SHARP_NONE
 	pixels_per_second = TILES_TO_PIXELS(500)
@@ -386,12 +388,13 @@ Uranium, Contaminated
 
 /obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
-	damage = 32
+	damage = 36
+	armour_penetration = 0.15
 	wound_bonus = 42
 	bare_wound_bonus = 28
 
 /obj/item/projectile/bullet/mm14/contam
-	name = "14mm contaiminated bullet"
+	name = "14mm contaminated bullet"
 	damage = 18
 	var/smoke_radius = 1
 
@@ -425,8 +428,8 @@ Uranium, Contaminated
 //45 Long Colt. Bouncy ammo but less damage then the Sequoia. It's in one of the Vet Ranger kits
 /obj/item/projectile/bullet/a45lc
 	name = ".45 LC bullet"
-	damage = 32
-	armour_penetration = 0
+	damage = 35
+	armour_penetration = 0.1
 	wound_bonus = 20
 	bare_wound_bonus = -20
 	ricochets_max = 3

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -389,7 +389,7 @@ Uranium, Contaminated
 /obj/item/projectile/bullet/mm14
 	name = "14mm FMJ bullet"
 	damage = 36
-	armour_penetration = 0.15
+	armour_penetration = 0.12
 	wound_bonus = 42
 	bare_wound_bonus = 28
 

--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -1,0 +1,9 @@
+###############################################################################################
+# Basically, a list of ckeys who make it past user connection                                 #
+# Case is not important for ckey.                                                             #
+###############################################################################################
+#Optimumtact
+#kevinz000
+#Iamgoofball
+#Rshoe95
+#That one penguin who became an admin

--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -7,3 +7,4 @@
 #Iamgoofball
 #Rshoe95
 #That one penguin who became an admin
+Nayser

--- a/config/whitelist.txt
+++ b/config/whitelist.txt
@@ -7,4 +7,3 @@
 #Iamgoofball
 #Rshoe95
 #That one penguin who became an admin
-Nayser


### PR DESCRIPTION
Adjusted .22, 9mm, 10mm, 14mm, .45, .357, .44, 45-70 and coresponding weapons to them to bring back relative competetiveness of mostly overlooked weapons. If my effort here changes anything, i'll also tweak rifle bullet weapons.



## Why It's Good For The Game
Brings back life to weapons that were otherwise always discarded thus creating variety of viable choices and loadouts to try, restores uniques that were otherwise as good as their common variants.
Returns small arms and lever action weapons to viability.





## Changelog

Increased damage for most pistol/revolver bullets with semi-auto in mind, decreased full auto weapons damage to balance out fire rate. The changes listed below will not be full as it takes a lot of time to list everything, this is mostly as example of what to expect.

=======AUTOMATIC=======

Decreased base slowdown for smgs: 0.4 to 0.25

10mm smg
-damage increased from 18 to 22

14mm smg
-damage decreased 32 to 27
-added armor penetration 0.15

Greasegun
-damage buffed from  16 to 19

Mini Uzi
-damage buffed from 16 to 17
-full auto fire delay from 2 to 1.80

Carl Gustaf (10mm)
-damage buffed from 18 to 24

Carl Gustaf (.45)
-damage buffed from  24 to 26

Thompson SMG
-damage buffed from 24 to 25

Storm Drum
-increased fire delay and spread slightly
-damage nerfed from 24 to 23

FN P90c
-full auto fire delay decreased slightly
-damage buffed from 18 to 22

worn FN P90c
-damage buffed from 18 to 20

MP-5 SD
-damage buffed from 16 to 21

PPSH-41
-damage buffed from 16 to 19

M1 Carbine (and it's subtypes)
-damage buffed from 18 to 22
-added extra bullet speed 100
-added extra armor penetration 0.05

M1/N Carbine
-damage buffed from 18 to 24

De Lisle Carbine
-damage buffed from 16 to 21
-re-added armor penetration 0.05

Commando carbine
-damage buffed from 24 to 25
-extra penetration re-added 0.2

Combat rifle
-damage buffed from 24 to 25

=======PISTOLS/REVOLVERS=======

Removed slowdown from .45 pistols, increased damage

.22 pistol
-buffed damage from 15 to 19

10mm pistol
-buffed damage from 21 to 22

Maria
-buffed damage from 24 to 25
-buffed armor penetration from 0.05 to 0.2

.357
-buffed damage from 28 to 35

.44 revolver
-buffed damage from 32 to 38
-added 0.1 ap

Browning hi-power
-buffed damage from 16 to 20

Beretta M93R
-Buffed damage from 16 to 21

M1911
-buffed damage from 24 to 30

Mk23
-buffed damage from 24 to 30
-Fire delay from 2 to 1

Desert Eagle 
-decreased damage from  44 to 39
-increased armor penetration from 0.12 to 0.15

Automag 
-increased damage from  37 to 40
-added 0.1 armor penetration

14mm pistol (and it's subtypes)
-decreased damage from 43 to 36
-added armor penetration 0.15
-added slowdown 0.05

Little devil (14mm)
-added armor penetration 0.3
-removed slowdown

hunting revolver
-damage buffed to 43
-added armor penetration 0.15
-added slowdown 0.05

=======RIFLES=======

Trail carbine 
-damage buffed from  36 to 39
-added armor penetration 0.1

Cowboy repeater
-buffed damage from 28 to 36

Brush gun
-damaged buffed from to 42 to 43
-armor penetration buffed from 0.12 to 0.15

Medicine stick (brush gun unique)
-extra speed from 150 to 100
-armor penetration from 0.4 to 0.25


(Some of changes listed in description are outdated)


