### PR TITLE
Tweak parrying and smithed weapons again

### DIFF
--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -17,7 +17,7 @@
 #define RECIPE_SABRE "ffdd" //fold fold draw draw
 #define RECIPE_SWORD "ffdf" // fold fold draw fold
 #define RECIPE_WAKI "fffd" //fold fold fold draw
-#define RECIPE_KATANA "fffff" //fold fold fold fold fold
+#define RECIPE_KATANA "ffffffffff" //fold fold fold fold fold fold fold fold fold fold (seriously)
 
 #define RECIPE_MACE "upu"  //upset punch upset
 #define RECIPE_AXE "udsp" //upset draw shrink punch

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -253,7 +253,7 @@
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 100
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.5)
 
 /datum/block_parry_data/smithsaber
 	parry_stamina_cost = 15
@@ -268,7 +268,7 @@
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 100
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.5)
 
 // go for the eyes Boo
 /obj/item/melee/smith/dagger
@@ -277,7 +277,7 @@
 	overlay_state = "hilt_dagger"
 	w_class = WEIGHT_CLASS_TINY
 	sharpness = SHARP_EDGED
-	force = 24
+	force = 19
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
 /obj/item/melee/smith/dagger/attack(mob/living/carbon/M, mob/living/carbon/user)
@@ -314,15 +314,15 @@
 	icon_state = "waki_smith"
 	overlay_state = "hilt_waki"
 	sharpness = SHARP_EDGED
-	force = 25
+	force = 21
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/waki
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	block_chance = 5
-	wound_bonus = 15
+	wound_bonus = 25
 	bare_wound_bonus = 30
 
-/datum/block_parry_data/waki //like longbokken but worse reflect
+/datum/block_parry_data/waki
 	parry_stamina_cost = 6
 	parry_time_windup = 0
 	parry_time_active = 15 //decent window
@@ -334,21 +334,21 @@
 	parry_efficiency_considered_successful = 80
 	parry_efficiency_perfect = 120
 	parry_failed_stagger_duration = 3 SECONDS
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.5)
 
 // Mace - low damage, high AP (25, 0,4)
 /obj/item/melee/smith/mace
 	name = "mace"
 	icon_state = "mace_smith"
 	overlay_state = "handle_mace"
-	force = 15
+	force = 17
 	block_parry_data = /datum/block_parry_data/smith_generic
 
 /obj/item/melee/smith/mace/attack(mob/living/M, mob/living/user)
 	. = ..()
 	if(!istype(M))
 		return
-	M.apply_damage(15, STAMINA, "chest", M.run_armor_check("chest", "melee"))
+	M.apply_damage(20, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
 
 //////////////////////////
@@ -363,7 +363,7 @@
 	icon_prefix = "katana_smith"
 	overlay_state = "hilt_katana"
 	force = 22
-	wielded_mult = 1.5
+	wielded_mult = 1.4
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
 	block_parry_data = /datum/block_parry_data/smithkatana
 	hitsound = 'sound/weapons/rapierhit.ogg'
@@ -371,7 +371,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
 	block_chance = 30
-	wound_bonus = 25
+	wound_bonus = 35
 	bare_wound_bonus = 40
 
 /datum/block_parry_data/smithkatana
@@ -387,7 +387,7 @@
 	parry_efficiency_to_counterattack = 100
 	parry_efficiency_considered_successful = 120
 	parry_efficiency_perfect = 120
-	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 0.6)
+	parry_data = list(PARRY_COUNTERATTACK_MELEE_ATTACK_CHAIN = 1.5)
 
 // Heavy axe, 2H focused chopper 27/54. Can be worn on your back.
 /obj/item/melee/smith/twohand/axe
@@ -401,7 +401,6 @@
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	layer = MOB_UPPER_LAYER
-	block_parry_data = /datum/block_parry_data/smith_generic
 	wound_bonus = 10
 	bare_wound_bonus = 10
 
@@ -486,9 +485,9 @@
 	overlay_state = "shaft_javelin"
 	item_state = "javelin_smith"
 	sharpness = SHARP_POINTY
-	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
+	embedding = list("pain_mult" = 2, "embed_chance" = 75, "fall_chance" = 16, "ignore_throwspeed_threshold" = TRUE)
 	force = 15
-	armour_penetration = 0.10
+	armour_penetration = 0.15
 
 // Smaller weaker javelin, easier to store/carry, less effective
 /obj/item/melee/smith/throwingknife
@@ -496,8 +495,9 @@
 	icon_state = "throwing_smith"
 	overlay_state = "handle_throwing"
 	item_state = "dagger_smith"
-	embedding = list("pain_mult" = 2, "embed_chance" = 50, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 14
+	embedding = list("pain_mult" = 3, "embed_chance" = 80, "fall_chance" = 30, "ignore_throwspeed_threshold" = TRUE)
+	force = 13
+	armour_penetration = 0.05
 	w_class = WEIGHT_CLASS_SMALL
 
 


### PR DESCRIPTION
### Recipes
**Katana**
fold fold fold fold fold > fold fold fold fold fold fold fold fold fold fold

### Parrying tweaks
Parrying bonus damage changed from 1x on average to 1.5x on average

### Weapons
**Smithed Dagger**
STANDARD FORCE 24 > 19

**Wakizashi**
STANDARD FORCE 25 > 21
WOUND CHANCE  15 > 25

**Smithed Mace**
STANDARD FORCE 15 > 17
EXTRA STAMINA DAMAGE 15 > 20

**Smithed Katana**
WIELDED DAM. MULTIPLIER 1.5x > 1.4x
WOUND CHANCE 25 > 35

**Smithed Axe**
Can no longer parry.

**Smithed Javelin**
ARMOR PENETRATION 10% > 15%
EMBED CHANCE 60 > 75

**Smithed Throwing Knife**
STANDARD FORCE 14 > 13
ARMOR PENETRATION 0% > 5%