### PR TITLE
Fix ash storm sounds looping forever

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -47,7 +47,6 @@ require only minor tweaks.
 #define ZTRAIT_ABOVE "Above"
 //boolean - weather types that occur on the level
 #define ZTRAIT_SNOWSTORM "Weather_Snowstorm"
-#define ZTRAIT_ASHSTORM "Weather_Ashstorm"
 #define ZTRAIT_ACIDRAIN "Weather_Acidrain"
 
 // number - bombcap is multiplied by this before being applied to bombs
@@ -81,7 +80,6 @@ require only minor tweaks.
 #define ZTRAITS_SPACE list(ZTRAIT_SPACE_RUINS = TRUE)
 #define ZTRAITS_LAVALAND list(\
 	ZTRAIT_MINING = TRUE, \
-	ZTRAIT_ASHSTORM = TRUE, \
 	ZTRAIT_LAVA_RUINS = TRUE, \
 	ZTRAIT_BOMBCAP_MULTIPLIER = 5, \
 	ZTRAIT_BASETURF = /turf/open/lava/smooth/lava_land_surface)

--- a/code/datums/elements/weather_listener.dm
+++ b/code/datums/elements/weather_listener.dm
@@ -15,12 +15,13 @@
 	. = ..()
 	if(!weather_type)
 		weather_type = w_type
-		sound_change_signals = list(
-			COMSIG_WEATHER_TELEGRAPH(weather_type),
-			COMSIG_WEATHER_START(weather_type),
-			COMSIG_WEATHER_WINDDOWN(weather_type),
-			COMSIG_WEATHER_END(weather_type)
-		)
+		for(var/type in typesof(weather_type))
+			sound_change_signals += list(
+				COMSIG_WEATHER_TELEGRAPH(type),
+				COMSIG_WEATHER_START(type),
+				COMSIG_WEATHER_WINDDOWN(type),
+				COMSIG_WEATHER_END(type)
+			)
 		weather_trait = trait
 		playlist = weather_playlist
 
@@ -46,7 +47,8 @@
 		fitting_z_levels = trait_levels
 	if(!(new_turf?.z in fitting_z_levels))
 		return
-	source.AddComponent(/datum/component/area_sound_manager, playlist, list(), COMSIG_MOB_LOGOUT, sound_change_signals, list(), fitting_z_levels)
+	var/datum/component/our_comp = source.AddComponent(/datum/component/area_sound_manager, playlist, list(), COMSIG_MOB_LOGOUT, fitting_z_levels)
+	our_comp.RegisterSignal(SSdcs, sound_change_signals, /datum/component/area_sound_manager/proc/handle_change)
 
 /datum/element/weather_listener/proc/handle_logout(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -59,7 +59,7 @@
 		return
 	on_start()
 
-/datum/looping_sound/proc/stop(null_parent)
+/datum/looping_sound/proc/stop(null_parent = FALSE)
 	if(null_parent)
 		set_parent(null)
 	if(!timerid)

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -18,11 +18,11 @@
 
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
 	protect_indoors = TRUE
-	target_trait = ZTRAIT_ASHSTORM
+	target_trait = ZTRAIT_SURFACE
 
 	immunity_type = "ash"
 
-	probability = 90
+	probability = 0
 
 	barometer_predictable = TRUE
 	var/list/weak_sounds = list()
@@ -32,8 +32,7 @@
 	var/list/eligible_areas = list()
 	for (var/z in impacted_z_levels)
 		eligible_areas += SSmapping.areas_in_z["[z]"]
-	for(var/i in 1 to eligible_areas.len)
-		var/area/place = eligible_areas[i]
+	for(var/area/place in eligible_areas)
 		if(place.outdoors)
 			weak_sounds[place] = /datum/looping_sound/weak_outside_ashstorm
 			strong_sounds[place] = /datum/looping_sound/active_outside_ashstorm

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -24,10 +24,7 @@
 	usr.reset_perspective(O)
 	usr.control_object = O
 	O.AddElement(/datum/element/weather_listener, /datum/weather/rain, ZTRAIT_SURFACE, GLOB.rain_sounds)
-	O.AddElement(/datum/element/weather_listener, /datum/weather/rain/eventarea, ZTRAIT_SURFACE, GLOB.rain_sounds)
 	O.AddElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
-	O.AddElement(/datum/element/weather_listener, /datum/weather/ash_storm/sandstorm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
-	O.AddElement(/datum/element/weather_listener, /datum/weather/ash_storm/dust_event, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Possess Object") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /proc/release()
@@ -44,10 +41,7 @@
 			H.name = H.get_visible_name()
 
 	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/rain, ZTRAIT_SURFACE, GLOB.rain_sounds)
-	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/rain/eventarea, ZTRAIT_SURFACE, GLOB.rain_sounds)
-	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_ASHSTORM, GLOB.ash_storm_sounds)
-	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/ash_storm/sandstorm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
-	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/ash_storm/dust_event, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
+	usr.control_object.RemoveElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
 	usr.forceMove(get_turf(usr.control_object))
 	usr.reset_perspective()
 	usr.control_object = null

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -103,11 +103,7 @@
 	client.init_verbs()
 
 	AddElement(/datum/element/weather_listener, /datum/weather/rain, ZTRAIT_SURFACE, GLOB.rain_sounds)
-	AddElement(/datum/element/weather_listener, /datum/weather/rain/eventarea, ZTRAIT_SURFACE, GLOB.rain_sounds)
-	AddElement(/datum/element/weather_listener, /datum/weather/snow_storm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
-	AddElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_ASHSTORM, GLOB.ash_storm_sounds)
-	AddElement(/datum/element/weather_listener, /datum/weather/ash_storm/sandstorm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
-	AddElement(/datum/element/weather_listener, /datum/weather/ash_storm/dust_event, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
+	AddElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_SURFACE, GLOB.ash_storm_sounds)
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGGED_IN, src)
 


### PR DESCRIPTION
## About The Pull Request
Taken mostly from https://github.com/tgstation/tgstation/pull/71282. Undoes most of the changes I made to area sound managers, should be much faster and more performant now. Also makes the base ashstorm type have a probability of 0, but also makes it able to be adminspawned in the Wasteland.

## Why It's Good For The Game
It's annoying.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.