### PR TITLE
Surgery Change added dialysis effect to Surgically assisted rejuvenation

### DIFF
--- a/code/modules/surgery/advanced/toxichealing.dm
+++ b/code/modules/surgery/advanced/toxichealing.dm
@@ -12,6 +12,7 @@
 				/datum/surgery_step/close)
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	ignore_clothes = TRUE
 	possible_locs = list(BODY_ZONE_CHEST)
 	requires_bodypart_type = 0
 	requires_trait = "MEDICALGRADUATE"

--- a/code/modules/surgery/advanced/toxichealing.dm
+++ b/code/modules/surgery/advanced/toxichealing.dm
@@ -1,5 +1,5 @@
 /datum/surgery/advanced/toxichealing
-	name = "Surgically assisted rejuvenation (oxygen deprivation & toxicity)"
+	name = "Surgically assisted rejuvenation (oxygen deprivation & toxicity & purge)"
 	desc = "A surgical procedure that helps deal with oxygen  deprivation, and treats parts damaged due to toxic compounds. Works on corpses and alive alike without chemicals."
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/incise,

--- a/code/modules/surgery/advanced/toxichealing.dm
+++ b/code/modules/surgery/advanced/toxichealing.dm
@@ -30,6 +30,10 @@
 	target.heal_bodypart_damage(0,0,30) //Heals stam
 	target.adjustToxLoss(-15, 0, TRUE)
 	target.adjustOxyLoss(-20, 0)
+	for(var/A in target.reagents.reagent_list)
+		var/datum/reagent/R = A
+		if(R != src)
+			target.reagents.remove_reagent(R.type,15)
 	return TRUE
 
 /datum/surgery_step/toxichealing/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/toxichealing.dm
+++ b/code/modules/surgery/advanced/toxichealing.dm
@@ -31,6 +31,7 @@
 	target.heal_bodypart_damage(0,0,30) //Heals stam
 	target.adjustToxLoss(-15, 0, TRUE)
 	target.adjustOxyLoss(-20, 0)
+	target.adjustBruteLoss(0.01, 0) // this is because the game doesnt register the toxins being removed, meaning it counts there over all heal state is still negative. breaking defibs when used on them. quick fix. give light damage to brute.
 	for(var/A in target.reagents.reagent_list)
 		var/datum/reagent/R = A
 		if(R != src)


### PR DESCRIPTION
changed rejuv surgery to also removed reagents. fully purging them from the body even when they are dead
this surgery is a surg_mid so it requires DC journal of medicine to do...which auxilia's get if they go medicus. medics get and follower doctors get

edit : I found this lil bastard that had been giving me an others grief....it was this damn surgery that was breaking defibs before i even touched it. why it was breaking it and why I added. 0.01 brute damage to its step is explained in my last commit.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
