### PR TITLE
Sanitize most string interpolations in queries

### DIFF
--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -286,9 +286,10 @@
 					to_chat(usr, "Cancelled")
 					return
 
+			var/edit_string = "- [e_key] changed ban reason from <cite><b>\\\"[reason]\\\"</b></cite> to <cite><b>\\\"[value]\\\"</b></cite><BR>"
 			var/datum/db_query/query_edit_ban_reason = SSdbcore.NewQuery(
-				"UPDATE [format_table_name("ban")] SET reason = :reason, edits = CONCAT(edits,'- [e_key] changed ban reason from <cite><b>\\\"[reason]\\\"</b></cite> to <cite><b>\\\"[value]\\\"</b></cite><BR>') WHERE id = [banid]",
-				list("reason" = value)
+				"UPDATE [format_table_name("ban")] SET reason = :reason, edits = CONCAT(edits, :edit_string) WHERE id = :banid",
+				list("reason" = value, "edit_string" = edit_string, "banid" = banid)
 			)
 			if(!query_edit_ban_reason.warn_execute())
 				qdel(query_edit_ban_reason)
@@ -302,7 +303,11 @@
 					to_chat(usr, "Cancelled")
 					return
 
-			var/datum/db_query/query_edit_ban_duration = SSdbcore.NewQuery("UPDATE [format_table_name("ban")] SET duration = [value], edits = CONCAT(edits,'- [e_key] changed ban duration from [duration] to [value]<br>'), expiration_time = DATE_ADD(bantime, INTERVAL [value] MINUTE) WHERE id = [banid]")
+			var/edit_string = "- [e_key] changed ban duration from [duration] to [value]<br>"
+			var/datum/db_query/query_edit_ban_duration = SSdbcore.NewQuery(
+				"UPDATE [format_table_name("ban")] SET duration = :value, edits = CONCAT(edits, :edit_string), expiration_time = DATE_ADD(bantime, INTERVAL :value MINUTE) WHERE id = :banid",
+				list("value" = value, "edit_string" = edit_string, "banid" = banid)
+			)
 			if(!query_edit_ban_duration.warn_execute())
 				qdel(query_edit_ban_duration)
 				return

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -94,15 +94,18 @@
 
 		var/ipquery = ""
 		var/cidquery = ""
+		var/list/ban_params = list("ckey" = ckey)
 		if(address)
-			ipquery = " OR ip = INET_ATON('[address]') "
+			ipquery = " OR ip = INET_ATON(:address) "
+			ban_params["address"] = address
 
 		if(computer_id)
-			cidquery = " OR computerid = '[computer_id]' "
+			cidquery = " OR computerid = :computer_id "
+			ban_params["computer_id"] = computer_id
 
 		var/datum/db_query/query_ban_check = SSdbcore.NewQuery(
 			"SELECT IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].ckey), ckey), IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].a_ckey), a_ckey), reason, expiration_time, duration, bantime, bantype, id, round_id FROM [format_table_name("ban")] WHERE ( ckey = :ckey [ipquery] [cidquery]) AND (bantype = 'PERMABAN' OR bantype = 'ADMIN_PERMABAN' OR ((bantype = 'TEMPBAN' OR bantype = 'ADMIN_TEMPBAN') AND expiration_time > Now())) AND isnull(unbanned)",
-			list("ckey" = ckey)
+			ban_params
 		)
 		if(!query_ban_check.Execute(async = TRUE))
 			qdel(query_ban_check)

--- a/code/modules/admin/create_poll.dm
+++ b/code/modules/admin/create_poll.dm
@@ -34,7 +34,10 @@
 	var/endtime = input("Set end time for poll as format YYYY-MM-DD HH:MM:SS. All times in server time. HH:MM:SS is optional and 24-hour. Must be later than starting time for obvious reasons.", "Set end time", SQLtime()) as text
 	if(!endtime)
 		return
-	var/datum/db_query/query_validate_time = SSdbcore.NewQuery("SELECT IF(STR_TO_DATE('[endtime]','%Y-%c-%d %T') > NOW(), STR_TO_DATE('[endtime]','%Y-%c-%d %T'), 0)")
+	var/datum/db_query/query_validate_time = SSdbcore.NewQuery(
+		"SELECT IF(STR_TO_DATE(:endtime,'%Y-%c-%d %T') > NOW(), STR_TO_DATE(:endtime,'%Y-%c-%d %T'), 0)",
+		list("endtime" = endtime)
+	)
 	if(!query_validate_time.warn_execute() || QDELETED(usr) || !src)
 		qdel(query_validate_time)
 		return
@@ -115,7 +118,8 @@
 					return 0
 	var/m1 = "[key_name(usr)] has created a new server poll. Poll type: [polltype] - Admin Only: [adminonly ? "Yes" : "No"] - Question: [question]"
 	var/m2 = "[key_name_admin(usr)] has created a new server poll. Poll type: [polltype] - Admin Only: [adminonly ? "Yes" : "No"]<br>Question: [question]"
-	var/datum/db_query/query_polladd_question = SSdbcore.NewQuery("INSERT INTO [format_table_name("poll_question")] (polltype, starttime, endtime, question, adminonly, multiplechoiceoptions, createdby_ckey, createdby_ip, dontshow) VALUES ('[polltype]', '[starttime]', '[endtime]', '[question]', '[adminonly]', '[choice_amount]', '[ckey]', INET_ATON('[address]'), '[dontshow]')")
+	var/datum/db_query/query_polladd_question = SSdbcore.NewQuery("INSERT INTO [format_table_name("poll_question")] (polltype, starttime, endtime, question, adminonly, multiplechoiceoptions, createdby_ckey, createdby_ip, dontshow) VALUES (:polltype, :starttime, :endtime, :question, :adminonly, :choice_amount, :ckey, INET_ATON(:address), :dontshow)",
+	list("polltype" = polltype, "starttime" = starttime, "endtime" = endtime, "question" = question, "adminonly" = adminonly, "choice_amount" = choice_amount, "ckey" = ckey, "address" = address, "dontshow" = dontshow))
 	if(!query_polladd_question.warn_execute())
 		qdel(query_polladd_question)
 		return

--- a/code/modules/admin/ipintel.dm
+++ b/code/modules/admin/ipintel.dm
@@ -67,7 +67,9 @@
 	if (updatecache && res.intel >= 0)
 		SSipintel.cache[ip] = res
 		if(SSdbcore.Connect())
-			var/datum/db_query/query_add_ip_intel = SSdbcore.NewQuery("INSERT INTO [format_table_name("ipintel")] (ip, intel) VALUES (INET_ATON('[ip]'), [res.intel]) ON DUPLICATE KEY UPDATE intel = VALUES(intel), date = NOW()")
+			var/datum/db_query/query_add_ip_intel = SSdbcore.NewQuery(
+				"INSERT INTO [format_table_name("ipintel")] (ip, intel) VALUES (INET_ATON(:ip), :resintel) ON DUPLICATE KEY UPDATE intel = VALUES(intel), date = NOW()",
+				list("ip" = ip, "resintel" = res.intel))
 			query_add_ip_intel.Execute()
 			qdel(query_add_ip_intel)
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -419,7 +419,10 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 					else
 
 						var/msg = "[key_name(usr)] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs"
-						var/datum/db_query/query_library_upload = SSdbcore.NewQuery("INSERT INTO [format_table_name("library")] (author, title, content, category, ckey, datetime, round_id_created) VALUES ('[scanner.cache.author]', '[scanner.cache.name]', '[scanner.cache.dat]', '[upload_category]', '[usr.ckey]', Now(), '[GLOB.round_id]')")
+						var/datum/db_query/query_library_upload = SSdbcore.NewQuery(
+							"INSERT INTO [format_table_name("library")] (author, title, content, category, ckey, datetime, round_id_created) VALUES (:author, :name, :dat, :upload_category, :ckey, Now(), :roundid)",
+							list("author" = scanner.cache.author, "name" = scanner.cache.name, "dat" = scanner.cache.dat, "upload_category" = upload_category, "ckey" = usr.ckey, "roundid" = GLOB.round_id)
+						)
 						if(!query_library_upload.Execute())
 							qdel(query_library_upload)
 							alert("Database error encountered uploading to Archive")

--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -48,8 +48,8 @@
 	switch(polltype)
 		if(POLLTYPE_OPTION)
 			var/datum/db_query/query_option_get_votes = SSdbcore.NewQuery(
-				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = [pollid] AND ckey = :ckey",
-				list("ckey" = ckey)
+				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = :pollid AND ckey = :ckey",
+				list("ckey" = ckey, "pollid" = pollid)
 			)
 			if(!query_option_get_votes.warn_execute())
 				qdel(query_option_get_votes)
@@ -96,8 +96,8 @@
 			src << browse(output,"window=playerpoll;size=500x250")
 		if(POLLTYPE_TEXT)
 			var/datum/db_query/query_text_get_votes = SSdbcore.NewQuery(
-				"SELECT replytext FROM [format_table_name("poll_textreply")] WHERE pollid = [pollid] AND ckey = :ckey",
-				list("ckey" = ckey)
+				"SELECT replytext FROM [format_table_name("poll_textreply")] WHERE pollid = :pollid AND ckey = :ckey",
+				list("ckey" = ckey, "pollid" = pollid)
 			)
 			if(!query_text_get_votes.warn_execute())
 				qdel(query_text_get_votes)
@@ -127,8 +127,8 @@
 			src << browse(output,"window=playerpoll;size=500x500")
 		if(POLLTYPE_RATING)
 			var/datum/db_query/query_rating_get_votes = SSdbcore.NewQuery(
-				"SELECT o.text, v.rating FROM [format_table_name("poll_option")] o, [format_table_name("poll_vote")] v WHERE o.pollid = [pollid] AND v. ckey = :ckey AND o.id = v.optionid",
-				list("ckey" = ckey)
+				"SELECT o.text, v.rating FROM [format_table_name("poll_option")] o, [format_table_name("poll_vote")] v WHERE o.pollid = :pollid AND v.ckey = :ckey AND o.id = v.optionid",
+				list("ckey" = ckey, "pollid" = pollid)
 			)
 			if(!query_rating_get_votes.warn_execute())
 				qdel(query_rating_get_votes)
@@ -187,8 +187,8 @@
 				src << browse(output,"window=playerpoll;size=500x500")
 		if(POLLTYPE_MULTI)
 			var/datum/db_query/query_multi_get_votes = SSdbcore.NewQuery(
-				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = [pollid] AND ckey = :ckey",
-				list("ckey" = ckey)
+				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = :pollid AND ckey = :ckey",
+				list("ckey" = ckey, "pollid" = pollid)
 			)
 			if(!query_multi_get_votes.warn_execute())
 				qdel(query_multi_get_votes)
@@ -245,8 +245,8 @@
 			irv_assets.send(src)
 
 			var/datum/db_query/query_irv_get_votes = SSdbcore.NewQuery(
-				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = [pollid] AND ckey = :ckey",
-				list("ckey" = ckey)
+				"SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = :pollid AND ckey = :ckey",
+				list("ckey" = ckey, "pollid" = pollid)
 			)
 			if(!query_irv_get_votes.warn_execute())
 				qdel(query_irv_get_votes)
@@ -370,8 +370,8 @@
 		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
 	var/datum/db_query/query_hasvoted = SSdbcore.NewQuery(
-		"SELECT id FROM `[format_table_name(table)]` WHERE pollid = [pollid] AND ckey = :ckey",
-		list("ckey" = ckey)
+		"SELECT id FROM `[format_table_name(table)]` WHERE pollid = :pollid AND ckey = :ckey",
+		list("ckey" = ckey, pollid = "pollid")
 	)
 	if(!query_hasvoted.warn_execute())
 		qdel(query_hasvoted)
@@ -592,8 +592,8 @@
 	if (!vote_valid_check(pollid, client.holder, POLLTYPE_RATING))
 		return 0
 	var/datum/db_query/query_numval_hasvoted = SSdbcore.NewQuery(
-		"SELECT id FROM [format_table_name("poll_vote")] WHERE optionid = [optionid] AND ckey = :ckey",
-		list("ckey" = ckey)
+		"SELECT id FROM [format_table_name("poll_vote")] WHERE optionid = :optionid AND ckey = :ckey",
+		list("ckey" = ckey, "optionid" = optionid)
 	)
 	if(!query_numval_hasvoted.warn_execute())
 		qdel(query_numval_hasvoted)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -366,8 +366,8 @@
 	if(!SSdbcore.Connect())
 		return
 	var/datum/db_query/query_round_shuttle_name = SSdbcore.NewQuery(
-		"UPDATE [format_table_name("round")] SET shuttle_name = :shuttle_name WHERE id = [GLOB.round_id]",
-		list("shuttle_name" = name)
+		"UPDATE [format_table_name("round")] SET shuttle_name = :shuttle_name WHERE id = :id",
+		list("shuttle_name" = name, "id" = GLOB.round_id)
 	)
 	query_round_shuttle_name.Execute()
 	qdel(query_round_shuttle_name)


### PR DESCRIPTION
## About The Pull Request
Technically it's less sanitizing and more using the [Rust mysql crate's named parameters](https://docs.rs/mysql/latest/mysql/#named-parameters) and rust-g's SQL handling to make prepared statements not a pain in the ass, but this also happens to prevent SQL injection, which is "sanitized" enough for me even though we're not really doing any input processing or anything.

## Why It's Good For The Game
Quotes in ban edit reasons won't cause the entire statement to explode.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

(I can't be assed to set up a local database and run through all of these functions just for testing this, honestly.)