### PR TITLE
Properly tweaks parrying

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -26,29 +26,6 @@
 // SWORDS //
 ////////////		-block, 34-39 damage
 
-
-/obj/item/melee/onehanded/dragonfire
-	name = "Dragonfire Katana"
-	desc = "After the world ended, seppuku rates in Japan skyrocketed, the owner of this one however is crazy enough to keep going!"
-	icon_state = "DFkatana"
-	item_state = "DFkatana"
-	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	flags_1 = CONDUCT_1
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 30
-	throwforce = 10
-	w_class = WEIGHT_CLASS_BULKY
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	sharpness = SHARP_EDGED
-	max_integrity = 200
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
-	resistance_flags = FIRE_PROOF
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
-
-
-
 /obj/item/melee/onehanded/machete
 	name = "simple machete"
 	desc = "A makeshift machete made of a lawn mower blade."
@@ -67,6 +44,7 @@
 	force = 35
 	wound_bonus = 20
 	block_chance = 8
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 
 /obj/item/melee/onehanded/machete/training
 	name = "training machete"
@@ -90,6 +68,7 @@
 	item_state = "gladius"
 	force = 36
 	wound_bonus = 30
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	block_chance = 10
 
 /obj/item/melee/onehanded/machete/spatha
@@ -212,6 +191,7 @@
 	item_state = "knife_trench"
 	desc = "This blade is designed for brutal close quarters combat."
 	force = 31
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file //Also gives trench knife an actual advantage
 	custom_materials = list(/datum/material/iron=8000)
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -39,6 +39,7 @@
 	desc = "Heavy fireman axe from the old world, Restored to working order by legion craftsmen. Excellent for smashing doors or heads."
 	icon_state = "legionaxe"
 	icon_prefix = "legionaxe"
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	force = 30
 	throwforce = 15
 	wound_bonus = 10
@@ -154,6 +155,7 @@
 	wound_bonus = null
 	sharpness = SHARP_NONE
 	resistance_flags = null
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 
 /obj/item/twohanded/fireaxe/bmprsword/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
@@ -182,6 +184,7 @@
 	icon_prefix = "spear-metal"
 	force = 10
 	throwforce = 30
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	throw_speed = 4
 	embedding = list("embed_chance" = 0)
 	max_reach = 2
@@ -463,6 +466,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	damtype = "fire"
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	force = 5
 	armour_penetration = 0.1
 	throwforce = 5
@@ -507,6 +511,7 @@
 	righthand_file = 'icons/fallout/onmob/weapons/melee2h_righthand.dmi'
 	icon_state = "protonaxe"
 	icon_state_on = "protonaxe_on"
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = null
 	force = 20
@@ -527,6 +532,7 @@
 	desc = "A heavy sledgehammer manufacted from ultra-dense materials, developed by the Brotherhood of Steel. It looks like it could crush someone's skull with ease."
 	icon_state = "hammer-super"
 	icon_prefix = "hammer-super"
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	force = 25
 
 /obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
@@ -631,6 +637,7 @@
 	icon_prefix = "hammer-war"
 	force = 25
 	throwforce = 20
+	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file
 	armour_penetration = 0.2
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
 

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -216,7 +216,7 @@
 	force = 25
 	sharpness = SHARP_EDGED
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
-	block_parry_data = /datum/block_parry_data/captain_saber
+	block_parry_data = /datum/block_parry_data/smith_generic
 	w_class = WEIGHT_CLASS_BULKY
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
@@ -240,21 +240,35 @@
 	force = 24
 	block_chance = 25
 
+/datum/block_parry_data/smith_generic
+	parry_stamina_cost = 12
+	parry_time_active = 6
+	parry_time_perfect = 3
+	parry_time_perfect_leeway = 2
+	parry_failed_stagger_duration = 6 SECONDS
+	parry_failed_clickcd_duration = 5 SECONDS
+	parry_time_windup = 0
+	parry_time_spindown = 0
+	parry_imperfect_falloff_percent = 10
+	parry_efficiency_to_counterattack = 100
+	parry_efficiency_considered_successful = 100
+	parry_efficiency_perfect = 120
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
 
 /datum/block_parry_data/smithsaber
 	parry_stamina_cost = 15
 	parry_time_active = 8
-	parry_time_perfect = 2
+	parry_time_perfect = 4
 	parry_time_perfect_leeway = 2
-	parry_failed_stagger_duration = 3 SECONDS
-	parry_failed_clickcd_duration = 3 SECONDS
+	parry_failed_stagger_duration = 6 SECONDS
+	parry_failed_clickcd_duration = 5 SECONDS
 	parry_time_windup = 0
 	parry_time_spindown = 0
 	parry_imperfect_falloff_percent = 0
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 100
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 4)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
 
 // go for the eyes Boo
 /obj/item/melee/smith/dagger
@@ -279,6 +293,7 @@
 	name = "machete"
 	icon_state = "machete_smith"
 	overlay_state = "hilt_machete"
+	block_parry_data = /datum/block_parry_data/smith_generic
 	force = 24
 	sharpness = SHARP_EDGED
 	wound_bonus = 30
@@ -319,7 +334,7 @@
 	parry_efficiency_considered_successful = 80
 	parry_efficiency_perfect = 120
 	parry_failed_stagger_duration = 3 SECONDS
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.9)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
 
 // Mace - low damage, high AP (25, 0,4)
 /obj/item/melee/smith/mace
@@ -327,6 +342,7 @@
 	icon_state = "mace_smith"
 	overlay_state = "handle_mace"
 	force = 15
+	block_parry_data = /datum/block_parry_data/smith_generic
 
 /obj/item/melee/smith/mace/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -359,19 +375,19 @@
 	bare_wound_bonus = 40
 
 /datum/block_parry_data/smithkatana
-	parry_stamina_cost = 12 //dont miss
+	parry_stamina_cost = 24 //dont miss
 	parry_time_active = 6
 	parry_time_perfect = 3
 	parry_time_perfect_leeway = 3
-	parry_failed_stagger_duration = 3 SECONDS
-	parry_failed_clickcd_duration = 3 SECONDS
+	parry_failed_stagger_duration = 6 SECONDS
+	parry_failed_clickcd_duration = 5 SECONDS
 	parry_time_windup = 0
 	parry_time_spindown = 0
 	parry_imperfect_falloff_percent = 0
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 4)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 0.6)
 
 // Heavy axe, 2H focused chopper 27/54. Can be worn on your back.
 /obj/item/melee/smith/twohand/axe
@@ -385,6 +401,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	layer = MOB_UPPER_LAYER
+	block_parry_data = /datum/block_parry_data/smith_generic
 	wound_bonus = 10
 	bare_wound_bonus = 10
 
@@ -446,6 +463,7 @@
 	max_reach = 2
 	force = 10
 	sharpness = SHARP_POINTY
+	block_parry_data = /datum/block_parry_data/smith_generic
 
 /obj/item/melee/smith/twohand/spear/lance
 	name = "legion lance"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -112,9 +112,6 @@
 /obj/item/storage/box/large/custom_kit/pug/PopulateContents()
 	new /obj/item/melee/transforming/cleaving_saw/old_rusty(src)
 
-/obj/item/storage/box/large/custom_kit/pug2/PopulateContents()
-	new /obj/item/melee/onehanded/dragonfire(src)
-
 /obj/item/storage/box/large/custom_kit/mutie/PopulateContents()
 	new /obj/item/clothing/shoes/f13/mutie/boots(src)
 	new /obj/item/clothing/gloves/f13/mutant/mk2(src)
@@ -124,11 +121,6 @@
 /datum/gear/donator/kits/pug
 	name = "I die to mobs"
 	path = /obj/item/storage/box/large/custom_kit/pug
-	ckeywhitelist = list("puglord777")
-
-/datum/gear/donator/kits/pug2
-	name = "I die to mobsx2"
-	path = /obj/item/storage/box/large/custom_kit/pug2
 	ckeywhitelist = list("puglord777")
 
 /datum/gear/donator/kits/mutie


### PR DESCRIPTION
### THE MAIN CHANGES
**A load of melee weapons can parry now, most of them two handed.
Parrying is more punishing but also doesn't reward a good connection, windows are longer.**

### THE CODE STUFF NOBODY CARES ABOUT
Parries now only apply a single hit when succeeding.
Generic parries have a 10% (per decisecond) effectiveness falloff past their perfect window.

Also removed the cringy katana thing unique item that just exists for some reason.