### PR TITLE
Stealth nanites, now with stealth

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -15,6 +15,7 @@
 	var/list/datum/nanite_program/protocol/protocols = list() ///Separate list of protocol programs, to avoid looping through the whole programs list when checking for conflicts
 	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
+	var/spreading = FALSE //if TRUE, this is spreading or somehow should be extra detectable
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
 	var/research_id = "SCIENCE"
 
@@ -307,21 +308,22 @@
 			to_chat(user, "<span class='notice'>Saturation: [nanite_volume]/[max_nanites]</span>")
 			return TRUE
 	else
-		to_chat(user, "<span class='info'>NANITES DETECTED</span>")
-		to_chat(user, "<span class='info'>================</span>")
-		to_chat(user, "<span class='info'>Saturation: [nanite_volume]/[max_nanites]</span>")
-		to_chat(user, "<span class='info'>Safety Threshold: [safety_threshold]</span>")
-		to_chat(user, "<span class='info'>Cloud ID: [cloud_id ? cloud_id : "None"]</span>")
-		to_chat(user, "<span class='info'>Cloud Sync: [cloud_active ? "Active" : "Disabled"]</span>")
-		to_chat(user, "<span class='info'>================</span>")
-		to_chat(user, "<span class='info'>Program List:</span>")
-		if(!diagnostics)
-			to_chat(user, "<span class='alert'>Diagnostics Disabled</span>")
-		else
-			for(var/X in programs)
-				var/datum/nanite_program/NP = X
-				to_chat(user, "<span class='info'><b>[NP.name]</b> | [NP.activated ? "Active" : "Inactive"]</span>")
-		return TRUE
+		if(spreading || !stealth)
+			to_chat(user, "<span class='info'>NANITES DETECTED</span>")
+			to_chat(user, "<span class='info'>================</span>")
+			to_chat(user, "<span class='info'>Saturation: [nanite_volume]/[max_nanites]</span>")
+			to_chat(user, "<span class='info'>Safety Threshold: [safety_threshold]</span>")
+			to_chat(user, "<span class='info'>Cloud ID: [cloud_id ? cloud_id : "None"]</span>")
+			to_chat(user, "<span class='info'>Cloud Sync: [cloud_active ? "Active" : "Disabled"]</span>")
+			to_chat(user, "<span class='info'>================</span>")
+			to_chat(user, "<span class='info'>Program List:</span>")
+			if(!diagnostics)
+				to_chat(user, "<span class='alert'>Diagnostics Disabled</span>")
+			else
+				for(var/X in programs)
+					var/datum/nanite_program/NP = X
+					to_chat(user, "<span class='info'><b>[NP.name]</b> | [NP.activated ? "Active" : "Inactive"]</span>")
+			return TRUE
 
 /datum/component/nanites/proc/nanite_ui_data(datum/source, list/data, scan_level)
 	data["has_nanites"] = TRUE

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -235,6 +235,14 @@
 	rogue_types = list(/datum/nanite_program/aggressive_replication, /datum/nanite_program/necrotic)
 	var/spread_cooldown = 0
 
+/datum/nanite_program/spreading/enable_passive_effect()
+	. = ..()
+	nanites.spreading = TRUE
+
+/datum/nanite_program/spreading/disable_passive_effect()
+	. = ..()
+	nanites.spreading = FALSE
+
 /datum/nanite_program/spreading/active_effect()
 	if(world.time < spread_cooldown)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

This PR adds a new variable to nanite datums called "spreading" and modifies health/nanite scanners to not detect nanites marked with the "stealth" variable unless the "spreading" variable is also set.

Spreading is controlled by the spreading nanite program, stealth by the stealth program.


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The only faction in the game with nanite technology is the Enclave, as an always valid faction they tend to go out in disguises without any obvious equipment.  This has been countered by the Brotherhood printing nanite scanners to scan people they don't recognize for nanites so they can valid them.

Two solutions were presented, the first which I have not coded would be to have a nanite scan take 5 or more seconds and allow the person being scanned to break it by moving.  This makes it more painful to use a nanite scanner for its intended use, and does not resolve the underlying problem.  People using nanite scanners pro-actively on wastelanders to determine if they are Enclave without any other evidence, it will just make them suspicious of people who don't submit to a scan, and to use that as evidence to force the issue.

The second, which I have coded here makes it so that if a stealth program is running, the nanites can only be detected by user actions such as dermal buttons, or if they are self-spreading.  This preserves the usefulness of a nanite scanner in preventing a nanite virus, but limits its use as a proactive means of filtering wastelanders on the chance one of them may be an Enclave player.

Those programing nanites can put in a deactivation code to the stealth routine with an auto-restart timer set if they have stealth enabled but still want to use the scanner for its intended purpose.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Stealth nanites can now only be detected if they are actively trying to spread themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
