### PR TITLE
Miscellaneous Changes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -283,6 +283,7 @@
 /area/f13/enclave)
 "cs" = (
 /obj/machinery/autolathe/ammo/unlocked,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "ct" = (
@@ -523,7 +524,8 @@
 /obj/item/clothing/shoes/combat/coldres,
 /obj/item/clothing/shoes/combat/coldres,
 /obj/item/clothing/shoes/combat/coldres,
-/turf/open/floor/f13,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "ej" = (
 /obj/structure/table/glass,
@@ -576,6 +578,11 @@
 /area/f13/mountain_area)
 "eE" = (
 /obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/enclave)
+"eH" = (
+/obj/structure/decoration/vent,
+/obj/item/locked_box/misc/seed,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
 "eL" = (
@@ -857,6 +864,7 @@
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "hb" = (
@@ -867,6 +875,7 @@
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "hd" = (
@@ -1266,6 +1275,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/wood_common,
 /area/f13/building)
+"jE" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/enclave)
 "jH" = (
 /obj/structure/sign/plaques,
 /turf/closed/wall/r_wall/f13/vault,
@@ -1301,12 +1315,14 @@
 /area/f13/enclave)
 "jU" = (
 /obj/machinery/ammobench,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "jV" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "jY" = (
@@ -1404,6 +1420,7 @@
 	req_access_txt = "134"
 	},
 /obj/effect/spawner/bundle/f13/ionrifle,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "kF" = (
@@ -1887,6 +1904,7 @@
 /obj/item/gun/energy/laser/pistol,
 /obj/item/gun/energy/laser/pistol,
 /obj/item/gun/energy/laser/pistol,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "ov" = (
@@ -1944,6 +1962,7 @@
 /obj/item/grenade/f13/incendiary,
 /obj/item/grenade/f13/incendiary,
 /obj/item/grenade/f13/incendiary,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "oO" = (
@@ -1999,6 +2018,7 @@
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "pd" = (
@@ -2138,9 +2158,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/item/shield/riot/tele,
-/obj/item/shield/riot/tele,
-/obj/item/shield/riot/tele,
 /obj/item/melee/classic_baton/telescopic,
 /obj/item/melee/classic_baton/telescopic,
 /obj/item/melee/classic_baton/telescopic,
@@ -2247,6 +2264,17 @@
 "qU" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/enclave)
+"qW" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/card/id/syndicate/anyone,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "qY" = (
 /obj/machinery/grill,
@@ -2385,6 +2413,7 @@
 /obj/item/gun/ballistic/automatic/assault_carbine,
 /obj/item/gun/ballistic/automatic/assault_carbine,
 /obj/item/gun/ballistic/automatic/assault_carbine,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "rQ" = (
@@ -2445,6 +2474,7 @@
 /obj/item/grenade/f13/frag,
 /obj/item/grenade/f13/frag,
 /obj/item/grenade/f13/frag,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "sh" = (
@@ -2746,6 +2776,7 @@
 /obj/item/ammo_box/magazine/m5mm,
 /obj/item/ammo_box/magazine/m5mm,
 /obj/item/ammo_box/magazine/m5mm,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/enclave)
 "tY" = (
@@ -2903,6 +2934,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/spawner/bundle/f13/needler,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "va" = (
@@ -2914,7 +2946,8 @@
 	dir = 4
 	},
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/f13,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "vd" = (
 /obj/structure/window/reinforced/fulltile,
@@ -3076,7 +3109,8 @@
 /area/f13/enclave)
 "wk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/f13,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "wm" = (
 /obj/structure/decoration/warning{
@@ -3159,6 +3193,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/structure/window/reinforced,
 /obj/effect/spawner/bundle/f13/needler,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "wU" = (
@@ -3173,6 +3208,7 @@
 /obj/item/grenade/f13/plasma,
 /obj/item/grenade/f13/plasma,
 /obj/item/grenade/f13/plasma,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "wV" = (
@@ -3274,6 +3310,8 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/spawner/bundle/f13/needler,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "xB" = (
@@ -3777,6 +3815,7 @@
 /obj/item/clothing/suit/armor/f13/combat/enclave,
 /obj/item/clothing/head/helmet/f13/combat/enclave,
 /obj/item/storage/belt/military,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
 "Bh" = (
@@ -4077,6 +4116,7 @@
 /area/f13/enclave)
 "DJ" = (
 /obj/machinery/door/airlock/survival_pod/glass{
+	locked = 1;
 	req_access_txt = "134"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -4128,11 +4168,18 @@
 /turf/open/indestructible/ground/outside/snow_plating,
 /area/f13/mountain_area)
 "DX" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/mask/chameleon,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "Eb" = (
 /obj/structure/window/reinforced{
@@ -4233,6 +4280,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "EL" = (
@@ -4312,7 +4361,6 @@
 /area/f13/enclave)
 "Fj" = (
 /obj/structure/table/glass,
-/obj/item/shield/riot/tele,
 /obj/item/melee/classic_baton/telescopic,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
@@ -4487,6 +4535,7 @@
 /area/f13/building)
 "GG" = (
 /obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "GN" = (
@@ -5088,6 +5137,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "Lg" = (
@@ -5168,6 +5219,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "LS" = (
@@ -5360,6 +5413,7 @@
 "NT" = (
 /obj/machinery/workbench/advanced,
 /obj/item/crafting/reloader,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
 "NU" = (
@@ -5408,14 +5462,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Om" = (
-/obj/machinery/door/airlock/hatch{
-	locked = 1;
-	req_access_txt = "134"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/airlock/hatch{
+	req_access = null;
+	req_access_txt = "134"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "Oo" = (
@@ -5963,6 +6016,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
 "Sy" = (
@@ -6752,6 +6807,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/locked_box/medical/medicine,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "YH" = (
@@ -16367,11 +16423,11 @@ Sm
 Sm
 HP
 mA
-oO
+Jx
 EK
 Lf
 Sx
-oO
+Jx
 mA
 Ny
 Ny
@@ -16624,11 +16680,11 @@ Sm
 Sm
 HP
 mA
-oO
-oO
-LP
-oO
-oO
+Jx
+Jx
+RG
+Jx
+Jx
 mA
 KA
 Ny
@@ -16881,11 +16937,11 @@ Sm
 Sm
 HP
 mA
-oO
-oO
+Jx
+jE
 LP
-oO
-oO
+jE
+Jx
 mA
 Ny
 Ny
@@ -17138,11 +17194,11 @@ PF
 PF
 zE
 mA
-DX
-oO
-LP
-oO
-DX
+DU
+Jx
+RG
+Jx
+DU
 mA
 yE
 XN
@@ -24839,7 +24895,7 @@ rP
 tV
 AH
 AW
-GZ
+DX
 NX
 eh
 AW
@@ -25096,7 +25152,7 @@ FJ
 FJ
 zK
 AW
-Jx
+qW
 RG
 Jx
 Ir
@@ -27451,10 +27507,10 @@ SP
 SP
 Lq
 Lg
-BC
+eH
 SP
 Lq
-BC
+eH
 AW
 iT
 HA

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -573,7 +573,7 @@
 	time = 25
 	category = CAT_CLOTHING
 	subcategory = CAT_WASTELAND
-
+/*
 /datum/crafting_recipe/triplesurvivalpouch
 	name = "empty large survival pouch"
 	result = /obj/item/storage/survivalkit_triple_empty
@@ -582,7 +582,7 @@
 	time = 25
 	category = CAT_CLOTHING
 	subcategory = CAT_WASTELAND
-
+*/
 //General clothing
 
 /datum/crafting_recipe/jeans

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -530,7 +530,7 @@
 			if(stun_animation)
 				user.do_attack_animation(target)
 			playsound(get_turf(src), on_stun_sound, 75, 1, -1)
-			target.adjustStaminaLoss(30)
+			target.adjustStaminaLoss(60)
 			additional_effects_carbon(target, user)
 			add_fingerprint(user)
 			target.visible_message(desc["visible"], desc["local"])

--- a/code/game/objects/items/storage/survivalkit.dm
+++ b/code/game/objects/items/storage/survivalkit.dm
@@ -133,6 +133,10 @@
 	icon_state = "survivalkit"
 	w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/storage/survivalkit_empty/PopulateContents()
+	. = ..()
+
+/*
 /obj/item/storage/survivalkit_triple_empty
 	name = "large survival kit"
 	desc = "A large, robust leather pouch containing the essentials for wasteland survival. Holds three times as much."
@@ -145,6 +149,4 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 21
 	STR.max_combined_w_class = 42
-
-/obj/item/storage/survivalkit_empty/PopulateContents()
-	. = ..()
+*/


### PR DESCRIPTION
- - -
Balance:
 - Stamina damage on batons upped to sixty, from thirty. This is probably a horrible idea, but we'll try it.
 - Large survival kits temporarily removed.
 - Enclave access to chameleon masks and IDs returned.
 - Enclave IS loses telescopic shields.
- - -
Map:
 - Enclave given personal lockers again.
- - -