### PR TITLE
Minor Modifications

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -43921,6 +43921,12 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland/museum)
+"pkD" = (
+/obj/item/wrench,
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/city/bighorn)
 "pkJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
@@ -54009,6 +54015,12 @@
 	icon_state = "verticalleftborderright0"
 	},
 /area/f13/building/massfusion)
+"vxt" = (
+/obj/item/multitool,
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/city/bighorn)
 "vxz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -78308,7 +78320,7 @@ fWw
 fWw
 fWw
 qMN
-qMN
+pkD
 qMN
 wok
 ygj
@@ -78565,7 +78577,7 @@ fWw
 fWw
 fWw
 ivP
-qMN
+vxt
 peG
 wok
 ygj

--- a/_maps/pahrump.json
+++ b/_maps/pahrump.json
@@ -1,5 +1,5 @@
 {
-	"map_name": "Yuma",
+	"map_name": "Rawlins, Wyoming",
 	"map_path": "map_files/Pahrump-Sunset",
 	"map_file": [
 		"Dungeons.dmm",

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -13,14 +13,14 @@
 
 /datum/supply_pack/engineering/mfcc
 	name = "Overcharged mfc crate"
-	desc = "Super charged mfc, that was made by one of the few gunsmiths that still knows how to make them."
-	cost = 30000
+	desc = "A singular super charged mfc unit."
+	cost = 30000//We want ammo to be hard to replace. Especially in the case of something like this.
 	contains = list(/obj/item/stock_parts/cell/ammo/mfc/overcharged)
 	crate_name = "MFC experimental crate"
 
 /datum/supply_pack/engineering/mfcr
 	name = "Three mfc crate"
-	desc = "Three mfc's, that was made by one of the few gunsmiths that still knows how to make them."
+	desc = "Three mfc units, pulled from storage and shipped directly to you."
 	cost = 3000
 	contains = list(/obj/item/stock_parts/cell/ammo/mfc,
 					/obj/item/stock_parts/cell/ammo/mfc,
@@ -29,7 +29,7 @@
 
 /datum/supply_pack/engineering/electrion
 	name = "Electron pack crate"
-	desc = "One electron pack, that was made by one of the few gunsmiths that still knows how to make them."
+	desc = "One electron pack, pulled from storage and shipped directly to you."
 	cost = 17500
 	contains = list(/obj/item/stock_parts/cell/ammo/ecp)
 

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -19,7 +19,7 @@
 	icon_state = "missile"
 	ricochets_max = 0 //it's a ROCKET NOT A MISSILE STOP AND GET IT RIGHT AAAAAAAAAAAAAAA
 	damage = 25
-	shrapnel_magnitude = 6
+	shrapnel_magnitude = 2
 
 /obj/item/projectile/bullet/rocket/a84mm_chem/Initialize()
 	. = ..()


### PR DESCRIPTION
- - -
Balance:
 - Chemical rocket shrapnel magnitude dropped from six to two.
- - -
Map:
 - Wrench and multitool now present within the Bighorn reactor area round start.
 - Map name clarified from Yuma to its actual name.
- - -
Other:
 - Minor description changes to two cargo packs.
- - -