### PR TITLE
Knight Cavalry trekking (at a loadout disadvantage)

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -708,7 +708,7 @@ Scribe
 		)
 
 /*
-Senior Knight
+Knight C
 */
 
 /datum/job/bos/f13seniorknight
@@ -917,12 +917,13 @@ Knight
 /datum/outfit/loadout/knightc
 	name = "Junior Knight-Cavalry"
 	backpack_contents = list(
-		/obj/item/clothing/accessory/bos/juniorknight=1,
-		/obj/item/melee/powered/ripper=1,
-		/obj/item/gun/energy/laser/pistol=1,
-		/obj/item/stock_parts/cell/ammo/ec=2,
-		/obj/item/clothing/accessory/bos/KnightC=1,
-		/obj/item/clothing/accessory/bos/KnightT=1,
+		/obj/item/book/granter/trait/trekking = 1,
+		/obj/item/clothing/accessory/bos/juniorknight = 1,
+		/obj/item/clothing/accessory/bos/KnightC = 1,
+		/obj/item/clothing/accessory/bos/KnightT = 1,
+		/obj/item/attachments/scope = 1,
+		/obj/item/gun/energy/laser/pistol/cavalier = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		)
 
 
@@ -953,10 +954,11 @@ Knight
 /datum/outfit/loadout/knightf
 	name = "Knight-Cavalry"
 	backpack_contents = list(
+		/obj/item/book/granter/trait/trekking = 1,
 		/obj/item/clothing/accessory/bos/knight=1,
-		/obj/item/melee/powered/ripper=1,
-		/obj/item/gun/energy/laser/pistol=1,
-		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/attachments/scope = 1,
+		/obj/item/gun/energy/laser/pistol/cavalier = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
 		/obj/item/clothing/accessory/bos/KnightC=1,
 		/obj/item/clothing/accessory/bos/KnightT=1,
 		)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -708,7 +708,7 @@ Scribe
 		)
 
 /*
-Knight C
+Knight Captain
 */
 
 /datum/job/bos/f13seniorknight

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -281,6 +281,11 @@
 	cell_type = /obj/item/stock_parts/cell/secborg
 	charge_delay = 3
 
+/obj/item/gun/energy/laser/pistol/cavalier
+	name = "\improper AEP7 scout pistol"
+	slowdown = 0.05
+	can_scope = TRUE
+
 /obj/item/gun/energy/laser/pistol/cyborg/gutsy
 	name = "\improper integrated laser pistol"
 	desc = "An integrated laser pistol that draws power directly from your cell."

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -283,6 +283,7 @@
 
 /obj/item/gun/energy/laser/pistol/cavalier
 	name = "\improper AEP7 scout pistol"
+	desc = "A basic energy-based laser gun that fires concentrated beams of light. This one bears the mark of the Brotherhood of Steel, and has a scope mount. Most of its frame has been replaced with superlight alloy."
 	slowdown = 0.05
 	can_scope = TRUE
 


### PR DESCRIPTION
I got into a Discord argument on why BOS shouldn't have trekking with another admin
I ended up making this.

**Knight-Cavalry**
RIPPER REMOVED
ADDED SCOPE-ABLE, LOW SLOWDOWN AEP7
ADDED TREKKING