### PR TITLE
Lurze cyborg bug fix pass 1

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -147,6 +147,8 @@
 					sub_category += "Medical"
 				if(module_types & BORG_MODULE_ENGINEERING)
 					sub_category += "Engineering"
+			else if(U in typesof(/obj/item/borg/upgrade/modkit)) //added else if statment for cyborg items in mining_designs.dm
+				sub_category += "Mining"
 			else
 				sub_category += "All Cyborgs"
 		// Else check if this design builds a piece of exosuit equipment.

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -132,7 +132,7 @@
 	if(categories)
 		// Handle some special cases to build up sub-categories for the fab interface.
 		// Start with checking if this design builds a cyborg module.
-		if(built_item in typesof(/obj/item/borg/upgrade))
+		if(ispath(built_item, /obj/item/borg/upgrade))
 			var/obj/item/borg/upgrade/U = built_item
 			var/module_types = initial(U.module_flags)
 			sub_category = list()
@@ -147,8 +147,6 @@
 					sub_category += "Medical"
 				if(module_types & BORG_MODULE_ENGINEERING)
 					sub_category += "Engineering"
-			else if(U in typesof(/obj/item/borg/upgrade/modkit)) //added else if statment for cyborg items in mining_designs.dm
-				sub_category += "Mining"
 			else
 				sub_category += "All Cyborgs"
 		// Else check if this design builds a piece of exosuit equipment.

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -192,6 +192,7 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	module_type = list(/obj/item/robot_module/miner)
+	module_flags = BORG_MODULE_MINER
 
 /obj/item/borg/upgrade/advcutter/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -326,16 +327,15 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 	var/datum/action/toggle_action
 
 /obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		var/obj/item/borg/upgrade/selfrepair/U = locate() in R
-		if(U)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair module.</span>")
-			return FALSE
-
-		icon_state = "selfrepair_off"
-		toggle_action = new /datum/action/item_action/toggle(src)
-		toggle_action.Grant(R)
+    . = ..()
+    if(.)
+        for(var/obj/item/borg/upgrade/U in R.upgrades)
+            if(U.type == /obj/item/borg/upgrade/selfrepair)
+                to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair module.</span>")
+                return FALSE
+        icon_state = "selfrepair_off"
+        toggle_action = new /datum/action/item_action/toggle(src)
+        toggle_action.Grant(R)
 
 /obj/item/borg/upgrade/selfrepair/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -460,6 +460,7 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 	desc = "An upgrade to a cyborg's hypospray, allowing it to \
 		pierce armor and thick material."
 	icon_state = "cyborg_upgrade3"
+	module_flags = BORG_MODULE_MEDICAL //added line so it appears correctly in the Exo fab 
 
 /obj/item/borg/upgrade/piercing_hypospray/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -485,10 +486,10 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		R.module.remove_module(S, TRUE)
 
 /obj/item/borg/upgrade/processor
-	name = "medical cyborg surgical processor"
+	name = "General Atomics International surgical processor" //changed name to fit in the theme
 	desc = "An upgrade to the Medical module, installing a processor \
 		capable of scanning surgery disks and carrying \
-		out procedures"
+		out research procedures" // added one word to better hint to players what the added traits do
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	module_type = list(/obj/item/robot_module/medical,
@@ -503,6 +504,12 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		var/obj/item/surgical_processor/SP = new(R.module)
 		R.module.basic_modules += SP
 		R.module.add_module(SP, FALSE, TRUE)
+
+		ADD_TRAIT(R, TRAIT_CHEMWHIZ, src) // Added traits to medical proccessor so that Medical borgs can do medical stuff
+		ADD_TRAIT(R, TRAIT_RESEARCHER, src)
+		ADD_TRAIT(R, TRAIT_MEDICALEXPERT, src)
+		ADD_TRAIT(R, TRAIT_SURGERY_HIGH, src)
+		ADD_TRAIT(R, TRAIT_RESEARCHER, src) // Why is this in here twice? Saw it in followers.dm and didn't want to break it. That's why
 
 /obj/item/borg/upgrade/processor/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -521,6 +528,7 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		/obj/item/robot_module/syndicate_medical,
 		/obj/item/robot_module/medihound,
 		/obj/item/robot_module/assaultron/medical)
+	module_flags = BORG_MODULE_MEDICAL
 
 /obj/item/borg/upgrade/advhealth/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -487,7 +487,7 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		R.module.remove_module(S, TRUE)
 
 /obj/item/borg/upgrade/processor
-	name = "General Atomics International surgical processor" //changed name to fit in the theme
+	name = "\improper General Atomics International surgical processor" //changed name to fit in the theme
 	desc = "An upgrade to the Medical module, installing a processor \
 		capable of scanning surgery disks and carrying \
 		out research procedures" // added one word to better hint to players what the added traits do
@@ -506,10 +506,10 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		R.module.basic_modules += SP
 		R.module.add_module(SP, FALSE, TRUE)
 
-		ADD_TRAIT(R, TRAIT_CHEMWHIZ, src) // Added traits to medical proccessor so that Medical borgs can do medical stuff
-		ADD_TRAIT(R, TRAIT_RESEARCHER, src)
-		ADD_TRAIT(R, TRAIT_MEDICALEXPERT, src)
-		ADD_TRAIT(R, TRAIT_SURGERY_HIGH, src)
+		ADD_TRAIT(R, TRAIT_CHEMWHIZ, CYBORG_ITEM_TRAIT) // Added traits to medical proccessor so that Medical borgs can do medical stuff
+		ADD_TRAIT(R, TRAIT_RESEARCHER, CYBORG_ITEM_TRAIT)
+		ADD_TRAIT(R, TRAIT_MEDICALEXPERT, CYBORG_ITEM_TRAIT)
+		ADD_TRAIT(R, TRAIT_SURGERY_HIGH, CYBORG_ITEM_TRAIT)
 
 /obj/item/borg/upgrade/processor/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -327,15 +327,16 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 	var/datum/action/toggle_action
 
 /obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R, user = usr)
-    . = ..()
-    if(.)
-        for(var/obj/item/borg/upgrade/U in R.upgrades)
-            if(U.type == /obj/item/borg/upgrade/selfrepair)
-                to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair module.</span>")
-                return FALSE
-        icon_state = "selfrepair_off"
-        toggle_action = new /datum/action/item_action/toggle(src)
-        toggle_action.Grant(R)
+	. = ..()
+	if(.)
+		var/obj/item/borg/upgrade/selfrepair/U = locate() in R.upgrades
+		if(U)
+			to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair module.</span>")
+			return FALSE
+
+		icon_state = "selfrepair_off"
+		toggle_action = new /datum/action/item_action/toggle(src)
+		toggle_action.Grant(R)
 
 /obj/item/borg/upgrade/selfrepair/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
@@ -509,7 +510,6 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		ADD_TRAIT(R, TRAIT_RESEARCHER, src)
 		ADD_TRAIT(R, TRAIT_MEDICALEXPERT, src)
 		ADD_TRAIT(R, TRAIT_SURGERY_HIGH, src)
-		ADD_TRAIT(R, TRAIT_RESEARCHER, src) // Why is this in here twice? Saw it in followers.dm and didn't want to break it. That's why
 
 /obj/item/borg/upgrade/processor/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -517,6 +517,11 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		var/obj/item/surgical_processor/SP = locate() in R.module
 		R.module.remove_module(SP, TRUE)
 
+		REMOVE_TRAIT(R, TRAIT_CHEMWHIZ, CYBORG_ITEM_TRAIT) // Remove traits once board is removed
+		REMOVE_TRAIT(R, TRAIT_RESEARCHER, CYBORG_ITEM_TRAIT)
+		REMOVE_TRAIT(R, TRAIT_MEDICALEXPERT, CYBORG_ITEM_TRAIT)
+		REMOVE_TRAIT(R, TRAIT_SURGERY_HIGH, CYBORG_ITEM_TRAIT)
+
 /obj/item/borg/upgrade/advhealth
 	name = "advanced cyborg health scanner"
 	desc = "An upgrade to the Medical modules, installing a built-in \

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -277,6 +277,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	require_module = 1
 	module_type = list(/obj/item/robot_module/miner)
+	module_flags = BORG_MODULE_MINER// added for exo fab subcat
 	var/denied_type = null
 	var/maximum_of_type = 1
 	var/cost = 30

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -799,7 +799,7 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_surgicalprocessor
-	name = "Cyborg Upgrade (Surgical Processor)"
+	name = "Cyborg Upgrade (General Atomics International surgical processor)"
 	id = "borg_upgrade_surgicalprocessor"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/processor


### PR DESCRIPTION
CHANGE LOG

CHANGE 1, Fixed self-repair, so that it is no longer stuck in a loop

CHANGE 2 Added traits to the surgical processor so that medical robots are granted sci-related traits when

CHANGE 3, Changed the readable name on the surgical processor to something fallout-related, Changed flavor text very slightly

Change 4, added flags to robot modules in robot_upgrades.dm So that they appear in the correct list in the exo fab

CHANGE 5, added else if(U in typesof(/obj/item/borg/upgrade/modkit))
				sub_category += "Mining" to mech_fabricator.DM so that mining_designs.dm is placed properly in the exofab screen.

TLDR; Self-repair works, Surgical processor renamed, and adds traits to Medical borgs when installed, allowing them to do chem, research, and surgery. Correctly organized the exofab subcategories
