### PR TITLE
Reduce worst-case mob wakeup time to 2 seconds (6x faster)

### DIFF
--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(idlenpcpool)
 	name = "Idling NPC Pool"
 	flags = SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 	priority = FIRE_PRIORITY_IDLE_NPC
-	wait = 120
+	wait = 2 SECONDS
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()


### PR DESCRIPTION
## About The Pull Request
Lowers the worst-case mob wakeup time from 12 seconds to 2 seconds, making it 6x faster.

## Why It's Good For The Game
People complained about being able to skip past mobs that should've absolutely seen you. Rather than have a rule against it, it'd be better to just make them wake faster.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.