### PR TITLE
Fix circuits harddeling

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -117,6 +117,8 @@
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.remove_from_hud(src)
 	QDEL_NULL(access_card)
+	QDEL_NULL(battery)
+	QDEL_LIST(assembly_components)
 	return ..()
 
 /obj/item/electronic_assembly/process()

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -93,6 +93,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	return
 
 /obj/item/integrated_circuit/Destroy()
+	assembly?.remove_component(src)
 	QDEL_LIST(inputs)
 	QDEL_LIST(outputs)
 	QDEL_LIST(activators)


### PR DESCRIPTION
## About The Pull Request
Fixes circuits harddeling, which takes up a disproportionate amount of SSGarbage CPU time.

## Why It's Good For The Game
SSGarbage is once again at the top of the profiler, mostly due to circuits.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->