### PR TITLE
Makes bowie and trench knife bayonettable

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -190,6 +190,7 @@
 	item_state = "knife_bowie"
 	desc = "A large clip point fighting knife."
 	force = 30
+	bayonet = TRUE
 	throwforce = 25
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
@@ -199,6 +200,7 @@
 	item_state = "knife_trench"
 	desc = "This blade is designed for brutal close quarters combat."
 	force = 31
+	bayonet = TRUE
 	block_parry_data = /datum/block_parry_data/smith_generic //data is in finished items file //Also gives trench knife an actual advantage
 	custom_materials = list(/datum/material/iron=8000)
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -181,7 +181,8 @@
 	name = "bayonet knife"
 	icon_state = "knife_bayonet"
 	desc = "This weapon is made for stabbing, not much use for other things."
-	force = 26
+	force = 24
+	armour_penetration = 0.12
 	bayonet = TRUE
 
 /obj/item/melee/onehanded/knife/bowie


### PR DESCRIPTION

## About The Pull Request

This could be a huge mistake, not gonna lie, but the damage values between bowie, knife, and trench are just in the 5 damage range. Feel free to contest this PR, this can also be seen as an NCR buff, as most of their weapons are bayonettable.

## Why It's Good For The Game

It's not. The trade-off between the bayonet and the two other high-end combat knives is that it does less damage, no wound but it gets to be at the end of the gun. This would make trench knives and bowie knives a direct upgrade to the bayonet knife without a doubt. If people have better ideas on how we could tune these (IF THIS REQUIRES TUNING AT ALL) this PR can go in the bin, and can always be reverted if it ends up becoming a problem in the server.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
tweak: bowie and trench knife are bayonettable
/:cl:
