### PR TITLE
Minor Balance Tweaks

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2071,7 +2071,6 @@
 				/obj/item/book/granter/trait/chemistry = 10,
 				/obj/item/book/granter/trait/trekking = 17,
 				/obj/item/book/granter/trait/techno = 14,
-				/obj/item/book/granter/trait/pa_wear = 4,
 				/obj/item/book/granter/trait/gunslinger = 4,
 				/obj/item/book/granter/trait/iron_fist = 4,
 				/obj/item/book/granter/trait/bigleagues = 4,

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -153,6 +153,7 @@
 
 	loadout_options = list(
 		/datum/outfit/loadout/gysgt_ballistics, // Vindicator
+		/datum/outfit/loadout/gysgt_gatlas, // L30
 		/datum/outfit/loadout/gysgt_laser, // Multiplas
 		)
 
@@ -184,6 +185,13 @@
 	backpack_contents = list(
 		/obj/item/encencminigunbal4mm = 1,
 		/obj/item/ammo_box/magazine/vindic = 2
+		)
+
+/datum/outfit/loadout/gysgt_gatlas
+	name = "Armored Support Kit"
+	backpack_contents = list(
+		/obj/item/encminigunpack = 1,
+		/obj/item/stock_parts/cell/ammo/ecp = 2
 		)
 
 /datum/outfit/loadout/gysgt_laser

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -9,8 +9,8 @@
 	inaccuracy_modifier = 0.5
 	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
-	w_class = WEIGHT_CLASS_NORMAL
-	weapon_weight = WEAPON_MEDIUM
+	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	pin = /obj/item/firing_pin
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/attackby(obj/item/A, mob/user, params)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -584,8 +584,8 @@
 
 //The ammo/gun is stored in a back slot item
 /obj/item/minigunpack
-	name = "backpack power source"
-	desc = "The massive external power source for the laser gatling gun."
+	name = "XM30 backpack power source"
+	desc = "The massive external power source for the XM30 laser gatling gun. A direct grandfather to the much superior L30."
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "holstered"
 	item_state = "backpack"
@@ -680,8 +680,8 @@
 	user.update_inv_back()
 
 /obj/item/gun/energy/minigun
-	name = "laser gatling gun"
-	desc = "An advanced laser cannon with an incredible rate of fire. Requires a bulky backpack power source to use."
+	name = "XM30 laser gatling gun"
+	desc = "An advanced laser cannon with an incredible rate of fire. Requires a bulky backpack power source to use. A direct grandfather to the much superior L30."
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "minigun_spin"
 	item_state = "minigun"


### PR DESCRIPTION
- - -
Balance:
 - Returns the L30 to the Platoon Sergeant.
 - Grenade Launcher made identical in size to the rocket launcher.
 - Removes ability to get PA Wear, as intended.
- - -
Other:
 - Name of the standard gatling laser changed to a lore inaccurate, but hopefully understandable name. It follows US experimental naming conventions. Kind of.
- - -