### PR TITLE
Runtime fixes, December 15 2022

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,7 +35,7 @@
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
-		if(lose_text)
+		if(!QDELETED(quirk_holder) && lose_text)
 			to_chat(quirk_holder, lose_text)
 		quirk_holder.roundstart_quirks -= src
 		if(mob_trait)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,7 +35,8 @@
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
-		to_chat(quirk_holder, lose_text)
+		if(lose_text)
+			to_chat(quirk_holder, lose_text)
 		quirk_holder.roundstart_quirks -= src
 		if(mob_trait)
 			REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -507,7 +507,7 @@
 	return
 
 /atom/proc/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(density && !QDELETED(AM) && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav, unless the thrown stuff ends up inside what it hit(embedding, bola, etc...).
+	if(density && !QDELETED(src) && !QDELETED(AM) && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav, unless the thrown stuff ends up inside what it hit(embedding, bola, etc...).
 		addtimer(CALLBACK(src, .proc/hitby_react, AM), 2)
 
 /atom/proc/hitby_react(atom/movable/AM)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -507,7 +507,7 @@
 	return
 
 /atom/proc/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(density && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav, unless the thrown stuff ends up inside what it hit(embedding, bola, etc...).
+	if(density && !QDELETED(AM) && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav, unless the thrown stuff ends up inside what it hit(embedding, bola, etc...).
 		addtimer(CALLBACK(src, .proc/hitby_react, AM), 2)
 
 /atom/proc/hitby_react(atom/movable/AM)

--- a/code/game/turfs/f13concrete.dm
+++ b/code/game/turfs/f13concrete.dm
@@ -187,9 +187,7 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 		to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
 		if(do_after(user, 50, target=src))
 			C.use(3)
-			var/turf/T = get_turf(src)
-			T.PlaceOnTop(/turf/closed/wall/mineral/concrete/blastproof)
-			qdel(src)
+			PlaceOnTop(/turf/closed/wall/mineral/concrete/blastproof)
 		return
 	else if(istype(I, /obj/item/weldingtool))
 		if(!I.tool_start_check(user, amount=0))
@@ -198,7 +196,7 @@ GLOBAL_LIST_INIT(concrete_recipes, list ( \
 		if(I.use_tool(src, user, 60, volume=50))
 			user.visible_message("[user] welds the [src] apart.", "You start to weld the [src] apart...")
 			to_chat(user, "<span class='notice'>You weld the [src] apart.</span>")
-			qdel(src)
+			ScrapeAway()
 			return
 	return ..()
 

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -29,6 +29,8 @@
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads.
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	. = ..()
+	if(!thrownthing)
+		return
 	///if the thrown object's target zone isn't the head
 	if(thrownthing.target_zone != BODY_ZONE_HEAD)
 		return

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -432,8 +432,9 @@
 	desc = "Looks cold."
 	icon_state = "snowplating"
 	footstep = FOOTSTEP_PLATING
-	barefootstep = FOOTSTEP_PLATING
-	clawfootstep = FOOTSTEP_PLATING
+	barefootstep = FOOTSTEP_HARD_BAREFOOT
+	clawfootstep = FOOTSTEP_HARD_CLAW
+	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
 /turf/open/indestructible/ground/outside/snow/proc/setTurfPlant(newTurfPlant)
 	turfPlant = newTurfPlant

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -33,26 +33,27 @@
 	var/cotton_name = "raw cotton"
 
 /obj/item/grown/cotton/attack_self(mob/user)
-	user.show_message("<span class='notice'>You pull some [cotton_name] out of the [name]!</span>", MSG_VISUAL)
+	user.show_message(span_notice("You pull some [cotton_name] out of the [name]!"), MSG_VISUAL)
 	var/seed_modifier = 0
 	if(seed)
 		seed_modifier = round(seed.potency / 25)
-	var/obj/item/stack/cotton = new cotton_type(user.loc, 1 + seed_modifier)
-	var/old_cotton_amount = cotton.amount
 	// We do this so that other stuff merges with this, not the other way around.
 	// That way we know we always have a reference to a stack of the largest possible size.
-	for(var/obj/item/stack/potential_stack in user.loc)
-		if(QDELETED(potential_stack)) // don't merge with deleted things
+	var/obj/item/stack/cotton = new cotton_type(null, 1 + seed_modifier) // created in nullspace to avoid deletion via merging on turf entered
+	var/old_cotton_amount = cotton.amount
+	for(var/obj/item/stack/potential_stack in get_turf(user)) 
+		if(QDELETED(potential_stack))
 			continue
-		if(potential_stack == cotton) // don't merge with ourselves
+		if(potential_stack == cotton)
 			continue
-		if(potential_stack.amount >= potential_stack.max_amount) // don't steal from full stacks
+		if(potential_stack.amount >= potential_stack.max_amount) // don't steal from already full stacks
 			continue
-		if(!potential_stack.can_merge(cotton)) // don't merge with other types
+		if(!potential_stack.can_merge(cotton))
 			continue
-		potential_stack.merge(cotton) // merge the other stack into the one we have a ref to
+		potential_stack.merge(cotton)
+	cotton.forceMove(get_turf(user))
 	if(cotton.amount > old_cotton_amount)
-		to_chat(user, "<span class='notice'>You add the newly-formed [cotton_name] to the stack. It now contains [cotton.amount] [cotton_name].</span>")
+		to_chat(user, span_notice("You add the newly-formed [cotton_name] to the stack. It now contains [cotton.amount] [cotton_name]."))
 	qdel(src)
 
 //reinforced mutated variant

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -39,9 +39,18 @@
 		seed_modifier = round(seed.potency / 25)
 	var/obj/item/stack/cotton = new cotton_type(user.loc, 1 + seed_modifier)
 	var/old_cotton_amount = cotton.amount
-	for(var/obj/item/stack/ST in user.loc)
-		if(ST != cotton && istype(ST, cotton_type) && ST.amount < ST.max_amount)
-			ST.attackby(cotton, user)
+	// We do this so that other stuff merges with this, not the other way around.
+	// That way we know we always have a reference to a stack of the largest possible size.
+	for(var/obj/item/stack/potential_stack in user.loc)
+		if(QDELETED(potential_stack)) // don't merge with deleted things
+			continue
+		if(potential_stack == cotton) // don't merge with ourselves
+			continue
+		if(potential_stack.amount >= potential_stack.max_amount) // don't steal from full stacks
+			continue
+		if(!potential_stack.can_merge(cotton)) // don't merge with other types
+			continue
+		potential_stack.merge(cotton) // merge the other stack into the one we have a ref to
 	if(cotton.amount > old_cotton_amount)
 		to_chat(user, "<span class='notice'>You add the newly-formed [cotton_name] to the stack. It now contains [cotton.amount] [cotton_name].</span>")
 	qdel(src)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -50,32 +50,33 @@
 
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(W.sharpness)
-		user.show_message("<span class='notice'>You make [plank_name] out of \the [src]!</span>", MSG_VISUAL)
+		user.show_message(span_notice("You make [plank_name] out of \the [src]!"), MSG_VISUAL)
 		var/seed_modifier = 3
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
-		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
-		var/old_plank_amount = plank.amount
 		// We do this so that other stuff merges with this, not the other way around.
 		// That way we know we always have a reference to a stack of the largest possible size.
-		for(var/obj/item/stack/potential_stack in user.loc)
-			if(QDELETED(potential_stack)) // don't merge with deleted things
+		var/obj/item/stack/plank = new plank_type(null, 1 + seed_modifier) // created in nullspace to avoid deletion via merging on turf entered
+		var/old_plank_amount = plank.amount
+		for(var/obj/item/stack/potential_stack in get_turf(user))
+			if(QDELETED(potential_stack))
 				continue
-			if(potential_stack == plank) // don't merge with ourselves
+			if(potential_stack == plank)
 				continue
-			if(potential_stack.amount >= potential_stack.max_amount) // don't steal from full stacks
+			if(potential_stack.amount >= potential_stack.max_amount) // don't steal from already full stacks
 				continue
-			if(!potential_stack.can_merge(plank)) // don't merge with other types
+			if(!potential_stack.can_merge(plank))
 				continue
-			potential_stack.merge(plank) // merge the other stack into the one we have a ref to
+			potential_stack.merge(plank)
+		plank.forceMove(get_turf(user))
 		if(plank.amount > old_plank_amount)
-			to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name].</span>")
+			to_chat(user, span_notice("You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name]."))
 		qdel(src)
 
 	if(CheckAccepted(W))
 		var/obj/item/reagent_containers/food/snacks/grown/leaf = W
 		if(leaf.dry)
-			user.show_message("<span class='notice'>You wrap \the [W] around the log, turning it into a torch!</span>")
+			user.show_message(span_notice("You wrap \the [W] around the log, turning it into a torch!"))
 			var/obj/item/flashlight/flare/torch/T = new /obj/item/flashlight/flare/torch(user.loc)
 			usr.dropItemToGround(W)
 			usr.put_in_active_hand(T)
@@ -83,7 +84,7 @@
 			qdel(src)
 			return
 		else
-			to_chat(usr, "<span class ='warning'>You must dry this first!</span>")
+			to_chat(usr, span_warning("You must dry this first!"))
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -330,6 +330,7 @@
 // Examining more a plant will yield a rough estimation of it's stats.
 // Intended for use by Wayfarer's and Legion to allow their farmers to gauge roughly how it's going.
 /obj/machinery/hydroponics/examine_more(user)
+	. = ..()
 	if(myseed && (in_range(user, src) || isobserver(user)))
 		. += span_info("You examine the plant to get a better view of its harvest...")
 		switch(src.myseed.potency)	// Check potency
@@ -416,6 +417,7 @@
 		. += span_notice("... nothing seems to be growing there.")
 	else
 		. += span_notice("... You can't see anything in particular. Maybe you need to get closer to examine it closely?")
+
 /obj/machinery/hydroponics/proc/weedinvasion() // If a weed growth is sufficient, this happens.
 	dead = 0
 	var/oldPlantName

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -69,7 +69,7 @@
 		BT.on_lose(TRUE)
 		BT.owner = null
 
-	if((!QDELETED(src) || C) && !no_id_transfer)
+	if((!QDELETED(src) || !QDELETED(C)) && !no_id_transfer)
 		transfer_identity(C)
 	if(C)
 		REMOVE_SKILL_MODIFIER_BODY(/datum/skill_modifier/brain_damage, null, C)

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -217,9 +217,9 @@
 			G.revive(1)
 		else
 			G.revive(1, 1)
-	set_light(7, 5, "#39FF14")
+	set_light_range_power_color(7, 5, "#39FF14")
 	spawn(40)
-	set_light(2)
+	set_light_range(2)
 
 /mob/living/simple_animal/hostile/ghoul/glowing/strong // FEV mutation
 	maxHealth = 200 //reduced. 20hp per healthtick heal


### PR DESCRIPTION
## About The Pull Request
Fixes several runtimes. Tested:
- [x] Invalid turf qdel when deconstructing concrete walls
- [x] Examining hydrotrays closely causes runtimes due to missing parent call
- [x] Mobs stepping on snowy plating cause runtimes in footstep code
- [x] Fix runtime from blank on-loss text in quirk code
- [x] Fix getting quirk loss messages when despawning or being deleted
- [x] Fix glowing ghouls using the wrong set_light proc
- [x] Fix runtime from merging cotton from cotton bundles
- [x] Fix runtime from merging wood planks from log splitting
- [x] Fix runtime from thrown items being deleted on hit
- [x] Fix runtime from thrown items hitting deleted things (gib-on-death mobs, etc)

## Why It's Good For The Game
Bugfixes!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.