### PR TITLE
Gives the Plundered Paladin Cape to Two Players

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -323,6 +323,11 @@
 	name = "Juniper's trophy"
 	path = /obj/item/storage/box/large/custom_kit/raxraus
 	ckeywhitelist = list ("raxraus")
+	
+/datum/gear/donator/plundered_cape
+	name = "Plundered Brotherhood cape"
+	path = /obj/item/clothing/neck/mantle/bos/paladin/donator_raxraus
+	ckeywhitelist = list ("mrsaxyman", "oshibka", )
 
 /obj/item/clothing/neck/mantle/bos/paladin/donator_raxraus
 	name = "plundered paladin cape"


### PR DESCRIPTION

## About This Shit

Adds "MrSaxyMan" and "Oshibka" to the list of the plundered paladin cape made for Raxraus by Allfd after their characters, Diplomatis and Inscius Bovarius, defeated a Brotherhood of Steel party.

## Why It's Bad For The Game

IC consequence.

## Pre-Merge Bullshit
- [ ] You gave it a go.
- [ ] Did This McFuckUp?
- [ ] You left a trail of breadcumbs for others to look at and laugh at.
- [x] Pissed self.


## NOBODY USES THIS THE SERVER NEVER SETS UP A CHANGELOG
:cl:
add: mrsaxyman, oshibka to plundered paladin cape
/:cl: