### PR TITLE
Davusi dogtag fluff

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -338,4 +338,17 @@
 	new /obj/item/book/granter/trait/bibledog(src) //being able to use the bible
 	new /obj/item/storage/book/bible(src) //Would kinda defeat the point if I don't actually get a bible with it
 
+/datum/gear/donator/kits/davusi
+	name = "Davusi's dogtags"
+	path = /obj/item/storage/box/large/custom_kit/davusi
+	ckeywhitelist = list ("angryblackmandavusi")
 
+/obj/item/card/id/dogtag/donator_davusi
+	name = "Davusi's dogtags"
+	desc = "Worn by Enclave NCOs.  This one belongs to 'Private Davusi' and smells faintly of moonshine."
+	icon_state = "enclavetrooper"
+	item_state = "card-id_leg"
+	assignment = "US dogtags"
+
+/obj/item/storage/box/large/custom_kit/davusi/PopulateContents()
+	new /obj/item/card/id/dogtag/donator_davusi(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request

This adds a pair of Enclave Private dogtags for Davusi as a special loadout, they have no access associated with them.

## Why It's Good For The Game

Devusi, a wastelander.  Jumped aboard a departing Vertibird and managed to convince both POs that he was a Enclave Private returning from the wastes, upon arriving he managed to convince the faction to provide him with access to the armory and an Agent ID with full access to the bunker.  This continued for a good amount of time until discovery, tricking two pilot officers, two sergeants, one enlisted, and an IA officer.

This is to commemorate them tricking high-pop Casper into thinking they were one of them by jumping on a helicopter and shouting about how great the Enclave was.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Davusi dogtags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
