### PR TITLE
Making plasma great again

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -502,7 +502,7 @@
 	name = "plasma stream"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 20
+	damage = 35
 	flag = "energy" //checks vs. energy protection
 	eyeblur = 0
 	is_reflectable = FALSE
@@ -511,7 +511,7 @@
 	name = "mining plasma stream"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 5
+	damage = 35
 	flag = "energy"
 	eyeblur = 0
 	is_reflectable = FALSE


### PR DESCRIPTION
Makes the plasma beam used by repeaters powerful again. The mining version did 5 damage, and the repeater did 10 less, the mining beam has been restored to it's previous damage, and the normal version has been buffed to it's damage as well, the idea is to use them for an automatic plasma weapon (plasma caster?)