### PR TITLE
Alffd Fluff

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -280,3 +280,34 @@
 	new /obj/item/circuitboard/machine/plantgenes(src)// plant manipulator
 	new /obj/item/stock_parts/manipulator/femto(src)// for gibber, works with clothes on/faster.
 	new /obj/item/stock_parts/matter_bin/bluespace(src)// for gibber. gives most meat.
+
+/datum/gear/donator/kits/transhumanism
+	name = "Half-Synth"
+	path = /obj/item/storage/box/large/custom_kit/transhumanism
+	ckeywhitelist = list ("alffd")
+
+/obj/item/storage/box/large/custom_kit/transhumanism/PopulateContents()
+	var/player = get_mob_by_key("alffd")
+	if(!ishuman(player)) //This should never be true, but who knows.
+		return
+	var/mob/living/carbon/human/P = player
+	implant(player, new /obj/item/organ/tongue/robot/gen2synth(src)) //Robotic voice.
+	implant(player, new /obj/item/organ/ears/cybernetic(src))  //Hearing loss on EMP
+	implant(player, new /obj/item/organ/cyberimp/brain(src)) //Causes a large stun if EMPed.
+	if(cmptext(P.mind.assigned_role, "Enclave Scientist"))
+		implant(player, new /obj/item/organ/lungs/cybernetic/tier2(src)) //Lack of atmos negates any buffs, massive Oxy loss on EMP.
+		implant(player, new /obj/item/organ/liver/cybernetic/upgraded(src)) //Better at filtering toxins, but twice EMP damage.
+		implant(player, new /obj/item/organ/heart/cybernetic/upgraded(src)) //Has epinephrine, heart attack on EMP.
+		implant(player, new /obj/item/organ/cyberimp/arm/toolset(src)) //Does not work on faction doors.
+		implant(player, new /obj/item/organ/cyberimp/chest/nutriment/plus(src)) //Simulates current synth hunger mechanics.
+		implant(player, new /obj/item/organ/cyberimp/chest/reviver(src)) //Reviver implant
+		implant(player, new /obj/item/organ/eyes/robotic/shield(src)) //Welding shield eyes.
+		implant(player, new /obj/item/organ/cyberimp/eyes/hud/medical(src)) //Medical hud for testing xeno-bio monkeys
+	else
+		implant(player, new /obj/item/organ/lungs/cybernetic(src))
+		implant(player, new /obj/item/organ/liver/cybernetic(src))
+		implant(player, new /obj/item/organ/heart/cybernetic(src))
+	qdel(src)
+
+/obj/item/storage/box/large/custom_kit/transhumanism/proc/implant(player, obj/item/organ/I)
+	I.Insert(player, drop_if_replaced = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

This pull request creates a custom loadout option for Alffd that makes a character half-synth on round-start.

This has two different setups, a basic one that would apply to any role and only adds a massive EMP weakness, and an Enclave Scientist one with a larger set of more balance impacting implants that are restricted round-start to a RP-only flagged role.  This should save about 30-45 minutes a round on implants that are used for RP purposes.


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Alffd custom half-synth loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
