### PR TITLE
Make auxmos downloading more robust, add auto-build to precompile script

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -20,6 +20,9 @@ export SPACEMAN_DMM_VERSION=suite-1.7.2
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.7.9
 
+# Auxmos repository name
+export AUXMOS_REPOSITORY=Putnam3145/auxmos
+
 # Auxmos git tag
 export AUXMOS_VERSION=v1.1.1
 

--- a/tools/ci/install_auxmos.sh
+++ b/tools/ci/install_auxmos.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 source dependencies.sh
 
 mkdir -p ~/.byond/bin
-wget -O ~/.byond/bin/libauxmos.so "https://github.com/Putnam3145/auxmos/releases/download/${AUXMOS_VERSION}/libauxmos.so"
+wget -O ~/.byond/bin/libauxmos.so "https://github.com/${AUXMOS_REPOSITORY}/releases/download/${AUXMOS_VERSION}/libauxmos.so"
 chmod +x ~/.byond/bin/libauxmos.so
 ldd ~/.byond/bin/libauxmos.so

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -66,6 +66,28 @@ env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target=i686-un
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd ..
 
+# Auxtools dependencies
+apt-get install -y build-essential g++-multilib libc6-i386 libstdc++6:i386
+
+# Update auxmos
+if [ ! -d "auxmos" ]; then
+	echo "Cloning auxmos..."
+	git clone "https://github.com/${AUXMOS_REPOSITORY}"
+	cd auxmos
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+else
+	echo "Fetching auxmos..."
+	cd auxmos
+	git fetch
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+fi
+
+echo "Deploying auxmos..."
+git checkout "$AUXMOS_VERSION"
+env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo rustc --release --target=i686-unknown-linux-gnu --features "all_reaction_hooks katmos" -- -C target-cpu=native
+mv -f target/i686-unknown-linux-gnu/release/libauxmos.so "$1/libauxmos.so"
+cd ..
+
 # install or update youtube-dl when not present, or if it is present with pip3,
 # which we assume was used to install it
 if ! [ -x "$has_youtubedl" ]; then


### PR DESCRIPTION
## About The Pull Request
- Separates the addition of `AUXMOS_REPOSITORY` to `dependencies.sh` from #721 out into a separate PR.
- Also separates the editing of the precompile script into this PR.

## Why It's Good For The Game
This is so that the game doesn't break if we untestmerge the Auxmos 2.1.1 PR; it can just re-grab the proper version from the repo.

## Pre-Merge Checklist
- [x] You documented all of your changes.