### PR TITLE
Removes a custom kit

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -215,15 +215,6 @@
 /obj/item/storage/box/large/custom_kit/cassidy/PopulateContents()
 	new /obj/item/clothing/gloves/ring/diamond(src)
 
-/datum/gear/donator/kits/tzzshali
-	name = "Tzzshali's Form"
-	path = /obj/item/storage/box/large/custom_kit/tzzshali
-	ckeywhitelist = list ("irkallaepsilon")
-
-/obj/item/storage/box/large/custom_kit/tzzshali/PopulateContents()
-	new /obj/item/clothing/under/misc/polyjumpsuit(src)
-	new /obj/item/clothing/suit/hooded/wintercoat/polychromic(src)
-
 /datum/gear/donator/kits/aim
 	name = "Baghead's Face"
 	path = /obj/item/storage/box/large/custom_kit/aim


### PR DESCRIPTION
This is no longer needed as I am pretty much done with the place and set my mind on other things. Please remove the kit. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

Wat kümmerts den Mond wenn 'ne Töle ihm anheult. Als ob mich dat wat kümmert obs funzt. Geht alle voll fett ma einen abseilen. Lappen. Ohne Scheiß und asideutschen Sarkasmus, sollte klappen, entfernt nur was Unnötiges. Fick die Gammastrahlenpistole.

It should work. 

## Changelog
:cl:
del: The nanite swarm now builds a tower at the southpole or something. In other words removes donor kit as it is no longer needed as the player is no longer active.
/:cl:
