### PR TITLE
Adds spraycan to loadout options

### DIFF
--- a/modular_citadel/code/modules/client/loadout/hands.dm
+++ b/modular_citadel/code/modules/client/loadout/hands.dm
@@ -83,6 +83,10 @@
 /datum/gear/hands/cane
 	name = "cane"
 	path = /obj/item/cane
+	
+/datum/gear/hands/cane
+	name = "spraycan"
+	path = /obj/item/toy/crayon/spraycan
 
 /datum/gear/hands/cigarettes
 	name = "cigarette pack"


### PR DESCRIPTION

## About The Pull Request

Not tested. Should add a spraycan to the item loadout hands category.

## Why It's Good For The Game

Allows people to paint the loadout items they start with regardless of job or proximity to the nearest public clothesmate (Bighorn)
Or just allows you to have graffiti on hand. QoL eitherway because you can just craft these from a workshop.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog
:cl:
add: spraycan to loadout
/:cl:
