### PR TITLE
Ungaurantees PA lootdrops

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -437,6 +437,7 @@
 	loot = list(
 				/obj/effect/spawner/bundle/f13/armor/t45d,
 				/obj/effect/spawner/bundle/f13/armor/t51b,
+				/obj/effect/spawner/bundle/f13/armor/t45b_salvaged = 2,
 				)
 
 /obj/effect/spawner/bundle/f13/armor/t45d


### PR DESCRIPTION


## About The Pull Request

Adds salvaged PA to the Tier 5 Armor (Power Armor) spawn, and weights it towards it.

## Why It's Good For The Game

Unguaranteed PA spawns means you no longer know for sure if you're gonna find PA at a certain spot.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
balance: unguarantees PA spawns
/:cl:
